### PR TITLE
Fix  remove deprecations

### DIFF
--- a/admin/class-ngg-options.php
+++ b/admin/class-ngg-options.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once('class-ngg-post-admin-page.php');
+include_once ( 'class-ngg-post-admin-page.php' );
 
 /**
  * Class NGG_Options
@@ -18,47 +18,47 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	protected function processor() {
 
 		//If we reset to default, we only do that.
-		if (isset($_POST['resetdefault'])) {
+		if ( isset ( $_POST['resetdefault'] ) ) {
 
 			global $ngg;
 
-			check_admin_referer('ngg_uninstall');
+			check_admin_referer( 'ngg_uninstall' );
 
-			include_once ( dirname (__FILE__).  '/class-ngg-installer.php');
+			include_once ( dirname( __FILE__ ) . '/class-ngg-installer.php' );
 
 			NGG_Installer::set_default_options();
 			$ngg->load_options();
 
-			nggGallery::show_message(__('Reset all settings to the default parameters.','nggallery'));
+			nggGallery::show_message( __( 'Reset all settings to the default parameters.', 'nggallery' ) );
 
 			return;
 		}
 
 		global $nggRewrite;
 
-		$ngg_options = get_option('ngg_options');
+		$ngg_options = get_option( 'ngg_options' );
 
 		$old_state = $ngg_options['usePermalinks'];
-		$old_slug  = $ngg_options['permalinkSlug'];
+		$old_slug = $ngg_options['permalinkSlug'];
 
-		if ( isset($_POST['updateoption']) ) {
-			check_admin_referer('ngg_settings');
+		if ( isset ( $_POST['updateoption'] ) ) {
+			check_admin_referer( 'ngg_settings' );
 			// get the hidden option fields, taken from WP core
 			if ( $_POST['page_options'] ) {
 				//$options = explode( ',', stripslashes( sanitize_text_field($_POST['page_options'] )) );
-				$options = explode( ',', stripslashes( ($_POST['page_options'] )) );
+				$options = explode( ',', stripslashes( ( $_POST['page_options'] ) ) );
 			} else {
 				$options = false;
 			}
 
-			if ($options) {
-				foreach ($options as $option) {
-					$option = trim($option);
+			if ( $options ) {
+				foreach ( $options as $option ) {
+					$option = trim( $option );
 					$value = false;
-					if ( isset( $_POST[ $option ] ) ) {
+					if ( isset ( $_POST[ $option ] ) ) {
 						//$value = sanitize_text_field( $_POST[ $option ] );
-						$value =  $_POST[ $option ] ;
-						if ($value === "true") {
+						$value = $_POST[ $option ];
+						if ( $value === "true" ) {
 							$value = true;
 						}
 
@@ -67,7 +67,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 						}
 					}
 
-					$ngg_options[$option] = $value;
+					$ngg_options[ $option ] = $value;
 				}
 
 				// do not allow a empty string
@@ -75,42 +75,42 @@ class NGG_Options extends NGG_Post_Admin_Page {
 					$ngg_options['permalinkSlug'] = 'nggallery';
 
 				// the path should always end with a slash
-				$ngg_options['gallerypath']    = trailingslashit($ngg_options['gallerypath']);
-				$ngg_options['imageMagickDir'] = trailingslashit($ngg_options['imageMagickDir']);
+				$ngg_options['gallerypath'] = trailingslashit( $ngg_options['gallerypath'] );
+				$ngg_options['imageMagickDir'] = trailingslashit( $ngg_options['imageMagickDir'] );
 
 				// the custom sortorder must be ascending
-				$ngg_options['galSortDir'] = ($ngg_options['galSort'] == 'sortorder') ? 'ASC' : $ngg_options['galSortDir'];
+				$ngg_options['galSortDir'] = ( $ngg_options['galSort'] == 'sortorder' ) ? 'ASC' : $ngg_options['galSortDir'];
 			}
 			// Save options
-			update_option('ngg_options', $ngg_options);
+			update_option( 'ngg_options', $ngg_options );
 
 			// Flush Rewrite rules
 			if ( $old_state != $ngg_options['usePermalinks'] || $old_slug != $ngg_options['permalinkSlug'] )
 				$nggRewrite->flush();
 
-			nggGallery::show_message(__('Settings updated successfully','nggallery'));
+			nggGallery::show_message( __( 'Settings updated successfully', 'nggallery' ) );
 		}
 
-		if ( isset($_POST['clearcache']) ) {
-			check_admin_referer('ngg_settings');
+		if ( isset ( $_POST['clearcache'] ) ) {
+			check_admin_referer( 'ngg_settings' );
 
 			$path = WINABSPATH . $ngg_options['gallerypath'] . 'cache/';
 
-			if (is_dir($path))
-				if ($handle = opendir($path)) {
-					while (false !== ($file = readdir($handle))) {
-						if ($file != '.' && $file != '..') {
-						  @unlink($path . '/' . $file);
+			if ( is_dir( $path ) )
+				if ( $handle = opendir( $path ) ) {
+					while ( false !== ( $file = readdir( $handle ) ) ) {
+						if ( $file != '.' && $file != '..' ) {
+							@unlink( $path . '/' . $file );
 						}
 					}
-					closedir($handle);
+					closedir( $handle );
 				}
 
-			nggGallery::show_message(__('Cache cleared','nggallery'));
+			nggGallery::show_message( __( 'Cache cleared', 'nggallery' ) );
 		}
 
-		if ( isset($_POST['createslugs']) ) {
-			check_admin_referer('ngg_settings');
+		if ( isset ( $_POST['createslugs'] ) ) {
+			check_admin_referer( 'ngg_settings' );
 			$this->rebuild_slugs();
 		}
 
@@ -127,30 +127,32 @@ class NGG_Options extends NGG_Post_Admin_Page {
 
 		// get list of tabs
 		$tabs = $this->get_tabs();
-		$options = get_option('ngg_options');
+		$options = get_option( 'ngg_options' );
 
 		?>
 		<div class="wrap">
-			<h2><?php _e('Settings', 'nggallery') ?></h2>
+			<h2>
+				<?php _e( 'Settings', 'nggallery' ) ?>
+			</h2>
 			<div id="slider" style="display: none;">
-			<ul id="tabs">
+				<ul id="tabs">
+					<?php
+					foreach ( $tabs as $tab_key => $tab_name ) {
+						echo "\n\t\t<li><a class='nav-tab' href='#$tab_key'>$tab_name</a></li>";
+					}
+					?>
+				</ul>
 				<?php
-				foreach($tabs as $tab_key => $tab_name) {
-					echo "\n\t\t<li><a class='nav-tab' href='#$tab_key'>$tab_name</a></li>";
+				foreach ( $tabs as $tab_key => $tab_name ) {
+					echo "\n\t<div id='$tab_key'>\n";
+					// Looks for the internal class function, otherwise enable a hook for plugins
+					if ( method_exists( $this, "tab_$tab_key" ) )
+						call_user_func( array( $this, "tab_$tab_key" ), $options );
+					else
+						do_action( 'ngg_tab_content_' . $tab_key );
+					echo "\n\t</div>";
 				}
 				?>
-			</ul>
-			<?php
-			foreach($tabs as $tab_key => $tab_name) {
-				echo "\n\t<div id='$tab_key'>\n";
-				// Looks for the internal class function, otherwise enable a hook for plugins
-				if ( method_exists( $this, "tab_$tab_key" ))
-					call_user_func( array( $this , "tab_$tab_key"), $options );
-				else
-					do_action( 'ngg_tab_content_' . $tab_key );
-				echo "\n\t</div>";
-			}
-			?>
 			</div>
 		</div>
 		<?php
@@ -193,7 +195,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 				jQuery("#effects-more").html(extra);
 			}
 
-			jQuery(document).ready( function($) {
+			jQuery(document).ready(function ($) {
 				//$('html,body').scrollTop(0);
 				//Set tabs.
 				$('#slider').tabs({ fxFade: true, fxSpeed: 'fast' }).css('display', 'block');
@@ -202,23 +204,23 @@ class NGG_Options extends NGG_Post_Admin_Page {
 				$('.picker').wpColorPicker();
 
 				//Set preview for watermark.
-				$('#wm-preview-select').on("nggAutocompleteDone", function() {
+				$('#wm-preview-select').on("nggAutocompleteDone", function () {
 					$('#wm-preview-image').attr("src", '<?php echo home_url( 'index.php' ); ?>' + '?callback=image&pid=' + this.value + '&mode=watermark');
-                    $('#wm-preview-image-url').attr("href", '<?php echo home_url( 'index.php' ); ?>' + '?callback=image&pid=' + this.value + '&mode=watermark');
+					$('#wm-preview-image-url').attr("href", '<?php echo home_url( 'index.php' ); ?>' + '?callback=image&pid=' + this.value + '&mode=watermark');
 				});
 
-                jQuery("#wm-preview-select").nggAutocomplete( {
-                    type: 'image',domain: "<?php echo home_url('index.php', is_ssl() ? 'https' : 'http'); ?>"
-                });
+				jQuery("#wm-preview-select").nggAutocomplete({
+					type: 'image', domain: "<?php echo home_url( 'index.php', is_ssl() ? 'https' : 'http' ); ?>"
+				});
 			});
 
-			document.getElementById('reset-to-default').addEventListener('click', function(event) {
+			document.getElementById('reset-to-default').addEventListener('click', function (event) {
 				var check = confirm(
 					'<?php echo esc_js( __( 'Reset all options to default settings?', 'nggallery' ) ) ?>' +
 					'\n\n' +
-					'<?php echo esc_js( __( 'Choose [Cancel] to Stop, [OK] to proceed.', 'ngallery') ) ?>'
+					'<?php echo esc_js( __( 'Choose [Cancel] to Stop, [OK] to proceed.', 'ngallery' ) ) ?>'
 				);
-				if(!check) {
+				if (!check) {
 					event.preventDefault();
 				}
 			}, false);
@@ -235,15 +237,15 @@ class NGG_Options extends NGG_Post_Admin_Page {
 
 		$tabs = array();
 
-		$tabs['general'] = __('General', 'nggallery');
-		$tabs['images'] = __('Images', 'nggallery');
+		$tabs['general'] = __( 'General', 'nggallery' );
+		$tabs['images'] = __( 'Images', 'nggallery' );
 		$tabs['gallery'] = __( 'Gallery', 'nggallery' );
-		$tabs['effects'] = __('Effects', 'nggallery');
-		$tabs['watermark'] = __('Watermark', 'nggallery');
-		$tabs['slideshow'] = __('Slideshow', 'nggallery');
-		$tabs['advanced']     = __('Advanced', 'nggallery');
+		$tabs['effects'] = __( 'Effects', 'nggallery' );
+		$tabs['watermark'] = __( 'Watermark', 'nggallery' );
+		$tabs['slideshow'] = __( 'Slideshow', 'nggallery' );
+		$tabs['advanced'] = __( 'Advanced', 'nggallery' );
 
-		$tabs = apply_filters('ngg_settings_tabs', $tabs);
+		$tabs = apply_filters( 'ngg_settings_tabs', $tabs );
 
 		return $tabs;
 
@@ -252,364 +254,514 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	/**
 	 * Show the general options.
 	 */
-	private function tab_general($options) {
+	private function tab_general( $options ) {
 		?>
-		<h3><?php _e( 'General settings', 'nggallery' ); ?></h3>
+		<h3>
+			<?php _e( 'General settings', 'nggallery' ); ?>
+		</h3>
 		<form name="generaloptions" method="post" action="<?php echo $this->page; ?>">
-			<?php wp_nonce_field('ngg_settings') ?>
-			<input type="hidden" name="page_options" value="gallerypath,silentUpgrade,deleteImg,useMediaRSS,usePicLens,usePermalinks,permalinkSlug,graphicLibrary,imageMagickDir,activateTags,appendType,maxImages" />
+			<?php wp_nonce_field( 'ngg_settings' ) ?>
+			<input type="hidden" name="page_options"
+				value="gallerypath,silentUpgrade,deleteImg,useMediaRSS,usePicLens,usePermalinks,permalinkSlug,graphicLibrary,imageMagickDir,activateTags,appendType,maxImages" />
 			<table class="form-table ngg-options">
 				<tr>
-					<th><label for="gallerypath"><?php _e('Gallery path','nggallery'); ?></label></th>
+					<th><label for="gallerypath">
+							<?php _e( 'Gallery path', 'nggallery' ); ?>
+						</label></th>
 					<td>
-						<input <?php $this->readonly(is_multisite()); ?> type="text" class="regular-text code" name="gallerypath" id="gallerypath" value="<?php echo $options['gallerypath']; ?>" />
-						<p class="description"><?php esc_html_e('This is the default path for all galleries','nggallery') ?></p>
+						<input <?php $this->readonly( is_multisite() ); ?> type="text" class="regular-text code"
+							name="gallerypath" id="gallerypath" value="<?php echo $options['gallerypath']; ?>" />
+						<p class="description">
+							<?php esc_html_e( 'This is the default path for all galleries', 'nggallery' ) ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Silent database upgrade','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Silent database upgrade', 'nggallery' ); ?>
+					</th>
 					<td>
-						<input <?php disabled(is_multisite()); ?> type="checkbox" name="silentUpgrade" id="silentUpgrade" value="true" <?php checked( $options['silentUpgrade']); ?> />
-						<label for="silentUpgrade"><?php _e('Update the database without notice.','nggallery') ?></label>
-					</td>
-				</tr>
-				<tr>
-					<th><?php _e('Image files','nggallery'); ?></th>
-					<td>
-						<input <?php disabled(is_multisite()); ?> type="checkbox" name="deleteImg" id="deleteImg" value="true" <?php checked( $options['deleteImg']); ?>>
-						<label for="deleteImg">
-						<?php _e("Delete files when removing a gallery from the database",'nggallery'); ?>
+						<input <?php disabled( is_multisite() ); ?> type="checkbox" name="silentUpgrade" id="silentUpgrade"
+							value="true" <?php checked( $options['silentUpgrade'] ); ?> />
+						<label for="silentUpgrade">
+							<?php _e( 'Update the database without notice.', 'nggallery' ) ?>
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Select graphic library','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Image files', 'nggallery' ); ?>
+					</th>
+					<td>
+						<input <?php disabled( is_multisite() ); ?> type="checkbox" name="deleteImg" id="deleteImg" value="true"
+							<?php checked( $options['deleteImg'] ); ?>>
+						<label for="deleteImg">
+							<?php _e( "Delete files when removing a gallery from the database", 'nggallery' ); ?>
+						</label>
+					</td>
+				</tr>
+				<tr>
+					<th>
+						<?php _e( 'Select graphic library', 'nggallery' ); ?>
+					</th>
 					<td>
 						<fieldset>
 							<label>
-								<input name="graphicLibrary" type="radio" value="gd" <?php checked('gd', $options['graphicLibrary']); ?>>
-								<?php _e('GD Library', 'nggallery');?>
+								<input name="graphicLibrary" type="radio" value="gd" <?php checked( 'gd', $options['graphicLibrary'] ); ?>>
+								<?php _e( 'GD Library', 'nggallery' ); ?>
 							</label><br>
 							<label>
-								<input name="graphicLibrary" type="radio" value="im" <?php checked('im', $options['graphicLibrary']); ?>>
-								<?php _e('ImageMagick (Experimental)', 'nggallery'); ?>
+								<input name="graphicLibrary" type="radio" value="im" <?php checked( 'im', $options['graphicLibrary'] ); ?>>
+								<?php _e( 'ImageMagick (Experimental)', 'nggallery' ); ?>
 							</label>
 						</fieldset>
 						<label>
-							<?php _e('Path to the ImageMagick library:', 'nggallery'); ?>
-							<input <?php $this->readonly(is_multisite()); ?> type="text" class="regular-text code" name="imageMagickDir" value="<?php echo $options['imageMagickDir']; ?>">
+							<?php _e( 'Path to the ImageMagick library:', 'nggallery' ); ?>
+							<input <?php $this->readonly( is_multisite() ); ?> type="text" class="regular-text code"
+								name="imageMagickDir" value="<?php echo $options['imageMagickDir']; ?>">
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Media RSS feed','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Media RSS feed', 'nggallery' ); ?>
+					</th>
 					<td>
-						<input type="checkbox" name="useMediaRSS" id="useMediaRSS" value="true" <?php checked( $options['useMediaRSS']); ?>>
-						<label for="useMediaRSS"><?php esc_html_e('Add a RSS feed to you blog header. Useful for CoolIris/PicLens','nggallery') ?></label>
+						<input type="checkbox" name="useMediaRSS" id="useMediaRSS" value="true" <?php checked( $options['useMediaRSS'] ); ?>>
+						<label for="useMediaRSS">
+							<?php esc_html_e( 'Add a RSS feed to you blog header. Useful for CoolIris/PicLens', 'nggallery' ) ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('PicLens/CoolIris','nggallery'); ?> (<a href="http://www.cooliris.com">CoolIris</a>)</th>
+					<th>
+						<?php _e( 'PicLens/CoolIris', 'nggallery' ); ?> (<a href="http://www.cooliris.com">CoolIris</a>)
+					</th>
 					<td>
-						<input type="checkbox" id="usePicLens" name="usePicLens" value="true" <?php checked( $options['usePicLens']); ?>>
-						<label for="usePicLens"><?php _e('Include support for PicLens and CoolIris','nggallery'); ?></label>
-						<p class="description"><?php _e('When activated, JavaScript is added to your site footer. Make sure that wp_footer is called in your theme.','nggallery') ?></p>
-					</td>
-				</tr>
-			</table>
-			<h3><?php _e('Permalinks','nggallery') ?></h3>
-			<table class="form-table ngg-options">
-				<tr>
-					<th><?php _e('Use permalinks','nggallery'); ?></th>
-					<td>
-						<input type="checkbox" name="usePermalinks" id="usePermalinks" value="true" <?php checked( $options['usePermalinks']); ?>>
-						<label for="usePermalinks"><?php _e('Adds a static link to all images','nggallery'); ?></label>
-						<p class="description"><?php _e('When activating this option, you need to update your permalink structure once','nggallery'); ?></p>
-					</td>
-				</tr>
-				<tr>
-					<th><label for="permalinkSlug"><?php _e('Gallery slug:','nggallery'); ?></label></th>
-					<td>
-						<input type="text" class="regular-text code" name="permalinkSlug" id="permalinkSlug" value="<?php echo $options['permalinkSlug']; ?>">
-					</td>
-				</tr>
-				<tr>
-					<th><label for="createslugs"><?php _e('Recreate URLs','nggallery'); ?></label></th>
-					<td>
-						<input type="submit" name="createslugs" id="createslugs" class="button-secondary"  value="<?php _e('Start now &raquo;','nggallery') ;?>"/>
-						<p class="description"><?php _e( "If you've changed these settings, you'll have to recreate the URLs.",'nggallery'); ?></p>
+						<input type="checkbox" id="usePicLens" name="usePicLens" value="true" <?php checked( $options['usePicLens'] ); ?>>
+						<label for="usePicLens">
+							<?php _e( 'Include support for PicLens and CoolIris', 'nggallery' ); ?>
+						</label>
+						<p class="description">
+							<?php _e( 'When activated, JavaScript is added to your site footer. Make sure that wp_footer is called in your theme.', 'nggallery' ) ?>
+						</p>
 					</td>
 				</tr>
 			</table>
-			<h3><?php _e('Related images','nggallery'); ?></h3>
+			<h3>
+				<?php _e( 'Permalinks', 'nggallery' ) ?>
+			</h3>
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Add related images','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Use permalinks', 'nggallery' ); ?>
+					</th>
 					<td>
-						<input name="activateTags" id="activateTags" type="checkbox" value="true" <?php checked( $options['activateTags']); ?>>
-						<label for="activateTags"><?php _e('This will add related images to every post','nggallery'); ?></label>
+						<input type="checkbox" name="usePermalinks" id="usePermalinks" value="true" <?php checked( $options['usePermalinks'] ); ?>>
+						<label for="usePermalinks">
+							<?php _e( 'Adds a static link to all images', 'nggallery' ); ?>
+						</label>
+						<p class="description">
+							<?php _e( 'When activating this option, you need to update your permalink structure once', 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Match with','nggallery'); ?></th>
+					<th><label for="permalinkSlug">
+							<?php _e( 'Gallery slug:', 'nggallery' ); ?>
+						</label></th>
+					<td>
+						<input type="text" class="regular-text code" name="permalinkSlug" id="permalinkSlug"
+							value="<?php echo $options['permalinkSlug']; ?>">
+					</td>
+				</tr>
+				<tr>
+					<th><label for="createslugs">
+							<?php _e( 'Recreate URLs', 'nggallery' ); ?>
+						</label></th>
+					<td>
+						<input type="submit" name="createslugs" id="createslugs" class="button-secondary"
+							value="<?php _e( 'Start now &raquo;', 'nggallery' ); ?>" />
+						<p class="description">
+							<?php _e( "If you've changed these settings, you'll have to recreate the URLs.", 'nggallery' ); ?>
+						</p>
+					</td>
+				</tr>
+			</table>
+			<h3>
+				<?php _e( 'Related images', 'nggallery' ); ?>
+			</h3>
+			<table class="form-table ngg-options">
+				<tr>
+					<th>
+						<?php _e( 'Add related images', 'nggallery' ); ?>
+					</th>
+					<td>
+						<input name="activateTags" id="activateTags" type="checkbox" value="true" <?php checked( $options['activateTags'] ); ?>>
+						<label for="activateTags">
+							<?php _e( 'This will add related images to every post', 'nggallery' ); ?>
+						</label>
+					</td>
+				</tr>
+				<tr>
+					<th>
+						<?php _e( 'Match with', 'nggallery' ); ?>
+					</th>
 					<td>
 						<fieldset>
 							<label>
-								<input name="appendType" type="radio" value="category" <?php checked('category', $options['appendType']); ?>>
-								<?php _e('Categories', 'nggallery') ;?>
+								<input name="appendType" type="radio" value="category" <?php checked( 'category', $options['appendType'] ); ?>>
+								<?php _e( 'Categories', 'nggallery' ); ?>
 							</label>
 							<br>
 							<label>
-								<input name="appendType" type="radio" value="tags" <?php checked('tags', $options['appendType']); ?>>
-								<?php _e('Tags', 'nggallery') ;?>
+								<input name="appendType" type="radio" value="tags" <?php checked( 'tags', $options['appendType'] ); ?>>
+								<?php _e( 'Tags', 'nggallery' ); ?>
 							</label>
 						</fieldset>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="maxImages"><?php _e('Max. number of images','nggallery'); ?></label></th>
+					<th><label for="maxImages">
+							<?php _e( 'Max. number of images', 'nggallery' ); ?>
+						</label></th>
 					<td>
-						<input name="maxImages" id="maxImages" type="number" step="1" min="1" value="<?php echo $options['maxImages']; ?>" class="small-text">
-						<p class="description"><?php _e('0 will show all images','nggallery'); ?></p>
+						<input name="maxImages" id="maxImages" type="number" step="1" min="1"
+							value="<?php echo $options['maxImages']; ?>" class="small-text">
+						<p class="description">
+							<?php _e( '0 will show all images', 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 			</table>
-			<?php submit_button( __('Save Changes'), 'primary', 'updateoption' ); ?>
+			<?php submit_button( __( 'Save Changes' ), 'primary', 'updateoption' ); ?>
 		</form>
-	<?php
+		<?php
 	}
 
 	/**
 	 * Show the image and thumbnail related options.
 	 */
-	private function tab_images($options) {
+	private function tab_images( $options ) {
 		?>
-		<h3><?php _e('Image settings','nggallery'); ?></h3>
-		<form name="imagesettings" method="POST" action="<?php echo $this->page.'#images'; ?>">
-			<?php wp_nonce_field('ngg_settings') ?>
-			<input type="hidden" name="page_options" value="imgResize,imgWidth,imgHeight,imgQuality,imgBackup,imgAutoResize,thumbwidth,thumbheight,thumbfix,thumbquality,thumbDifferentSize">
+		<h3>
+			<?php _e( 'Image settings', 'nggallery' ); ?>
+		</h3>
+		<form name="imagesettings" method="POST" action="<?php echo $this->page . '#images'; ?>">
+			<?php wp_nonce_field( 'ngg_settings' ) ?>
+			<input type="hidden" name="page_options"
+				value="imgResize,imgWidth,imgHeight,imgQuality,imgBackup,imgAutoResize,thumbwidth,thumbheight,thumbfix,thumbquality,thumbDifferentSize">
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Resize images','nggallery') ?></th>
+					<th>
+						<?php _e( 'Resize images', 'nggallery' ) ?>
+					</th>
 					<td>
-						<label for="imgWidth"><?php _e('Width','nggallery') ?></label>
-						<input type="number" step="1" min="0" class="small-text" name="imgWidth" id="imgWidth" value="<?php echo $options['imgWidth']; ?>">
-						<label for="imgHeight"><?php _e('Height','nggallery') ?></label>
-						<input type="number" step="1" min="0" class="small-text" name="imgHeight" id="imgHeight" value="<?php echo $options['imgHeight']; ?>">
-						<p class="description"><?php _e('Width and height (in pixels). NextCellent Gallery will keep the ratio size.','nggallery') ?></p>
+						<label for="imgWidth">
+							<?php _e( 'Width', 'nggallery' ) ?>
+						</label>
+						<input type="number" step="1" min="0" class="small-text" name="imgWidth" id="imgWidth"
+							value="<?php echo $options['imgWidth']; ?>">
+						<label for="imgHeight">
+							<?php _e( 'Height', 'nggallery' ) ?>
+						</label>
+						<input type="number" step="1" min="0" class="small-text" name="imgHeight" id="imgHeight"
+							value="<?php echo $options['imgHeight']; ?>">
+						<p class="description">
+							<?php _e( 'Width and height (in pixels). NextCellent Gallery will keep the ratio size.', 'nggallery' ) ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="imgQuality"><?php _e('Image quality','nggallery'); ?></label></th>
-					<td><input type="number" step="1" min="0" max="100" class="small-text" name="imgQuality" id="imgQuality" value="<?php echo $options['imgQuality']; ?>">%</td>
+					<th><label for="imgQuality">
+							<?php _e( 'Image quality', 'nggallery' ); ?>
+						</label></th>
+					<td><input type="number" step="1" min="0" max="100" class="small-text" name="imgQuality" id="imgQuality"
+							value="<?php echo $options['imgQuality']; ?>">%</td>
 				</tr>
 				<tr>
-					<th><?php _e('Backup original','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Backup original', 'nggallery' ); ?>
+					</th>
 					<td>
 						<label>
-							<input type="checkbox" name="imgBackup" value="true" <?php checked( $options['imgBackup']); ?>>
-							<?php _e('Create a backup for the resized images','nggallery'); ?>
+							<input type="checkbox" name="imgBackup" value="true" <?php checked( $options['imgBackup'] ); ?>>
+							<?php _e( 'Create a backup for the resized images', 'nggallery' ); ?>
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Automatically resize','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Automatically resize', 'nggallery' ); ?>
+					</th>
 					<td>
 						<label>
-							<input type="checkbox" name="imgAutoResize" value="1" <?php checked( $options['imgAutoResize']); ?>>
-							<?php _e('Automatically resize images on upload.','nggallery') ?>
+							<input type="checkbox" name="imgAutoResize" value="1" <?php checked( $options['imgAutoResize'] ); ?>>
+							<?php _e( 'Automatically resize images on upload.', 'nggallery' ) ?>
 						</label>
 					</td>
 				</tr>
 			</table>
-		<h3><?php _e('Thumbnail settings','nggallery'); ?></h3>
+			<h3>
+				<?php _e( 'Thumbnail settings', 'nggallery' ); ?>
+			</h3>
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Different sizes','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Different sizes', 'nggallery' ); ?>
+					</th>
 					<td>
-						<input type="checkbox" name="thumbDifferentSize" id="thumbDifferentSize" value="true" <?php checked( $options['thumbDifferentSize']); ?>>
-						<label for="thumbDifferentSize"><?php _e('Allows you to make thumbnails with dimensions that differ from the rest of the gallery.','nggallery') ?></label>
+						<input type="checkbox" name="thumbDifferentSize" id="thumbDifferentSize" value="true" <?php checked( $options['thumbDifferentSize'] ); ?>>
+						<label for="thumbDifferentSize">
+							<?php _e( 'Allows you to make thumbnails with dimensions that differ from the rest of the gallery.', 'nggallery' ) ?>
+						</label>
 					</td>
 				</tr>
 			</table>
-			<p><?php _e('Please note: if you change the settings below settings, you need to recreate the thumbnails under -> Manage Gallery .', 'nggallery') ?></p>
+			<p>
+				<?php _e( 'Please note: if you change the settings below settings, you need to recreate the thumbnails under -> Manage Gallery .', 'nggallery' ) ?>
+			</p>
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Thumbnail size','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Thumbnail size', 'nggallery' ); ?>
+					</th>
 					<td>
-						<label for="thumbwidth"><?php _e('Width','nggallery') ?></label>
-						<input type="number" step="1" min="0" class="small-text" name="thumbwidth" id="thumbwidth" value="<?php echo $options['thumbwidth']; ?>">
-						<label for="thumbheight"><?php _e('Height','nggallery') ?></label>
-						<input type="number" step="1" min="0" class="small-text" name="thumbheight" id="thumbheight" value="<?php echo $options['thumbheight']; ?>">
-						<p class="description"><?php _e('These values are maximum values.','nggallery'); ?></p>
+						<label for="thumbwidth">
+							<?php _e( 'Width', 'nggallery' ) ?>
+						</label>
+						<input type="number" step="1" min="0" class="small-text" name="thumbwidth" id="thumbwidth"
+							value="<?php echo $options['thumbwidth']; ?>">
+						<label for="thumbheight">
+							<?php _e( 'Height', 'nggallery' ) ?>
+						</label>
+						<input type="number" step="1" min="0" class="small-text" name="thumbheight" id="thumbheight"
+							value="<?php echo $options['thumbheight']; ?>">
+						<p class="description">
+							<?php _e( 'These values are maximum values.', 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Fixed size','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Fixed size', 'nggallery' ); ?>
+					</th>
 					<td>
-						<input type="checkbox" name="thumbfix" id="thumbfix" value="true" <?php checked( $options['thumbfix']); ?>>
-						<label for="thumbfix"><?php _e('Ignore the aspect ratio, so no portrait thumbnails.','nggallery') ?></label>
+						<input type="checkbox" name="thumbfix" id="thumbfix" value="true" <?php checked( $options['thumbfix'] ); ?>>
+						<label for="thumbfix">
+							<?php _e( 'Ignore the aspect ratio, so no portrait thumbnails.', 'nggallery' ) ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="thumbquality"><?php _e('Thumbnail quality','nggallery'); ?></label></th>
-					<td><input type="number" step="1" min="0" max="100" class="small-text" name="thumbquality" id="thumbquality" value="<?php echo $options['thumbquality']; ?>">%</td>
+					<th><label for="thumbquality">
+							<?php _e( 'Thumbnail quality', 'nggallery' ); ?>
+						</label></th>
+					<td><input type="number" step="1" min="0" max="100" class="small-text" name="thumbquality" id="thumbquality"
+							value="<?php echo $options['thumbquality']; ?>">%</td>
 				</tr>
 			</table>
-			<h3><?php _e('Single picture','nggallery') ?></h3>
+			<h3>
+				<?php _e( 'Single picture', 'nggallery' ) ?>
+			</h3>
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Clear cache folder','nggallery'); ?></th>
-					<td><input type="submit" name="clearcache" class="button-secondary"  value="<?php _e('Proceed now &raquo;','nggallery') ;?>"/></td>
+					<th>
+						<?php _e( 'Clear cache folder', 'nggallery' ); ?>
+					</th>
+					<td><input type="submit" name="clearcache" class="button-secondary"
+							value="<?php _e( 'Proceed now &raquo;', 'nggallery' ); ?>" /></td>
 				</tr>
 			</table>
-			<?php submit_button( __('Save Changes'), 'primary', 'updateoption' ); ?>
+			<?php submit_button( __( 'Save Changes' ), 'primary', 'updateoption' ); ?>
 		</form>
 
-	<?php
+		<?php
 	}
 
 	/**
 	 * Show gallery related settings
 	 */
-	private function tab_gallery($options) {
+	private function tab_gallery( $options ) {
 		?>
-		<h3><?php _e('Gallery settings','nggallery'); ?></h3>
+		<h3>
+			<?php _e( 'Gallery settings', 'nggallery' ); ?>
+		</h3>
 		<form name="galleryform" method="POST" action="<?php echo $this->page . '#gallery'; ?>">
-			<?php wp_nonce_field('ngg_settings') ?>
-			<input type="hidden" name="page_options" value="galNoPages,galImages,galColumns,galShowSlide,galTextSlide,galTextGallery,galShowOrder,galImgBrowser,galSort,galSortDir,galHiddenImg,galAjaxNav">
+			<?php wp_nonce_field( 'ngg_settings' ) ?>
+			<input type="hidden" name="page_options"
+				value="galNoPages,galImages,galColumns,galShowSlide,galTextSlide,galTextGallery,galShowOrder,galImgBrowser,galSort,galSortDir,galHiddenImg,galAjaxNav">
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Inline gallery','nggallery') ?></th>
+					<th>
+						<?php _e( 'Inline gallery', 'nggallery' ) ?>
+					</th>
 					<td>
-						<input name="galNoPages" id="galNoPages" type="checkbox" value="true" <?php checked( $options['galNoPages']); ?>>
-						<label for="galNoPages"><?php _e('Galleries will not be shown on a subpage, but on the same page.','nggallery') ?></label>
+						<input name="galNoPages" id="galNoPages" type="checkbox" value="true" <?php checked( $options['galNoPages'] ); ?>>
+						<label for="galNoPages">
+							<?php _e( 'Galleries will not be shown on a subpage, but on the same page.', 'nggallery' ) ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="galImages"><?php _e('Images per page','nggallery'); ?></label></th>
+					<th><label for="galImages">
+							<?php _e( 'Images per page', 'nggallery' ); ?>
+						</label></th>
 					<td>
-						<input type="number" step="1" min="0" class="small-text" name="galImages" id="galImages" value="<?php echo $options['galImages']; ?>">
-						<?php _e( 'images', 'nggallery'); ?>
-						<p class="description"><?php _e('0 will disable pagination and show all images on one page.','nggallery') ?></p>
+						<input type="number" step="1" min="0" class="small-text" name="galImages" id="galImages"
+							value="<?php echo $options['galImages']; ?>">
+						<?php _e( 'images', 'nggallery' ); ?>
+						<p class="description">
+							<?php _e( '0 will disable pagination and show all images on one page.', 'nggallery' ) ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="galColumns"><?php esc_html_e('Columns','nggallery'); ?></label></th>
+					<th><label for="galColumns">
+							<?php esc_html_e( 'Columns', 'nggallery' ); ?>
+						</label></th>
 					<td>
-						<input type="number" step="1" min="0" class="small-text" name="galColumns" id="galColumns" value="<?php echo $options['galColumns']; ?>">
-						<?php _e( 'columns per page', 'nggallery'); ?>
-						<p class="description"><?php _e('0 will display as much columns as possible. This is normally only required for captions below the images.','nggallery') ?></p>
+						<input type="number" step="1" min="0" class="small-text" name="galColumns" id="galColumns"
+							value="<?php echo $options['galColumns']; ?>">
+						<?php _e( 'columns per page', 'nggallery' ); ?>
+						<p class="description">
+							<?php _e( '0 will display as much columns as possible. This is normally only required for captions below the images.', 'nggallery' ) ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Slideshow','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Slideshow', 'nggallery' ); ?>
+					</th>
 					<td>
 						<label>
-							<input name="galShowSlide" type="checkbox" value="true" <?php checked( $options['galShowSlide']); ?>>
-							<?php _e('Enable slideshow','nggallery'); ?>
+							<input name="galShowSlide" type="checkbox" value="true" <?php checked( $options['galShowSlide'] ); ?>>
+							<?php _e( 'Enable slideshow', 'nggallery' ); ?>
 						</label>
-							<br>
+						<br>
 						<label>
-							<?php _e('Text to show:','nggallery'); ?>
-							<input type="text" class="regular-text" name="galTextSlide" value="<?php echo $options['galTextSlide'] ?>">
+							<?php _e( 'Text to show:', 'nggallery' ); ?>
+							<input type="text" class="regular-text" name="galTextSlide"
+								value="<?php echo $options['galTextSlide'] ?>">
 						</label>
-						<input type="text" name="galTextGallery" value="<?php echo $options['galTextGallery'] ?>" class="regular-text">
-						<p class="description"> <?php _e('This is the text the visitors will have to click to switch between display modes.','nggallery'); ?></p>
+						<input type="text" name="galTextGallery" value="<?php echo $options['galTextGallery'] ?>"
+							class="regular-text">
+						<p class="description">
+							<?php _e( 'This is the text the visitors will have to click to switch between display modes.', 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Show first','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Show first', 'nggallery' ); ?>
+					</th>
 					<td>
 						<fieldset>
 							<label>
-								<input name="galShowOrder" type="radio" value="gallery" <?php checked('gallery', $options['galShowOrder']); ?>>
-								<?php _e('Thumbnails', 'nggallery') ;?>
+								<input name="galShowOrder" type="radio" value="gallery" <?php checked( 'gallery', $options['galShowOrder'] ); ?>>
+								<?php _e( 'Thumbnails', 'nggallery' ); ?>
 							</label>
 							<br>
 							<label>
-								<input name="galShowOrder" type="radio" value="slide" <?php checked('slide', $options['galShowOrder']); ?>>
-								<?php _e('Slideshow', 'nggallery') ;?>
+								<input name="galShowOrder" type="radio" value="slide" <?php checked( 'slide', $options['galShowOrder'] ); ?>>
+								<?php _e( 'Slideshow', 'nggallery' ); ?>
 							</label>
 						</fieldset>
-						<p class="description"><?php _e( 'Choose what visitors will see first.', 'nggallery'); ?></p>
+						<p class="description">
+							<?php _e( 'Choose what visitors will see first.', 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('ImageBrowser','nggallery'); ?></th>
+					<th>
+						<?php _e( 'ImageBrowser', 'nggallery' ); ?>
+					</th>
 					<td>
 						<label>
-							<input name="galImgBrowser" type="checkbox" value="true" <?php checked( $options['galImgBrowser']); ?>>
-							<?php _e('Use ImageBrowser instead of another effect.', 'nggallery'); ?>
+							<input name="galImgBrowser" type="checkbox" value="true" <?php checked( $options['galImgBrowser'] ); ?>>
+							<?php _e( 'Use ImageBrowser instead of another effect.', 'nggallery' ); ?>
 						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Hidden images','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Hidden images', 'nggallery' ); ?>
+					</th>
 					<td>
 						<label>
-							<input name="galHiddenImg" type="checkbox" value="true" <?php checked( $options['galHiddenImg']); ?>>
-							<?php _e('Loads all images for the modal window, when pagination is used (like Thickbox, Lightbox etc.).','nggallery'); ?>
+							<input name="galHiddenImg" type="checkbox" value="true" <?php checked( $options['galHiddenImg'] ); ?>>
+							<?php _e( 'Loads all images for the modal window, when pagination is used (like Thickbox, Lightbox etc.).', 'nggallery' ); ?>
 						</label>
-						<p class="description"> <?php _e('Note: this increases the page load (possibly a lot)', 'nggallery'); ?>
+						<p class="description">
+							<?php _e( 'Note: this increases the page load (possibly a lot)', 'nggallery' ); ?>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('AJAX pagination','nggallery'); ?></th>
+					<th>
+						<?php _e( 'AJAX pagination', 'nggallery' ); ?>
+					</th>
 					<td>
 						<label>
-							<input name="galAjaxNav" type="checkbox" value="true" <?php checked( $options['galAjaxNav']); ?>>
-							<?php _e('Use AJAX pagination to browse images without reloading the page.','nggallery'); ?>
+							<input name="galAjaxNav" type="checkbox" value="true" <?php checked( $options['galAjaxNav'] ); ?>>
+							<?php _e( 'Use AJAX pagination to browse images without reloading the page.', 'nggallery' ); ?>
 						</label>
-						<p class="description"><?php esc_html_e('Note: works only in combination with the Shutter effect.', 'nggallery'); ?></p>
+						<p class="description">
+							<?php esc_html_e( 'Note: works only in combination with the Shutter effect.', 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 			</table>
-			<h3><?php _e('Sort options','nggallery'); ?></h3>
+			<h3>
+				<?php _e( 'Sort options', 'nggallery' ); ?>
+			</h3>
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Sort thumbnails','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Sort thumbnails', 'nggallery' ); ?>
+					</th>
 					<td>
 						<fieldset>
 							<label>
-								<input name="galSort" type="radio" value="sortorder" <?php checked('sortorder', $options['galSort']); ?>>
-								<?php _e('Custom order', 'nggallery'); ?>
+								<input name="galSort" type="radio" value="sortorder" <?php checked( 'sortorder', $options['galSort'] ); ?>>
+								<?php _e( 'Custom order', 'nggallery' ); ?>
 							</label><br>
 							<label>
-								<input name="galSort" type="radio" value="pid" <?php checked('pid', $options['galSort']); ?>>
-								<?php _e('Image ID', 'nggallery'); ?>
+								<input name="galSort" type="radio" value="pid" <?php checked( 'pid', $options['galSort'] ); ?>>
+								<?php _e( 'Image ID', 'nggallery' ); ?>
 							</label><br>
 							<label>
-								<input name="galSort" type="radio" value="filename" <?php checked('filename', $options['galSort']); ?>>
-								<?php _e('File name', 'nggallery') ;?>
+								<input name="galSort" type="radio" value="filename" <?php checked( 'filename', $options['galSort'] ); ?>>
+								<?php _e( 'File name', 'nggallery' ); ?>
 							</label><br>
 							<label>
-								<input name="galSort" type="radio" value="alttext" <?php checked('alttext', $options['galSort']); ?>>
-								<?php _e('Alt / Title text', 'nggallery') ;?>
+								<input name="galSort" type="radio" value="alttext" <?php checked( 'alttext', $options['galSort'] ); ?>>
+								<?php _e( 'Alt / Title text', 'nggallery' ); ?>
 							</label><br>
 							<label>
-								<input name="galSort" type="radio" value="imagedate" <?php checked('imagedate', $options['galSort']); ?>>
-								<?php _e('Date / Time', 'nggallery') ;?>
+								<input name="galSort" type="radio" value="imagedate" <?php checked( 'imagedate', $options['galSort'] ); ?>>
+								<?php _e( 'Date / Time', 'nggallery' ); ?>
 							</label>
 						</fieldset>
 
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Sort direction','nggallery') ?></th>
+					<th>
+						<?php _e( 'Sort direction', 'nggallery' ) ?>
+					</th>
 					<td>
 						<label>
-							<input name="galSortDir" type="radio" value="ASC" <?php checked('ASC', $options['galSortDir']); ?>>
-							<?php _e('Ascending', 'nggallery') ;?>
+							<input name="galSortDir" type="radio" value="ASC" <?php checked( 'ASC', $options['galSortDir'] ); ?>>
+							<?php _e( 'Ascending', 'nggallery' ); ?>
 						</label><br>
 						<label>
-							<input name="galSortDir" type="radio" value="DESC" <?php checked('DESC', $options['galSortDir']); ?>>
-							<?php _e('Descending', 'nggallery') ;?>
+							<input name="galSortDir" type="radio" value="DESC" <?php checked( 'DESC', $options['galSortDir'] ); ?>>
+							<?php _e( 'Descending', 'nggallery' ); ?>
 						</label>
 					</td>
 				</tr>
 			</table>
-			<?php submit_button( __('Save Changes'), 'primary', 'updateoption' ); ?>
+			<?php submit_button( __( 'Save Changes' ), 'primary', 'updateoption' ); ?>
 		</form>
 		<?php
 	}
@@ -617,139 +769,194 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	/**
 	 * Show the effect related settings.
 	 */
-	private function tab_effects($options) {
-	?>
-		<h3><?php _e('Effects','nggallery'); ?></h3>
+	private function tab_effects( $options ) {
+		?>
+		<h3>
+			<?php _e( 'Effects', 'nggallery' ); ?>
+		</h3>
 		<p>
-			<?php _e('Here you can select the thumbnail effect, NextCellent Gallery will integrate the required HTML code in the images. Please note that only the Shutter and Thickbox effect will automatic added to your theme.','nggallery'); ?>
-			<?php _e('There are some placeholders available you can use in the code below.','nggallery'); ?>
+			<?php _e( 'Here you can select the thumbnail effect, NextCellent Gallery will integrate the required HTML code in the images. Please note that only the Shutter and Thickbox effect will automatic added to your theme.', 'nggallery' ); ?>
+			<?php _e( 'There are some placeholders available you can use in the code below.', 'nggallery' ); ?>
 		</p>
 		<ul style="list-style: inside">
-			<li><strong>%GALLERY_NAME%</strong> - <?php _e('The gallery name.', 'nggallery'); ?></li>
-			<li><strong>%IMG_WIDTH%</strong> - <?php _e('The width of the image.', 'nggallery'); ?></li>
-			<li><strong>%IMG_HEIGHT%</strong> - <?php _e('The height of the image.', 'nggallery'); ?></li>
+			<li><strong>%GALLERY_NAME%</strong> -
+				<?php _e( 'The gallery name.', 'nggallery' ); ?>
+			</li>
+			<li><strong>%IMG_WIDTH%</strong> -
+				<?php _e( 'The width of the image.', 'nggallery' ); ?>
+			</li>
+			<li><strong>%IMG_HEIGHT%</strong> -
+				<?php _e( 'The height of the image.', 'nggallery' ); ?>
+			</li>
 		</ul>
 		<form name="effectsform" method="POST" action="<?php echo $this->page . '#effects'; ?>">
-			<?php wp_nonce_field('ngg_settings') ?>
+			<?php wp_nonce_field( 'ngg_settings' ) ?>
 			<input type="hidden" name="page_options" value="thumbEffect,thumbCode">
 			<table class="form-table ngg-options">
 				<tr>
-					<th><label for="thumbEffect"><?php _e('JavaScript Thumbnail effect','nggallery') ?></label></th>
+					<th><label for="thumbEffect">
+							<?php _e( 'JavaScript Thumbnail effect', 'nggallery' ) ?>
+						</label></th>
 					<td>
 						<select size="1" id="thumbEffect" name="thumbEffect" onchange="insertcode(this.value)">
-							<option value="none" <?php selected('none', $options['thumbEffect']); ?>><?php _e('None', 'nggallery') ;?></option>
-							<option value="thickbox" <?php selected('thickbox', $options['thumbEffect']); ?>><?php _e('Thickbox', 'nggallery') ;?></option>
-							<option value="lightbox" <?php selected('lightbox', $options['thumbEffect']); ?>><?php _e('Lightbox', 'nggallery') ;?></option>
-							<option value="highslide" <?php selected('highslide', $options['thumbEffect']); ?>><?php _e('Highslide', 'nggallery') ;?></option>
-							<option value="shutter" <?php selected('shutter', $options['thumbEffect']); ?>><?php _e('Shutter', 'nggallery') ;?></option>
-							<option value="photoSwipe" <?php selected('photoSwipe', $options['thumbEffect']); ?>><?php _e('PhotoSwipe', 'nggallery') ;?></option>
-							<option value="custom" <?php selected('custom', $options['thumbEffect']); ?>><?php _e('Custom', 'nggallery') ;?></option>
+							<option value="none" <?php selected( 'none', $options['thumbEffect'] ); ?>>
+								<?php _e( 'None', 'nggallery' ); ?>
+							</option>
+							<option value="thickbox" <?php selected( 'thickbox', $options['thumbEffect'] ); ?>>
+								<?php _e( 'Thickbox', 'nggallery' ); ?>
+							</option>
+							<option value="lightbox" <?php selected( 'lightbox', $options['thumbEffect'] ); ?>>
+								<?php _e( 'Lightbox', 'nggallery' ); ?>
+							</option>
+							<option value="highslide" <?php selected( 'highslide', $options['thumbEffect'] ); ?>>
+								<?php _e( 'Highslide', 'nggallery' ); ?>
+							</option>
+							<option value="shutter" <?php selected( 'shutter', $options['thumbEffect'] ); ?>>
+								<?php _e( 'Shutter', 'nggallery' ); ?>
+							</option>
+							<option value="photoSwipe" <?php selected( 'photoSwipe', $options['thumbEffect'] ); ?>>
+								<?php _e( 'PhotoSwipe', 'nggallery' ); ?>
+							</option>
+							<option value="custom" <?php selected( 'custom', $options['thumbEffect'] ); ?>>
+								<?php _e( 'Custom', 'nggallery' ); ?>
+							</option>
 						</select>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="thumbCode"><?php _e('Link Code line','nggallery'); ?></label></th>
+					<th><label for="thumbCode">
+							<?php _e( 'Link Code line', 'nggallery' ); ?>
+						</label></th>
 					<td>
 						<textarea class="normal-text code" id="thumbCode" name="thumbCode" cols="50" rows="5">
-							<?php echo htmlspecialchars(stripslashes($options['thumbCode'])); ?>
-						</textarea>
+									<?php echo htmlspecialchars( stripslashes( $options['thumbCode'] ) ); ?>
+								</textarea>
 					</td>
 				</tr>
 			</table>
-			<?php submit_button( __('Save Changes'), 'primary', 'updateoption' ) ?>
+			<?php submit_button( __( 'Save Changes' ), 'primary', 'updateoption' ) ?>
 			<p id="effects-more"></p>
 		</form>
-	<?php
+		<?php
 	}
 
 	/**
 	 * Show watermark related settings.
 	 */
-	private function tab_watermark($options) {
+	private function tab_watermark( $options ) {
 
 		// take the first image as sample
-		$image_array = nggdb::find_last_images(0, 1);
+		$image_array = nggdb::find_last_images( 0, 1 );
 		$ngg_image = $image_array[0];
-		$imageID  = $ngg_image->pid;
+		$imageID = $ngg_image->pid;
 
 		?>
-		<h3><?php _e('Watermark','nggallery'); ?></h3>
-		<p><?php _e('Please note : you can only activate the watermark under -> Manage Galleries. This action cannot be undone.', 'nggallery') ?></p>
+		<h3>
+			<?php _e( 'Watermark', 'nggallery' ); ?>
+		</h3>
+		<p>
+			<?php _e( 'Please note : you can only activate the watermark under -> Manage Galleries. This action cannot be undone.', 'nggallery' ) ?>
+		</p>
 		<form name="watermarkform" method="POST" action="<?php echo $this->page . '#watermark'; ?>">
-			<?php wp_nonce_field('ngg_settings') ?>
-			<input type="hidden" name="page_options" value="wmPos,wmXpos,wmYpos,wmType,wmPath,wmFont,wmSize,wmColor,wmText,wmOpaque" />
+			<?php wp_nonce_field( 'ngg_settings' ) ?>
+			<input type="hidden" name="page_options"
+				value="wmPos,wmXpos,wmYpos,wmType,wmPath,wmFont,wmSize,wmColor,wmText,wmOpaque" />
 			<div id="wm-preview">
-				<h3><?php esc_html_e('Preview','nggallery') ?></h3>
-				<label for="wm-preview-select"><?php _e('Select an image','nggallery'); ?></label>
+				<h3>
+					<?php esc_html_e( 'Preview', 'nggallery' ) ?>
+				</h3>
+				<label for="wm-preview-select">
+					<?php _e( 'Select an image', 'nggallery' ); ?>
+				</label>
 				<select id="wm-preview-select" name="wm-preview-img" style="width: 200px">
 					<?php echo '<option value="' . $ngg_image->pid . '">' . $ngg_image->pid . ' - ' . $ngg_image->alttext . '</option>'; ?>
 				</select>
 				<div id="wm-preview-container">
-					<a id="wm-preview-image-url" href="<?php echo home_url( 'index.php' ); ?>?callback=image&pid=<?php echo intval( $imageID ); ?>&mode=watermark" target="_blank" title="<?php _e("View full image", 'nggallery'); ?>">
-                        <img id="wm-preview-image" src="<?php echo home_url( 'index.php' ); ?>?callback=image&pid=<?php echo intval( $imageID ); ?>&mode=watermark" />
-                    </a>
+					<a id="wm-preview-image-url"
+						href="<?php echo home_url( 'index.php' ); ?>?callback=image&pid=<?php echo intval( $imageID ); ?>&mode=watermark"
+						target="_blank" title="<?php _e( "View full image", 'nggallery' ); ?>">
+						<img id="wm-preview-image"
+							src="<?php echo home_url( 'index.php' ); ?>?callback=image&pid=<?php echo intval( $imageID ); ?>&mode=watermark" />
+					</a>
 				</div>
-				<h3><?php _e('Position','nggallery') ?></h3>
+				<h3>
+					<?php _e( 'Position', 'nggallery' ) ?>
+				</h3>
 				<table id="wm-position">
 					<tr>
 						<td>
-							<strong><?php _e('Position','nggallery') ?></strong>
+							<strong>
+								<?php _e( 'Position', 'nggallery' ) ?>
+							</strong>
 							<table>
 								<tr>
-									<td><input type="radio" name="wmPos" value="topLeft" <?php checked('topLeft', $options['wmPos']); ?> /></td>
-									<td><input type="radio" name="wmPos" value="topCenter" <?php checked('topCenter', $options['wmPos']); ?> /></td>
-									<td><input type="radio" name="wmPos" value="topRight" <?php checked('topRight', $options['wmPos']); ?> /></td>
+									<td><input type="radio" name="wmPos" value="topLeft" <?php checked( 'topLeft', $options['wmPos'] ); ?> /></td>
+									<td><input type="radio" name="wmPos" value="topCenter" <?php checked( 'topCenter', $options['wmPos'] ); ?> /></td>
+									<td><input type="radio" name="wmPos" value="topRight" <?php checked( 'topRight', $options['wmPos'] ); ?> /></td>
 								</tr>
 								<tr>
-									<td><input type="radio" name="wmPos" value="midLeft" <?php checked('midLeft', $options['wmPos']); ?> /></td>
-									<td><input type="radio" name="wmPos" value="midCenter" <?php checked('midCenter', $options['wmPos']); ?> /></td>
-									<td><input type="radio" name="wmPos" value="midRight" <?php checked('midRight', $options['wmPos']); ?> /></td>
+									<td><input type="radio" name="wmPos" value="midLeft" <?php checked( 'midLeft', $options['wmPos'] ); ?> /></td>
+									<td><input type="radio" name="wmPos" value="midCenter" <?php checked( 'midCenter', $options['wmPos'] ); ?> /></td>
+									<td><input type="radio" name="wmPos" value="midRight" <?php checked( 'midRight', $options['wmPos'] ); ?> /></td>
 								</tr>
 								<tr>
-									<td><input type="radio" name="wmPos" value="botLeft" <?php checked('botLeft', $options['wmPos']); ?> /></td>
-									<td><input type="radio" name="wmPos" value="botCenter" <?php checked('botCenter', $options['wmPos']); ?> /></td>
-									<td><input type="radio" name="wmPos" value="botRight" <?php checked('botRight', $options['wmPos']); ?> /></td>
+									<td><input type="radio" name="wmPos" value="botLeft" <?php checked( 'botLeft', $options['wmPos'] ); ?> /></td>
+									<td><input type="radio" name="wmPos" value="botCenter" <?php checked( 'botCenter', $options['wmPos'] ); ?> /></td>
+									<td><input type="radio" name="wmPos" value="botRight" <?php checked( 'botRight', $options['wmPos'] ); ?> /></td>
 								</tr>
 							</table>
 						</td>
 						<td>
-							<strong><?php _e('Offset','nggallery') ?></strong>
+							<strong>
+								<?php _e( 'Offset', 'nggallery' ) ?>
+							</strong>
 							<table border="0">
 								<tr>
 									<td><label for="wmXpos">x:</label></td>
-									<td><input type="number" step="1" min="0" class="small-text" name="wmXpos" id="wmXpos" value="<?php echo $options['wmXpos'] ?>">px</td>
+									<td><input type="number" step="1" min="0" class="small-text" name="wmXpos" id="wmXpos"
+											value="<?php echo $options['wmXpos'] ?>">px</td>
 								</tr>
 								<tr>
 									<td><label for="wmYpos">y:</label></td>
-									<td><input type="number" step="1" min="0" class="small-text" name="wmYpos" id="wmYpos" value="<?php echo $options['wmYpos'] ?>" />px</td>
+									<td><input type="number" step="1" min="0" class="small-text" name="wmYpos" id="wmYpos"
+											value="<?php echo $options['wmYpos'] ?>" />px</td>
 								</tr>
 							</table>
 						</td>
 					</tr>
 				</table>
 			</div>
-			<h3><label><input type="radio" name="wmType" value="image" <?php checked('image', $options['wmType']); ?>><?php _e('Use image as watermark','nggallery') ?></label></h3>
+			<h3><label><input type="radio" name="wmType" value="image" <?php checked( 'image', $options['wmType'] ); ?>>
+					<?php _e( 'Use image as watermark', 'nggallery' ) ?>
+				</label></h3>
 			<table class="wm-table form-table">
 				<tr>
-					<th><label for="wmPath"><?php _e('URL to file','nggallery'); ?></label></th>
-					<td><input type="text" class="regular-text code" name="wmPath" id="wmPath" value="<?php echo $options['wmPath']; ?>"><br>
+					<th><label for="wmPath">
+							<?php _e( 'URL to file', 'nggallery' ); ?>
+						</label></th>
+					<td><input type="text" class="regular-text code" name="wmPath" id="wmPath"
+							value="<?php echo $options['wmPath']; ?>"><br>
 				</tr>
 			</table>
-			<h3><label><input type="radio" name="wmType" value="text" <?php checked('text', $options['wmType']); ?>><?php _e('Use text as watermark','nggallery') ?></label></h3>
+			<h3><label><input type="radio" name="wmType" value="text" <?php checked( 'text', $options['wmType'] ); ?>>
+					<?php _e( 'Use text as watermark', 'nggallery' ) ?>
+				</label></h3>
 			<table class="wm-table form-table">
 				<tr>
-					<th><?php _e('Font','nggallery') ?></th>
+					<th>
+						<?php _e( 'Font', 'nggallery' ) ?>
+					</th>
 					<td>
 						<select name="wmFont" size="1">
 							<?php
 							$fontlist = $this->get_fonts();
 							foreach ( $fontlist as $fontfile ) {
-								echo "\n".'<option value="'.$fontfile.'" '. selected($fontfile, $options['wmFont']).' >'.$fontfile.'</option>';
+								echo "\n" . '<option value="' . $fontfile . '" ' . selected( $fontfile, $options['wmFont'] ) . ' >' . $fontfile . '</option>';
 							}
 							?>
 						</select><br>
 						<span>
-							<?php if ( !function_exists('ImageTTFBBox') ) {
+							<?php if ( ! function_exists( 'ImageTTFBBox' ) ) {
 								_e( 'This function will not work, cause you need the FreeType library', 'nggallery' );
 							} else {
 								_e( 'You can upload more fonts in the folder <strong>nggallery/fonts</strong>', 'nggallery' );
@@ -758,26 +965,37 @@ class NGG_Options extends NGG_Post_Admin_Page {
 					</td>
 				</tr>
 				<tr>
-					<th><label for="wmSize"><?php _e('Size','nggallery'); ?></label></th>
-					<td><input type="number" step="1" min="0" class="small-text" name="wmSize" id="wmSize" value="<?php echo $options['wmSize']; ?>">px</td>
+					<th><label for="wmSize">
+							<?php _e( 'Size', 'nggallery' ); ?>
+						</label></th>
+					<td><input type="number" step="1" min="0" class="small-text" name="wmSize" id="wmSize"
+							value="<?php echo $options['wmSize']; ?>">px</td>
 				</tr>
 				<tr>
-					<th><label for="wmColor"><?php _e('Color','nggallery'); ?></label></th>
+					<th><label for="wmColor">
+							<?php _e( 'Color', 'nggallery' ); ?>
+						</label></th>
 					<td><input class="picker" type="text" id="wmColor" name="wmColor" value="<?php echo $options['wmColor'] ?>">
 				</tr>
 				<tr>
-					<th><label for="wmText"><?php _e('Text','nggallery'); ?></label></th>
-					<td><textarea name="wmText" id="wmText" cols="50" rows="5" class="normal-text"><?php echo $options['wmText'] ?></textarea></td>
+					<th><label for="wmText">
+							<?php _e( 'Text', 'nggallery' ); ?>
+						</label></th>
+					<td><textarea name="wmText" id="wmText" cols="50" rows="5"
+							class="normal-text"><?php echo $options['wmText'] ?></textarea></td>
 				</tr>
 				<tr>
-					<th><label for="wmOpaque"><?php _e('Opaque','nggallery'); ?></label></th>
-					<td><input type="number" step="1" min="0" max="100" class="small-text" name="wmOpaque" id="wmOpaque" value="<?php echo $options['wmOpaque'] ?>">%</td>
+					<th><label for="wmOpaque">
+							<?php _e( 'Opaque', 'nggallery' ); ?>
+						</label></th>
+					<td><input type="number" step="1" min="0" max="100" class="small-text" name="wmOpaque" id="wmOpaque"
+							value="<?php echo $options['wmOpaque'] ?>">%</td>
 				</tr>
 			</table>
 			<div class="clear"></div>
-			<?php submit_button( __('Save Changes'), 'primary', 'updateoption' ); ?>
+			<?php submit_button( __( 'Save Changes' ), 'primary', 'updateoption' ); ?>
 		</form>
-	<?php
+		<?php
 	}
 
 	/**
@@ -787,28 +1005,28 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	 */
 	private function get_fonts() {
 
-		$ttf_fonts = array ();
+		$ttf_fonts = array();
 
 		// Files in wp-content/plugins/nggallery/fonts directory
 		$plugin_root = NGGALLERY_ABSPATH . 'fonts';
 
-		$plugins_dir = @ dir($plugin_root);
-		if ($plugins_dir) {
-			while (($file = $plugins_dir->read()) !== false) {
-				if (preg_match('|^\.+$|', $file))
+		$plugins_dir = @dir( $plugin_root );
+		if ( $plugins_dir ) {
+			while ( ( $file = $plugins_dir->read() ) !== false ) {
+				if ( preg_match( '|^\.+$|', $file ) )
 					continue;
-				if (is_dir($plugin_root.'/'.$file)) {
-					$plugins_subdir = @ dir($plugin_root.'/'.$file);
-					if ($plugins_subdir) {
-						while (($subfile = $plugins_subdir->read()) !== false) {
-							if (preg_match('|^\.+$|', $subfile))
+				if ( is_dir( $plugin_root . '/' . $file ) ) {
+					$plugins_subdir = @dir( $plugin_root . '/' . $file );
+					if ( $plugins_subdir ) {
+						while ( ( $subfile = $plugins_subdir->read() ) !== false ) {
+							if ( preg_match( '|^\.+$|', $subfile ) )
 								continue;
-							if (preg_match('|\.ttf$|', $subfile))
+							if ( preg_match( '|\.ttf$|', $subfile ) )
 								$ttf_fonts[] = "$file/$subfile";
 						}
 					}
 				} else {
-					if (preg_match('|\.ttf$|', $file))
+					if ( preg_match( '|\.ttf$|', $file ) )
 						$ttf_fonts[] = $file;
 				}
 			}
@@ -820,132 +1038,197 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	/**
 	 * Show slideshow related settings
 	 */
-	private function tab_slideshow($ngg_options) {
+	private function tab_slideshow( $ngg_options ) {
 		?>
-		<form name="player_options" method="POST" action="<?php echo $this->page.'#slideshow'; ?>">
-			<?php wp_nonce_field('ngg_settings'); ?>
-			<input type="hidden" name="page_options" value="irAutoDim,slideFx,irWidth,irHeight,irRotatetime,irLoop,irDrag,irNavigation,irNavigationDots,irAutoplay,irAutoplayTimeout,irAutoplayHover,irNumber,irClick" />
-			<h3><?php _e('Slideshow','nggallery'); ?></h3>
+		<form name="player_options" method="POST" action="<?php echo $this->page . '#slideshow'; ?>">
+			<?php wp_nonce_field( 'ngg_settings' ); ?>
+			<input type="hidden" name="page_options"
+				value="irAutoDim,slideFx,irWidth,irHeight,irRotatetime,irLoop,irDrag,irNavigation,irNavigationDots,irAutoplay,irAutoplayTimeout,irAutoplayHover,irNumber,irClick" />
+			<h3>
+				<?php _e( 'Slideshow', 'nggallery' ); ?>
+			</h3>
 			<table class="form-table ngg-options">
 				<tr>
-					<th><?php _e('Fit to space','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Fit to space', 'nggallery' ); ?>
+					</th>
 					<td>
-						<input type="checkbox" name="irAutoDim" id="irAutoDim" value="true" <?php checked( $ngg_options['irAutoDim']); ?>">
-						<label for="irAutoDim"><?php _e( "Let the slideshow fit in the available space.", 'nggallery'); ?></label>
+						<input type="checkbox" name="irAutoDim" id="irAutoDim" value="true" <?php checked( $ngg_options['irAutoDim'] ); ?>">
+						<label for="irAutoDim">
+							<?php _e( "Let the slideshow fit in the available space.", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Default size','nggallery'); ?></th>
+					<th>
+						<?php _e( 'Default size', 'nggallery' ); ?>
+					</th>
 					<td>
-						<label for="irWidth"><?php _e('Width','nggallery'); ?></label>
-						<input <?php $this->readonly($ngg_options['irAutoDim']); ?> type="number" min="0" class="small-text" name="irWidth" id="irWidth" value="<?php echo $ngg_options['irWidth']; ?>">
-						<label for="irHeight"><?php _e('Height','nggallery'); ?></label>
-						<input <?php $this->readonly($ngg_options['irAutoDim']); ?> type="number" min="0" class="small-text" name="irHeight" id="irHeight" value="<?php echo $ngg_options['irHeight']; ?>">
+						<label for="irWidth">
+							<?php _e( 'Width', 'nggallery' ); ?>
+						</label>
+						<input <?php $this->readonly( $ngg_options['irAutoDim'] ); ?> type="number" min="0" class="small-text"
+							name="irWidth" id="irWidth" value="<?php echo $ngg_options['irWidth']; ?>">
+						<label for="irHeight">
+							<?php _e( 'Height', 'nggallery' ); ?>
+						</label>
+						<input <?php $this->readonly( $ngg_options['irAutoDim'] ); ?> type="number" min="0" class="small-text"
+							name="irHeight" id="irHeight" value="<?php echo $ngg_options['irHeight']; ?>">
 					</td>
 				</tr>
 				<tr>
-					<th><label for="slideFx"><?php _e('Transition / Fade effect','nggallery'); ?></label></th>
+					<th><label for="slideFx">
+							<?php _e( 'Transition / Fade effect', 'nggallery' ); ?>
+						</label></th>
 					<td>
 						<select size="1" name="slideFx" id="slideFx">
 							<?php
 							$options = array(
-								__( 'Attention Seekers', 'nggallery' )  => array( "bounce", "flash", "pulse", "rubberBand", "shake", "swing", "tada", "wobble"),
+								__( 'Attention Seekers', 'nggallery' ) => array( "bounce", "flash", "pulse", "rubberBand", "shake", "swing", "tada", "wobble" ),
 								__( 'Bouncing Entrances', 'nggallery' ) => array( "bounceIn", "bounceInDown", "bounceInLeft", "bounceInRight", "bounceInUp" ),
-								__( 'Fading Entrances', 'nggallery' )   => array( "fadeIn", "fadeInDown", "fadeInDownBig", "fadeInLeft", "fadeInLeftBig", "fadeInRight", "fadeInRightBig", "fadeInUp", "fadeInUpBig"),
-								__( 'Fading Exits', 'nggallery' )       => array( "fadeOut", "fadeOutDown", "fadeOutDownBig", "fadeOutLeft", "fadeOutLeftBig", "fadeOutRight", "fadeOutRightBig", "fadeOutUp", "fadeOutUpBig"),
-								__( 'Flippers', 'nggallery' )           => array( "flip", "flipInX", "flipInY", "flipOutX", "flipOutY" ),
-								__( 'Lightspeed', 'nggallery' )         => array( "lightSpeedIn", "lightSpeedOut"),
-								__( 'Rotating Entrances', 'nggallery' )	=> array( "rotateIn", "rotateInDownLeft", "rotateInDownRight", "rotateInUpLeft", "rotateInUpRight" ),
-								__( 'Rotating Exits', 'nggallery' )     => array( "rotateOut", "rotateOutDownLeft", "rotateOutDownRight", "rotateOutUpLeft", "rotateOutUpRight" ),
-								__( 'Specials', 'nggallery' )           => array( "hinge", "rollIn", "rollOut" ),
-								__( 'Zoom Entrances', 'nggallery' )     => array( "zoomIn", "zoomInDown", "zoomInLeft", "zoomInRight", "zoomInUp" )
+								__( 'Fading Entrances', 'nggallery' ) => array( "fadeIn", "fadeInDown", "fadeInDownBig", "fadeInLeft", "fadeInLeftBig", "fadeInRight", "fadeInRightBig", "fadeInUp", "fadeInUpBig" ),
+								__( 'Fading Exits', 'nggallery' ) => array( "fadeOut", "fadeOutDown", "fadeOutDownBig", "fadeOutLeft", "fadeOutLeftBig", "fadeOutRight", "fadeOutRightBig", "fadeOutUp", "fadeOutUpBig" ),
+								__( 'Flippers', 'nggallery' ) => array( "flip", "flipInX", "flipInY", "flipOutX", "flipOutY" ),
+								__( 'Lightspeed', 'nggallery' ) => array( "lightSpeedIn", "lightSpeedOut" ),
+								__( 'Rotating Entrances', 'nggallery' ) => array( "rotateIn", "rotateInDownLeft", "rotateInDownRight", "rotateInUpLeft", "rotateInUpRight" ),
+								__( 'Rotating Exits', 'nggallery' ) => array( "rotateOut", "rotateOutDownLeft", "rotateOutDownRight", "rotateOutUpLeft", "rotateOutUpRight" ),
+								__( 'Specials', 'nggallery' ) => array( "hinge", "rollIn", "rollOut" ),
+								__( 'Zoom Entrances', 'nggallery' ) => array( "zoomIn", "zoomInDown", "zoomInLeft", "zoomInRight", "zoomInUp" )
 							);
 
-							foreach( $options as $option => $val ) {
-								echo $this->convert_fx_to_optgroup( $val, $option, $ngg_options );
+							foreach ( $options as $option => $val ) {
+								echo $this->convert_fx_to_optgroup( $val, $ngg_options, $option );
 							}
 							?>
 						</select>
 						<p class="description">
-							<?php _e("These effects are powered by"); ?> <strong>animate.css</strong>. <a target="_blank" href="http://daneden.github.io/animate.css/"><?php _e("Click here for examples of all effects and to learn more."); ?></a></p>
+							<?php _e( "These effects are powered by" ); ?> <strong>animate.css</strong>. <a target="_blank"
+								href="http://daneden.github.io/animate.css/">
+								<?php _e( "Click here for examples of all effects and to learn more." ); ?>
+							</a>
+						</p>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Loop','nggallery') ?></th>
+					<th>
+						<?php _e( 'Loop', 'nggallery' ) ?>
+					</th>
 					<td>
-						<input type="checkbox" name="irLoop" id="irLoop" value="true" <?php checked( $ngg_options['irLoop']); ?>">
-						<label for="irLoop"><?php _e( "Infinity loop. Duplicate last and first items to get loop illusion.", 'nggallery'); ?></label>
+						<input type="checkbox" name="irLoop" id="irLoop" value="true" <?php checked( $ngg_options['irLoop'] ); ?>">
+						<label for="irLoop">
+							<?php _e( "Infinity loop. Duplicate last and first items to get loop illusion.", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Mouse/touch drag','nggallery') ?></th>
+					<th>
+						<?php _e( 'Mouse/touch drag', 'nggallery' ) ?>
+					</th>
 					<td>
 						<input type="checkbox" name="irDrag" id="irDrag" value="true" <?php checked( $ngg_options['irDrag'] ); ?>">
-						<label for="irDrag"><?php _e( "Enable dragging with the mouse (or touch).", 'nggallery'); ?></label>
+						<label for="irDrag">
+							<?php _e( "Enable dragging with the mouse (or touch).", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Previous / Next','nggallery') ?></th>
+					<th>
+						<?php _e( 'Previous / Next', 'nggallery' ) ?>
+					</th>
 					<td>
 						<input type="checkbox" name="irNavigation" id="irNavigation" value="true" <?php checked( $ngg_options['irNavigation'] ); ?>>
-						<label for="irNavigation"><?php _e( "Show next/previous buttons.", 'nggallery'); ?></label>
+						<label for="irNavigation">
+							<?php _e( "Show next/previous buttons.", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Show dots','nggallery') ?></th>
+					<th>
+						<?php _e( 'Show dots', 'nggallery' ) ?>
+					</th>
 					<td>
 						<input type="checkbox" name="irNavigationDots" id="irNavigationDots" value="true" <?php checked( $ngg_options['irNavigationDots'] ); ?>>
-						<label for="irNavigationDots"><?php _e( "Show dots for each image.", 'nggallery'); ?></label>
+						<label for="irNavigationDots">
+							<?php _e( "Show dots for each image.", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Autoplay','nggallery') ?></th>
+					<th>
+						<?php _e( 'Autoplay', 'nggallery' ) ?>
+					</th>
 					<td>
 						<input type="checkbox" name="irAutoplay" id="irAutoplay" value="true" <?php checked( $ngg_options['irAutoplay'] ); ?>>
-						<label for="irAutoplay"><?php _e( "Automatically play the images.", 'nggallery'); ?></label>
+						<label for="irAutoplay">
+							<?php _e( "Automatically play the images.", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><label for="irRotatetime"><?php _e('Duration','nggallery') ?></label></th>
+					<th><label for="irRotatetime">
+							<?php _e( 'Duration', 'nggallery' ) ?>
+						</label></th>
 					<td>
-						<input <?php $this->readonly( false, $ngg_options['irAutoplay'] ); ?> type="number" step="1" min="0" class="small-text" name="irRotatetime" id="irRotatetime" value="<?php echo $ngg_options['irRotatetime'] ?>">
-						<?php _e('sec.', 'nggallery') ;?>
+						<input <?php $this->readonly( false, $ngg_options['irAutoplay'] ); ?> type="number" step="1" min="0"
+							class="small-text" name="irRotatetime" id="irRotatetime"
+							value="<?php echo $ngg_options['irRotatetime'] ?>">
+						<?php _e( 'sec.', 'nggallery' ); ?>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Pause on hover','nggallery') ?></th>
+					<th>
+						<?php _e( 'Pause on hover', 'nggallery' ) ?>
+					</th>
 					<td>
-						<input <?php disabled(false, $ngg_options['irAutoplay']); ?> type="checkbox" name="irAutoplayHover" id="irAutoplayHover" value="true" <?php checked( $ngg_options['irAutoplayHover']); ?>>
-						<label for="irAutoplayHover"><?php _e( "Pause when hovering over the slideshow.", 'nggallery'); ?></label>
+						<input <?php disabled( false, $ngg_options['irAutoplay'] ); ?> type="checkbox" name="irAutoplayHover"
+							id="irAutoplayHover" value="true" <?php checked( $ngg_options['irAutoplayHover'] ); ?>>
+						<label for="irAutoplayHover">
+							<?php _e( "Pause when hovering over the slideshow.", 'nggallery' ); ?>
+						</label>
 					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Click for next','nggallery') ?></th>
+					<th>
+						<?php _e( 'Click for next', 'nggallery' ) ?>
+					</th>
 					<td>
-						<input type="checkbox" name="irClick" id="irClick" value="true" <?php checked( $ngg_options['irClick']); ?>>
-						<label for="irClick"><?php _e( "Click to go to the next image.", 'nggallery'); ?></label></td>
+						<input type="checkbox" name="irClick" id="irClick" value="true" <?php checked( $ngg_options['irClick'] ); ?>>
+						<label for="irClick">
+							<?php _e( "Click to go to the next image.", 'nggallery' ); ?>
+						</label>
+					</td>
 				</tr>
 				<tr>
-					<th><?php _e('Number of images','nggallery') ?></th>
+					<th>
+						<?php _e( 'Number of images', 'nggallery' ) ?>
+					</th>
 					<td>
-						<input type="number" step="1" min="1" class="small-text" name="irNumber" id="irNumber" value="<?php echo $ngg_options['irNumber'] ?>">
-						<label for="irNumber"><?php _e('images', 'nggallery') ;?></label>
-						<p class="description"><?php _e( "Number of images to display when using random or latest.", 'nggallery'); ?></p>
+						<input type="number" step="1" min="1" class="small-text" name="irNumber" id="irNumber"
+							value="<?php echo $ngg_options['irNumber'] ?>">
+						<label for="irNumber">
+							<?php _e( 'images', 'nggallery' ); ?>
+						</label>
+						<p class="description">
+							<?php _e( "Number of images to display when using random or latest.", 'nggallery' ); ?>
+						</p>
 					</td>
 				</tr>
 			</table>
-			<?php submit_button( __('Save Changes'), 'primary', 'updateoption' ); ?>
-	</form>
-	<?php
+			<?php submit_button( __( 'Save Changes' ), 'primary', 'updateoption' ); ?>
+		</form>
+		<?php
 	}
 
 
-	private function tab_advanced($options) {
+	private function tab_advanced( $options ) {
 		?>
-		<form name="resetsettings" method="post" action="<?php echo $this->page.'#advanced'; ?>">
-			<?php wp_nonce_field('ngg_uninstall') ?>
-			<p><?php _e('Use this button to reset all NextCellent options.', 'nggallery') ;?></p>
-			<input type="submit" class="button" id="reset-to-default" name="resetdefault" value="<?php _e('Reset settings', 'nggallery') ;?>">
+		<form name="resetsettings" method="post" action="<?php echo $this->page . '#advanced'; ?>">
+			<?php wp_nonce_field( 'ngg_uninstall' ) ?>
+			<p>
+				<?php _e( 'Use this button to reset all NextCellent options.', 'nggallery' ); ?>
+			</p>
+			<input type="submit" class="button" id="reset-to-default" name="resetdefault"
+				value="<?php _e( 'Reset settings', 'nggallery' ); ?>">
 		</form>
 		<?php
 	}
@@ -959,7 +1242,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	 *
 	 * @return string The output.
 	 */
-	private function convert_fx_to_optgroup( $data, $title = null, $ngg_options ) {
+	private function convert_fx_to_optgroup( $data, $ngg_options, $title = null ) {
 
 		if ( is_null( $title ) ) {
 			$out = null;
@@ -969,7 +1252,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 
 		foreach ( $data as $option ) {
 			$out .= '<option value="' . $option . '" ' . selected( $option,
-					$ngg_options['slideFx'] ) . '>' . $option . '</option>';
+				$ngg_options['slideFx'] ) . '>' . $option . '</option>';
 		}
 
 		if ( ! is_null( $title ) ) {
@@ -985,7 +1268,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 	 * @param mixed $current The current value.
 	 * @param mixed $other The other value.
 	 */
-	private function readonly($current, $other = true) {
+	private function readonly( $current, $other = true ) {
 		if ( $current == $other ) {
 			echo 'readonly="readonly"';
 		}
@@ -999,9 +1282,9 @@ class NGG_Options extends NGG_Post_Admin_Page {
 
 		$total = array();
 		// get the total number of images
-		$total['images'] = intval( $wpdb->get_var("SELECT COUNT(*) FROM $wpdb->nggpictures") );
-		$total['gallery'] = intval( $wpdb->get_var("SELECT COUNT(*) FROM $wpdb->nggallery") );
-		$total['album'] = intval( $wpdb->get_var("SELECT COUNT(*) FROM $wpdb->nggalbum") );
+		$total['images'] = intval( $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->nggpictures" ) );
+		$total['gallery'] = intval( $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->nggallery" ) );
+		$total['album'] = intval( $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->nggalbum" ) );
 
 		$messages = array(
 			'images' => __( 'Rebuild image structure : %s / %s images', 'nggallery' ),
@@ -1011,7 +1294,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 
 		foreach ( array_keys( $messages ) as $key ) {
 
-			$message = sprintf( $messages[ $key ] ,
+			$message = sprintf( $messages[ $key ],
 				"<span class='ngg-count-current'>0</span>",
 				"<span class='ngg-count-total'>" . $total[ $key ] . "</span>"
 			);
@@ -1022,7 +1305,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 		$ajax_url = add_query_arg( 'action', 'ngg_rebuild_unique_slugs', admin_url( 'admin-ajax.php' ) );
 		?>
 		<script type="text/javascript">
-			jQuery(document).ready(function($) {
+			jQuery(document).ready(function ($) {
 				var ajax_url = '<?php echo $ajax_url; ?>',
 					_action = 'images',
 					images = <?php echo $total['images']; ?>,
@@ -1037,7 +1320,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 				total = images;
 
 				function call_again() {
-					if ( offset > total ) {
+					if (offset > total) {
 						offset = 0;
 						// 1st run finished
 						if (_action == 'images') {
@@ -1067,7 +1350,7 @@ class NGG_Options extends NGG_Post_Admin_Page {
 						}
 					}
 
-					$.post(ajax_url, {'_action': _action, 'offset': offset}, function(response) {
+					$.post(ajax_url, { '_action': _action, 'offset': offset }, function (response) {
 						$display.html(offset);
 
 						offset += count;

--- a/admin/functions.php
+++ b/admin/functions.php
@@ -1,6 +1,8 @@
 <?php
 
-if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('You are not allowed to call this page directly.'); }
+if ( preg_match( '#' . basename( __FILE__ ) . '#', $_SERVER['PHP_SELF'] ) ) {
+	die ( 'You are not allowed to call this page directly.' );
+}
 
 /**
  * nggAdmin - Class for admin operation
@@ -10,7 +12,7 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('You 
  * 
  * @access public
  */
-class nggAdmin{
+class nggAdmin {
 
 	/**
 	 * Create a new gallery in a new folder
@@ -26,106 +28,111 @@ class nggAdmin{
 	 * @return bool|int True if successful, otherwise false.$galleryID if is successful and output = false)
 	 */
 
-	static function create_gallery($title, $defaultpath, $output = true, $description = '') {
+	static function create_gallery( $title, $defaultpath, $output = true, $description = '' ) {
 
 		$user = wp_get_current_user(); //get current user ID & sets global object $current_user (?well that was get_ucrrentuserinfo did)
-		$name = sanitize_file_name( sanitize_title($title)  );  //cleanup pathname
-		$name = apply_filters('ngg_gallery_name', $name);
+		$name = sanitize_file_name( sanitize_title( $title ) );  //cleanup pathname
+		$name = apply_filters( 'ngg_gallery_name', $name );
 
-		if ( empty($name) ) { // No gallery name ?
-			if ($output) nggGallery::show_error( __('No valid gallery name!', 'nggallery') );
+		if ( empty ( $name ) ) { // No gallery name ?
+			if ( $output )
+				nggGallery::show_error( __( 'No valid gallery name!', 'nggallery' ) );
 			return false;
 		}
 
-        $txt = '';
-        $nggRoot = WINABSPATH . $defaultpath;
+		$txt = '';
+		$nggRoot = WINABSPATH . $defaultpath;
 
 		// check for main folder
-		if ( !is_dir($nggRoot) ) {
-			if ( !wp_mkdir_p( $nggRoot ) ) {
-				$txt  = __('Directory', 'nggallery').' <strong>' . esc_html( $defaultpath ) . '</strong> '.__('didn\'t exist. Please create first the main gallery folder ', 'nggallery').'!<br />';
-				$txt .= __('Check this link, if you didn\'t know how to set the permission :', 'nggallery').' <a href="http://codex.wordpress.org/Changing_File_Permissions">http://codex.wordpress.org/Changing_File_Permissions</a> ';
-				if ($output) nggGallery::show_error($txt);
+		if ( ! is_dir( $nggRoot ) ) {
+			if ( ! wp_mkdir_p( $nggRoot ) ) {
+				$txt = __( 'Directory', 'nggallery' ) . ' <strong>' . esc_html( $defaultpath ) . '</strong> ' . __( 'didn\'t exist. Please create first the main gallery folder ', 'nggallery' ) . '!<br />';
+				$txt .= __( 'Check this link, if you didn\'t know how to set the permission :', 'nggallery' ) . ' <a href="http://codex.wordpress.org/Changing_File_Permissions">http://codex.wordpress.org/Changing_File_Permissions</a> ';
+				if ( $output )
+					nggGallery::show_error( $txt );
 				return false;
 			}
 		}
 
 		// check for permission settings, Safe mode limitations are not taken into account. 
-		if ( !is_writeable( $nggRoot ) ) {
-			$txt  = __('Directory', 'nggallery').' <strong>' . esc_html( $defaultpath ) . '</strong> '.__('is not writeable !', 'nggallery').'<br />';
-			$txt .= __('Check this link, if you didn\'t know how to set the permission :', 'nggallery').' <a href="http://codex.wordpress.org/Changing_File_Permissions">http://codex.wordpress.org/Changing_File_Permissions</a> ';
-			if ($output) nggGallery::show_error($txt);
+		if ( ! is_writeable( $nggRoot ) ) {
+			$txt = __( 'Directory', 'nggallery' ) . ' <strong>' . esc_html( $defaultpath ) . '</strong> ' . __( 'is not writeable !', 'nggallery' ) . '<br />';
+			$txt .= __( 'Check this link, if you didn\'t know how to set the permission :', 'nggallery' ) . ' <a href="http://codex.wordpress.org/Changing_File_Permissions">http://codex.wordpress.org/Changing_File_Permissions</a> ';
+			if ( $output )
+				nggGallery::show_error( $txt );
 			return false;
 		}
-		
+
 		// 1. Check for existing folder, if it already exists, create new one with suffix
-		if ( is_dir($nggRoot . $name ) && !(SAFE_MODE) ) {
+		if ( is_dir( $nggRoot . $name ) && ! ( SAFE_MODE ) ) {
 			$suffix = 1;
 			do {
-				$alt_name = substr ($name, 0, 200 - ( strlen( $suffix ) + 1 ) ) . "_$suffix";
-				$dir_check = is_dir($nggRoot . $alt_name );
+				$alt_name = substr( $name, 0, 200 - ( strlen( $suffix ) + 1 ) ) . "_$suffix";
+				$dir_check = is_dir( $nggRoot . $alt_name );
 				$suffix++;
 			} while ( $dir_check );
 			$name = $alt_name;
-		}  
-        // define relative path to gallery inside wp root folder
-        $nggpath = $defaultpath . $name;
-        $win_nggpath = WINABSPATH . $nggpath;
+		}
+		// define relative path to gallery inside wp root folder
+		$nggpath = $defaultpath . $name;
+		$win_nggpath = WINABSPATH . $nggpath;
 		// 2. Create new gallery folder
 
-        if ( !wp_mkdir_p ($win_nggpath) )
-		  $txt  = __('Unable to create directory ', 'nggallery') . esc_html( $nggpath ) . '!<br />';
-		
+		if ( ! wp_mkdir_p( $win_nggpath ) )
+			$txt = __( 'Unable to create directory ', 'nggallery' ) . esc_html( $nggpath ) . '!<br />';
+
 		// 3. Check folder permission
-		if ( !is_writeable($win_nggpath) )
-			$txt .= __('Directory', 'nggallery').' <strong>' . esc_html( $nggpath ) . '</strong> '.__('is not writeable !', 'nggallery').'<br />';
+		if ( ! is_writeable( $win_nggpath ) )
+			$txt .= __( 'Directory', 'nggallery' ) . ' <strong>' . esc_html( $nggpath ) . '</strong> ' . __( 'is not writeable !', 'nggallery' ) . '<br />';
 
 		// 4. Now create thumbnail folder inside
-		if ( !is_dir($win_nggpath . '/thumbs') ) {
-			if ( !wp_mkdir_p ( $win_nggpath . '/thumbs') )
-				$txt .= __('Unable to create directory ', 'nggallery').' <strong>' . esc_html( $nggpath ) . '/thumbs !</strong>';
+		if ( ! is_dir( $win_nggpath . '/thumbs' ) ) {
+			if ( ! wp_mkdir_p( $win_nggpath . '/thumbs' ) )
+				$txt .= __( 'Unable to create directory ', 'nggallery' ) . ' <strong>' . esc_html( $nggpath ) . '/thumbs !</strong>';
 		}
-		
-		if (SAFE_MODE) {
-			$help  = __('The server setting Safe-Mode is on !', 'nggallery');	
-			$help .= '<br />'.__('If you have problems, please create directory', 'nggallery').' <strong>' . esc_html( $nggpath ) . '</strong> ';	
-			$help .= __('and the thumbnails directory', 'nggallery').' <strong>' . esc_html( $nggpath ) . '/thumbs</strong> '.__('with permission 777 manually !', 'nggallery');
-			if ($output) nggGallery::show_message($help);
+
+		if ( SAFE_MODE ) {
+			$help = __( 'The server setting Safe-Mode is on !', 'nggallery' );
+			$help .= '<br />' . __( 'If you have problems, please create directory', 'nggallery' ) . ' <strong>' . esc_html( $nggpath ) . '</strong> ';
+			$help .= __( 'and the thumbnails directory', 'nggallery' ) . ' <strong>' . esc_html( $nggpath ) . '/thumbs</strong> ' . __( 'with permission 777 manually !', 'nggallery' );
+			if ( $output )
+				nggGallery::show_message( $help );
 		}
-		
+
 		// show a error message			
-		if ( !empty($txt) ) {
-			if (SAFE_MODE) {
-			// for safe_mode , better delete folder, both folder must be created manually
-				@rmdir($win_nggpath . '/thumbs');
-				@rmdir($win_nggpath);
+		if ( ! empty ( $txt ) ) {
+			if ( SAFE_MODE ) {
+				// for safe_mode , better delete folder, both folder must be created manually
+				@rmdir( $win_nggpath . '/thumbs' );
+				@rmdir( $win_nggpath );
 			}
-			if ($output) nggGallery::show_error($txt);
+			if ( $output )
+				nggGallery::show_error( $txt );
 			return false;
 		}
 
 		//clean the description and add the gallery
-		$description = nggGallery::suppress_injection($description);
-        $galleryID = nggdb::add_gallery($title, $nggpath, $description, 0, 0, $user->ID);
+		$description = nggGallery::suppress_injection( $description );
+		$galleryID = nggdb::add_gallery( $title, $nggpath, $description, 0, 0, $user->ID );
 		// here you can inject a custom function
-		do_action('ngg_created_new_gallery', $galleryID);
+		do_action( 'ngg_created_new_gallery', $galleryID );
 
 		// return only the id if defined
-		if ($output == false)
+		if ( $output == false )
 			return $galleryID;
-			
-		if ($galleryID != false) {
-			$message  = __('Gallery ID %1$s successfully created. You can show this gallery in your post or page with the shortcode %2$s.<br/>','nggallery');
-			$message  = sprintf($message, $galleryID, '<strong>[nggallery id=' . $galleryID . ']</strong>');
+
+		if ( $galleryID != false ) {
+			$message = __( 'Gallery ID %1$s successfully created. You can show this gallery in your post or page with the shortcode %2$s.<br/>', 'nggallery' );
+			$message = sprintf( $message, $galleryID, '<strong>[nggallery id=' . $galleryID . ']</strong>' );
 			$message .= '<a href="' . admin_url() . 'admin.php?page=nggallery-manage&mode=image&gid=' . $galleryID . '" >';
-			$message .= __('Edit gallery','nggallery');
+			$message .= __( 'Edit gallery', 'nggallery' );
 			$message .= '</a>';
-			
-			nggGallery::show_message($message);
+
+			nggGallery::show_message( $message );
 		}
 		return true;
 	}
-	
+
 	/**
 	 * nggAdmin::import_gallery()
 	 * TODO: Check permission of existing thumb folder & images
@@ -135,136 +142,136 @@ class nggAdmin{
 	 * @param string $galleryfolder contains relative path to the gallery itself
 	 * @return void
 	 */
-	 
-	static function import_gallery($galleryfolder) {
+
+	static function import_gallery( $galleryfolder ) {
 		/**
 		 * @global nggdb $nggdb
 		 */
 		global $wpdb, $nggdb;
 
-		$user=wp_get_current_user(); // get the current user ID
-		
-		$created_msg = NULL;
-		
-		// remove trailing slash at the end, if somebody use it
-		$galleryfolder = untrailingslashit($galleryfolder);
-		$gallerypath = WINABSPATH . $galleryfolder;
-		
-		if (!is_dir($gallerypath)) {
-			nggGallery::show_error(__('Directory', 'nggallery').' <strong>' . esc_html( $gallerypath ) .'</strong> '.__('doesn&#96;t exist!', 'nggallery'));
-			return ;
-		}
-		
-		$test_images = nggAdmin::scandir($gallerypath);
+		$user = wp_get_current_user(); // get the current user ID
 
-		if (empty($test_images)) {
-			nggGallery::show_message(__('Directory', 'nggallery').' <strong>' . esc_html( $gallerypath ) . '</strong> '.__('contains no pictures', 'nggallery'));
+		$created_msg = NULL;
+
+		// remove trailing slash at the end, if somebody use it
+		$galleryfolder = untrailingslashit( $galleryfolder );
+		$gallerypath = WINABSPATH . $galleryfolder;
+
+		if ( ! is_dir( $gallerypath ) ) {
+			nggGallery::show_error( __( 'Directory', 'nggallery' ) . ' <strong>' . esc_html( $gallerypath ) . '</strong> ' . __( 'doesn&#96;t exist!', 'nggallery' ) );
 			return;
 		}
-		
+
+		$test_images = nggAdmin::scandir( $gallerypath );
+
+		if ( empty ( $test_images ) ) {
+			nggGallery::show_message( __( 'Directory', 'nggallery' ) . ' <strong>' . esc_html( $gallerypath ) . '</strong> ' . __( 'contains no pictures', 'nggallery' ) );
+			return;
+		}
+
 		//save orginals
 		$old_galleryfolder = $galleryfolder;
 		$old_gallerypath = $gallerypath;
-		
+
 		//sanitize name
 		$new_name = sanitize_file_name( sanitize_title( basename( $galleryfolder ) ) );
-		
+
 		//set new names
 		$galleryfolder = dirname( $galleryfolder ) . "/" . sanitize_file_name( sanitize_title( basename( $galleryfolder ) ) );
 		$gallerypath = WINABSPATH . $galleryfolder;
-			
+
 		//rename existing folder
-		if ( !($old_galleryfolder == $galleryfolder)) {
+		if ( ! ( $old_galleryfolder == $galleryfolder ) ) {
 			//check if it exists
 			$increment = ''; //start with no suffix
 
-			while(file_exists($gallerypath . $increment)) {
+			while ( file_exists( $gallerypath . $increment ) ) {
 				$increment++;
 			}
 			$galleryfolder = dirname( $galleryfolder ) . "/" . basename( $galleryfolder ) . $increment;
 			$gallerypath = WINABSPATH . $galleryfolder;
-			
-			if ( !rename( $old_gallerypath , $gallerypath ) )
-				nggGallery::show_message(__('Something went wrong when renaming', 'nggallery').' <strong>' . esc_html( $old_galleryfolder ) .'</strong>! ' .__('Importing was aborted.', 'nggallery'));
+
+			if ( ! rename( $old_gallerypath, $gallerypath ) )
+				nggGallery::show_message( __( 'Something went wrong when renaming', 'nggallery' ) . ' <strong>' . esc_html( $old_galleryfolder ) . '</strong>! ' . __( 'Importing was aborted.', 'nggallery' ) );
 		}
 
 		// check & create thumbnail folder
-		if ( !nggGallery::get_thumbnail_folder($gallerypath) )
+		if ( ! nggGallery::get_thumbnail_folder( $gallerypath ) )
 			return;
-		
-		// take folder name as gallery name		
-		$galleryname = basename($galleryfolder);
-		$galleryname = apply_filters('ngg_gallery_name', $galleryname);
-		
-		// check for existing gallery folder
-		$gallery_id = $wpdb->get_var("SELECT gid FROM $wpdb->nggallery WHERE path = '$old_galleryfolder' ");
 
-		if (!$gallery_id) {
-            // now add the gallery to the database
-            $gallery_id = nggdb::add_gallery( $galleryname, $galleryfolder, '', 0, 0, $user->ID );
-			if (!$gallery_id) {
-				nggGallery::show_error(__('Database error. Could not add gallery!','nggallery'));
+		// take folder name as gallery name		
+		$galleryname = basename( $galleryfolder );
+		$galleryname = apply_filters( 'ngg_gallery_name', $galleryname );
+
+		// check for existing gallery folder
+		$gallery_id = $wpdb->get_var( "SELECT gid FROM $wpdb->nggallery WHERE path = '$old_galleryfolder' " );
+
+		if ( ! $gallery_id ) {
+			// now add the gallery to the database
+			$gallery_id = nggdb::add_gallery( $galleryname, $galleryfolder, '', 0, 0, $user->ID );
+			if ( ! $gallery_id ) {
+				nggGallery::show_error( __( 'Database error. Could not add gallery!', 'nggallery' ) );
 				return;
 			}
-			$created_msg = __( 'Gallery', 'nggallery' ) . ' <strong>' . esc_html( $galleryname ) . '</strong> ' . __('successfully created!','nggallery') . '<br />';
+			$created_msg = __( 'Gallery', 'nggallery' ) . ' <strong>' . esc_html( $galleryname ) . '</strong> ' . __( 'successfully created!', 'nggallery' ) . '<br />';
 		} else {
 			//if the gallery path has changed, update the database
-			if ( !($old_galleryfolder == $galleryfolder )) {
-				$wpdb->query( $wpdb->prepare ("UPDATE $wpdb->nggallery SET path= '%s' WHERE gid = %d", $galleryfolder, $gallery_id ) );
+			if ( ! ( $old_galleryfolder == $galleryfolder ) ) {
+				$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->nggallery SET path= '%s' WHERE gid = %d", $galleryfolder, $gallery_id ) );
 			}
 		}
-		
+
 		// Look for existing image list and sanitize file names before scanning for new images
-		$db_images = $nggdb->get_gallery($gallery_id);
+		$db_images = $nggdb->get_gallery( $gallery_id );
 		$updated = array();
 
-		foreach( $db_images as $image ){
+		foreach ( $db_images as $image ) {
 
 			//save old values
 			$old_name = $image->filename;
 			$old_path = $gallerypath . '/' . $old_name;
-			
+
 			//get new name
 			$filepart = nggGallery::fileinfo( $old_name );
 
 			//only rename if necessary
-			if ( !($old_name == $filepart['basename']) ) {
-			
+			if ( ! ( $old_name == $filepart['basename'] ) ) {
+
 				//check if the sanitized name already exists
 				$increment = ''; //start with no suffix
 
-				while(file_exists($gallerypath . '/' . $filepart['filename'] . $increment . '.' . $filepart['extension'])) {
+				while ( file_exists( $gallerypath . '/' . $filepart['filename'] . $increment . '.' . $filepart['extension'] ) ) {
 					$increment++;
 				}
-				
+
 				//define new values
 				$name = $filepart['filename'] . $increment . '.' . $filepart['extension'];
 				$new_path = $gallerypath . "/" . $name;
 
 				//rename the file and update alttext
-				rename($old_path, $new_path);
+				rename( $old_path, $new_path );
 				$alttext = sanitize_file_name( $image->alttext );
-				
+
 				// update the database
-				nggdb::update_image($image->pid, false, $name, false, $alttext);
+				nggdb::update_image( $image->pid, false, $name, false, $alttext );
 
 				$updated[] = $image->pid;
 			}
 		}
 
 		// read list of images
-		$new_imageslist = nggAdmin::scandir($gallerypath);
-		$old_imageslist = $wpdb->get_col("SELECT filename FROM $wpdb->nggpictures WHERE galleryid = '$gallery_id' ");
+		$new_imageslist = nggAdmin::scandir( $gallerypath );
+		$old_imageslist = $wpdb->get_col( "SELECT filename FROM $wpdb->nggpictures WHERE galleryid = '$gallery_id' " );
 
 		// if no images are there, create empty array
-		if ($old_imageslist == NULL) 
+		if ( $old_imageslist == NULL )
 			$old_imageslist = array();
-			
+
 		// check difference
-		$new_images = array_diff($new_imageslist, $old_imageslist);
-		
+		$new_images = array_diff( $new_imageslist, $old_imageslist );
+
 		// all images must be valid files
-		foreach($new_images as $key => $picture) {
+		foreach ( $new_images as $key => $picture ) {
 
 			//rename images with the cleaned filename
 			$old_path = $gallerypath . '/' . $picture;
@@ -274,43 +281,43 @@ class nggAdmin{
 			$picture = $filepart['basename'];
 			$new_path = $gallerypath . "/" . $picture;
 
-			rename($old_path, $new_path); 
+			rename( $old_path, $new_path );
 
-            // filter function to rename/change/modify image before
-			$picture = apply_filters('ngg_pre_add_new_image', $picture, $gallery_id);
-            $new_images[$key] = $picture;
-            
-			if (!@getimagesize($gallerypath . '/' . $picture) ) {
-				unset($new_images[$key]);
-				@unlink($gallerypath . '/' . $picture);				
+			// filter function to rename/change/modify image before
+			$picture = apply_filters( 'ngg_pre_add_new_image', $picture, $gallery_id );
+			$new_images[ $key ] = $picture;
+
+			if ( ! @getimagesize( $gallerypath . '/' . $picture ) ) {
+				unset( $new_images[ $key ] );
+				@unlink( $gallerypath . '/' . $picture );
 			}
 		}
-				
+
 		// add images to database		
-		$image_ids = nggAdmin::add_Images($gallery_id, $new_images);
-		
+		$image_ids = nggAdmin::add_Images( $gallery_id, $new_images );
+
 		//add the preview image if needed
-		nggAdmin::set_gallery_preview ( $gallery_id );
+		nggAdmin::set_gallery_preview( $gallery_id );
 
 		// now create thumbnails
-		nggAdmin::do_ajax_operation( 'create_thumbnail' , array_merge($image_ids, $updated), __('Create new thumbnails','nggallery') );
+		nggAdmin::do_ajax_operation( 'create_thumbnail', array_merge( $image_ids, $updated ), __( 'Create new thumbnails', 'nggallery' ) );
 
 		//TODO:Message will not shown, because AJAX routine require more time, message should be passed to AJAX
-		$message  = $created_msg;
-		if ( count($updated) > 0)
-			$message .= $c . __(' picture(s) successfully renamed','nggallery') . '<br />';
-		if ( count($image_ids) > 0 )
-			$message .= count($image_ids) .__(' picture(s) successfully added','nggallery') . '<br />';
-		if ($created_msg) {
-		$message .= ' [<a href="' . admin_url() . 'admin.php?page=nggallery-manage&mode=image&gid=' . $gallery_id . '" >';
-		$message .=  __('Edit gallery','nggallery');
-		$message .= '</a>]';
+		$message = $created_msg;
+		if ( count( $updated ) > 0 )
+			$message .= $c . __( ' picture(s) successfully renamed', 'nggallery' ) . '<br />';
+		if ( count( $image_ids ) > 0 )
+			$message .= count( $image_ids ) . __( ' picture(s) successfully added', 'nggallery' ) . '<br />';
+		if ( $created_msg ) {
+			$message .= ' [<a href="' . admin_url() . 'admin.php?page=nggallery-manage&mode=image&gid=' . $gallery_id . '" >';
+			$message .= __( 'Edit gallery', 'nggallery' );
+			$message .= '</a>]';
 		}
-		if (!$message)
-		$message  = __('No images were added.','nggallery');
+		if ( ! $message )
+			$message = __( 'No images were added.', 'nggallery' );
 
-		nggGallery::show_message($message); 
-		
+		nggGallery::show_message( $message );
+
 		return;
 
 	}
@@ -324,21 +331,21 @@ class nggAdmin{
 	 * @return array $files list of image filenames 
 	 */
 	static function scandir( $dirname = '.' ) {
-		$ext = apply_filters('ngg_allowed_file_types', array('jpeg', 'jpg', 'png', 'gif') );
+		$ext = apply_filters( 'ngg_allowed_file_types', array( 'jpeg', 'jpg', 'png', 'gif' ) );
 
-		$files = array(); 
-		if( $handle = opendir( $dirname ) ) { 
-			while( false !== ( $file = readdir( $handle ) ) ) {
+		$files = array();
+		if ( $handle = opendir( $dirname ) ) {
+			while ( false !== ( $file = readdir( $handle ) ) ) {
 				$info = pathinfo( $file );
 				// just look for images with the correct extension
-                if ( isset($info['extension']) )
-				    if ( in_array( strtolower($info['extension']), $ext) )
-					   $files[] = utf8_encode( $file );
-			}		
-			closedir( $handle ); 
-		} 
+				if ( isset ( $info['extension'] ) )
+					if ( in_array( strtolower( $info['extension'] ), $ext ) )
+						$files[] = mb_convert_encoding( $file, 'UTF-8' );
+			}
+			closedir( $handle );
+		}
 		sort( $files );
-		return ( $files ); 
+		return ( $files );
 	}
 
 	/**
@@ -372,7 +379,7 @@ class nggAdmin{
 
 
 		if ( ! class_exists( 'ngg_Thumbnail' ) ) {
-			require_once( nggGallery::graphic_library() );
+			require_once ( nggGallery::graphic_library() );
 		}
 
 		if ( is_numeric( $image ) ) {
@@ -426,8 +433,8 @@ class nggAdmin{
 			nggAdmin::chmod( $image->thumbPath );
 
 			//read the new sizes
-			$new_size       = @getimagesize( $image->thumbPath );
-			$size['width']  = $new_size[0];
+			$new_size = @getimagesize( $image->thumbPath );
+			$size['width'] = $new_size[0];
 			$size['height'] = $new_size[1];
 
 			// add them to the database
@@ -436,14 +443,14 @@ class nggAdmin{
 
 		$thumb->destruct();
 
-		if ( ! empty( $thumb->errmsg ) ) {
+		if ( ! empty ( $thumb->errmsg ) ) {
 			return ' <strong>' . esc_html( $image->filename ) . ' (Error : ' . $thumb->errmsg . ')</strong>';
 		}
 
 		// success
 		return '1';
 	}
-	
+
 	/**
 	 * nggAdmin::resize_image() - create a new image, based on the height /width
 	 * 
@@ -453,53 +460,53 @@ class nggAdmin{
 	 * @param integer $height optional
 	 * @return string result code
 	 */
-	static function resize_image($image, $width = 0, $height = 0) {
-		
-		global $ngg;
-		
-		if(! class_exists('ngg_Thumbnail'))
-			require_once( nggGallery::graphic_library() );
+	static function resize_image( $image, $width = 0, $height = 0 ) {
 
-		if ( is_numeric($image) )
+		global $ngg;
+
+		if ( ! class_exists( 'ngg_Thumbnail' ) )
+			require_once ( nggGallery::graphic_library() );
+
+		if ( is_numeric( $image ) )
 			$image = nggdb::find_image( $image );
-		
-		if ( !is_object($image) ) 
-			return __('Object didn\'t contain correct data','nggallery');	
-		
+
+		if ( ! is_object( $image ) )
+			return __( 'Object didn\'t contain correct data', 'nggallery' );
+
 		// before we start we import the meta data to database (required for uploads before V1.4.0)
 		nggAdmin::maybe_import_meta( $image->pid );
-		
+
 		// if no parameter is set, take global settings
-		$width  = ($width  == 0) ? $ngg->options['imgWidth']  : $width;
-		$height = ($height == 0) ? $ngg->options['imgHeight'] : $height;
-		
-		if (!is_writable($image->imagePath))
-			return ' <strong>' . esc_html( $image->filename ) . __(' is not writeable','nggallery') . '</strong>';
-		
-		$file = new ngg_Thumbnail($image->imagePath, TRUE);
+		$width = ( $width == 0 ) ? $ngg->options['imgWidth'] : $width;
+		$height = ( $height == 0 ) ? $ngg->options['imgHeight'] : $height;
+
+		if ( ! is_writable( $image->imagePath ) )
+			return ' <strong>' . esc_html( $image->filename ) . __( ' is not writeable', 'nggallery' ) . '</strong>';
+
+		$file = new ngg_Thumbnail( $image->imagePath, TRUE );
 
 		// skip if file is not there
-		if (!$file->error) {
-			
+		if ( ! $file->error ) {
+
 			// If required save a backup copy of the file
-			if ( ($ngg->options['imgBackup'] == 1) && (!file_exists($image->imagePath . '_backup')) )
-				@copy ($image->imagePath, $image->imagePath . '_backup');
-			
-			$file->resize($width, $height);
-			$file->save($image->imagePath, $ngg->options['imgQuality']);
+			if ( ( $ngg->options['imgBackup'] == 1 ) && ( ! file_exists( $image->imagePath . '_backup' ) ) )
+				@copy( $image->imagePath, $image->imagePath . '_backup' );
+
+			$file->resize( $width, $height );
+			$file->save( $image->imagePath, $ngg->options['imgQuality'] );
 			// read the new sizes
-			$size = @getimagesize ( $image->imagePath );
+			$size = @getimagesize( $image->imagePath );
 			// add them to the database
-			nggdb::update_image_meta($image->pid, array( 'width' => $size[0], 'height' => $size[1] ) );
+			nggdb::update_image_meta( $image->pid, array( 'width' => $size[0], 'height' => $size[1] ) );
 			$file->destruct();
 		} else {
-            $file->destruct();
+			$file->destruct();
 			return ' <strong>' . esc_html( $image->filename ) . ' (Error : ' . $file->errmsg . ')</strong>';
 		}
 
 		return '1';
 	}
-	
+
 	/**
 	 * Rotated/Flip an image based on the orientation flag or a definded angle
 	 * 
@@ -508,94 +515,94 @@ class nggAdmin{
 	 * @param string (optional)  $flip, could be either false | V (flip vertical) | H (flip horizontal)
 	 * @return string result code
 	 */
-	static function rotate_image($image, $dir = false, $flip = false) {
+	static function rotate_image( $image, $dir = false, $flip = false ) {
 
 		global $ngg;
 
-		if(! class_exists('ngg_Thumbnail'))
-			require_once( nggGallery::graphic_library() );
-		
-		if ( is_numeric($image) )
+		if ( ! class_exists( 'ngg_Thumbnail' ) )
+			require_once ( nggGallery::graphic_library() );
+
+		if ( is_numeric( $image ) )
 			$image = nggdb::find_image( $image );
-		
-		if ( !is_object($image) ) 
-			return __('Object didn\'t contain correct data','nggallery');		
-	
-		if (!is_writable($image->imagePath))
-			return ' <strong>' . esc_html( $image->filename ) . __(' is not writeable','nggallery') . '</strong>';
-		
+
+		if ( ! is_object( $image ) )
+			return __( 'Object didn\'t contain correct data', 'nggallery' );
+
+		if ( ! is_writable( $image->imagePath ) )
+			return ' <strong>' . esc_html( $image->filename ) . __( ' is not writeable', 'nggallery' ) . '</strong>';
+
 		// if you didn't define a rotation, we look for the orientation flag in EXIF
 		if ( $dir === false ) {
 			$meta = new nggMeta( $image->pid );
-			$exif = $meta->get_EXIF();
-	
-			if (isset($exif['Orientation'])) {
-				
-				switch ($exif['Orientation']) {
-					case 5 : // vertical flip + 90 rotate right
+			$exif = is_array( $meta->get_EXIF() ) ? $meta->get_EXIF() : [];
+
+			if ( isset ( $exif['Orientation'] ) ) {
+
+				switch ( $exif['Orientation'] ) {
+					case 5: // vertical flip + 90 rotate right
 						$flip = 'V';
-					case 6 : // 90 rotate right
+					case 6: // 90 rotate right
 						$dir = 'CW';
 						break;
-					case 7 : // horizontal flip + 90 rotate right
+					case 7: // horizontal flip + 90 rotate right
 						$flip = 'H';
-					case 8 : // 90 rotate left
+					case 8: // 90 rotate left
 						$dir = 'CCW';
 						break;
-					case 4 : // vertical flip
+					case 4: // vertical flip
 						$flip = 'V';
 						break;
-					case 3 : // 180 rotate left
+					case 3: // 180 rotate left
 						$dir = 180;
 						break;
-					case 2 : // horizontal flip
+					case 2: // horizontal flip
 						$flip = 'H';
-						break;						
-					case 1 : // no action in the case it doesn't need a rotation
+						break;
+					case 1: // no action in the case it doesn't need a rotation
 					default:
 						return '0';
-						break; 
+						break;
 				}
 			} else
-                return '0';
+				return '0';
 		}
 		$file = new ngg_Thumbnail( $image->imagePath, TRUE );
-		
+
 		// skip if file is not there
-		if (!$file->error) {
+		if ( ! $file->error ) {
 
 			// If required save a backup copy of the file
-			if ( ($ngg->options['imgBackup'] == 1) && (!file_exists($image->imagePath . '_backup')) )
-				@copy ($image->imagePath, $image->imagePath . '_backup');
+			if ( ( $ngg->options['imgBackup'] == 1 ) && ( ! file_exists( $image->imagePath . '_backup' ) ) )
+				@copy( $image->imagePath, $image->imagePath . '_backup' );
 
 			// before we start we import the meta data to database (required for uploads before V1.4.X)
 			nggAdmin::maybe_import_meta( $image->pid );
 
 			if ( $dir !== 0 )
 				$file->rotateImage( $dir );
-			if ( $dir === 180)
+			if ( $dir === 180 )
 				$file->rotateImage( 'CCW' ); // very special case, we rotate the image two times
-			if ( $flip == 'H')
-				$file->flipImage(true, false);
-			if ( $flip == 'V')
-				$file->flipImage(false, true);
-					
-			$file->save($image->imagePath, $ngg->options['imgQuality']);
-			
+			if ( $flip == 'H' )
+				$file->flipImage( true, false );
+			if ( $flip == 'V' )
+				$file->flipImage( false, true );
+
+			$file->save( $image->imagePath, $ngg->options['imgQuality'] );
+
 			// read the new sizes
-			$size = @getimagesize ( $image->imagePath );
+			$size = @getimagesize( $image->imagePath );
 			// add them to the database
-			nggdb::update_image_meta($image->pid, array( 'width' => $size[0], 'height' => $size[1] ) );
-			
+			nggdb::update_image_meta( $image->pid, array( 'width' => $size[0], 'height' => $size[1] ) );
+
 		}
-		
+
 		$file->destruct();
 
-		if ( !empty($file->errmsg) )
-			return ' <strong>' . esc_html( $image->filename ) . ' (Error : '.$file->errmsg .')</strong>';		
+		if ( ! empty ( $file->errmsg ) )
+			return ' <strong>' . esc_html( $image->filename ) . ' (Error : ' . $file->errmsg . ')</strong>';
 
 		return '1';
-		
+
 	}
 
 	/**
@@ -605,50 +612,50 @@ class nggAdmin{
 	 * @param object | int $image contain all information about the image or the id
 	 * @return string result code
 	 */
-	static function set_watermark($image) {
-		
+	static function set_watermark( $image ) {
+
 		global $ngg;
 
-		if(! class_exists('ngg_Thumbnail'))
-			require_once( nggGallery::graphic_library() );
-		
-		if ( is_numeric($image) )
+		if ( ! class_exists( 'ngg_Thumbnail' ) )
+			require_once ( nggGallery::graphic_library() );
+
+		if ( is_numeric( $image ) )
 			$image = nggdb::find_image( $image );
-		
-		if ( !is_object($image) ) 
-			return __('Object didn\'t contain correct data','nggallery');		
+
+		if ( ! is_object( $image ) )
+			return __( 'Object didn\'t contain correct data', 'nggallery' );
 
 		// before we start we import the meta data to database (required for uploads before V1.4.0)
-		nggAdmin::maybe_import_meta( $image->pid );	
+		nggAdmin::maybe_import_meta( $image->pid );
 
-		if (!is_writable($image->imagePath))
-			return ' <strong>' . esc_html( $image->filename ) . __(' is not writeable','nggallery') . '</strong>';
-		
+		if ( ! is_writable( $image->imagePath ) )
+			return ' <strong>' . esc_html( $image->filename ) . __( ' is not writeable', 'nggallery' ) . '</strong>';
+
 		$file = new ngg_Thumbnail( $image->imagePath, TRUE );
 
 		// skip if file is not there
-		if (!$file->error) {
-			
+		if ( ! $file->error ) {
+
 			// If required save a backup copy of the file
-			if ( ($ngg->options['imgBackup'] == 1) && (!file_exists($image->imagePath . '_backup')) )
-				@copy ($image->imagePath, $image->imagePath . '_backup');
-			
-			if ($ngg->options['wmType'] == 'image') {
+			if ( ( $ngg->options['imgBackup'] == 1 ) && ( ! file_exists( $image->imagePath . '_backup' ) ) )
+				@copy( $image->imagePath, $image->imagePath . '_backup' );
+
+			if ( $ngg->options['wmType'] == 'image' ) {
 				$file->watermarkImgPath = $ngg->options['wmPath'];
-				$file->watermarkImage($ngg->options['wmPos'], $ngg->options['wmXpos'], $ngg->options['wmYpos']); 
+				$file->watermarkImage( $ngg->options['wmPos'], $ngg->options['wmXpos'], $ngg->options['wmYpos'] );
 			}
-			if ($ngg->options['wmType'] == 'text') {
+			if ( $ngg->options['wmType'] == 'text' ) {
 				$file->watermarkText = $ngg->options['wmText'];
-				$file->watermarkCreateText($ngg->options['wmFont'], $ngg->options['wmColor'], $ngg->options['wmSize'], $ngg->options['wmOpaque']);
-				$file->watermarkImage($ngg->options['wmPos'], $ngg->options['wmXpos'], $ngg->options['wmYpos']);  
+				$file->watermarkCreateText( $ngg->options['wmFont'], $ngg->options['wmColor'], $ngg->options['wmSize'], $ngg->options['wmOpaque'] );
+				$file->watermarkImage( $ngg->options['wmPos'], $ngg->options['wmXpos'], $ngg->options['wmYpos'] );
 			}
-			$file->save($image->imagePath, $ngg->options['imgQuality']);
+			$file->save( $image->imagePath, $ngg->options['imgQuality'] );
 		}
-		
+
 		$file->destruct();
 
-		if ( !empty($file->errmsg) )
-			return ' <strong>' . esc_html( $image->filename ) . ' (Error : '.$file->errmsg .')</strong>';		
+		if ( ! empty ( $file->errmsg ) )
+			return ' <strong>' . esc_html( $image->filename ) . ' (Error : ' . $file->errmsg . ')</strong>';
 
 		return '1';
 	}
@@ -661,39 +668,39 @@ class nggAdmin{
 	 * @param object | int $image contain all information about the image or the id
 	 * @return string result code
 	 */
-	
-	static function recover_image($image) {
+
+	static function recover_image( $image ) {
 
 		global $ngg;
-		
-		if ( is_numeric($image) )
+
+		if ( is_numeric( $image ) )
 			$image = nggdb::find_image( $image );
-		
-		if ( !is_object( $image ) ) 
-			return __('Object didn\'t contain correct data','nggallery');		
-			
-		if (!is_writable( $image->imagePath ))
-			return ' <strong>' . esc_html( $image->filename ) . __(' is not writeable','nggallery') . '</strong>';
-		
-		if (!file_exists( $image->imagePath . '_backup' )) {
-			return ' <strong>'.__('File do not exists','nggallery').'</strong>';
+
+		if ( ! is_object( $image ) )
+			return __( 'Object didn\'t contain correct data', 'nggallery' );
+
+		if ( ! is_writable( $image->imagePath ) )
+			return ' <strong>' . esc_html( $image->filename ) . __( ' is not writeable', 'nggallery' ) . '</strong>';
+
+		if ( ! file_exists( $image->imagePath . '_backup' ) ) {
+			return ' <strong>' . __( 'File do not exists', 'nggallery' ) . '</strong>';
 		}
 
-		if (!@copy( $image->imagePath . '_backup' , $image->imagePath) )
-			return ' <strong>'.__('Couldn\'t restore original image','nggallery').'</strong>';
-		
-		require_once(NGGALLERY_ABSPATH . '/lib/meta.php');
-		
+		if ( ! @copy( $image->imagePath . '_backup', $image->imagePath ) )
+			return ' <strong>' . __( 'Couldn\'t restore original image', 'nggallery' ) . '</strong>';
+
+		require_once ( NGGALLERY_ABSPATH . '/lib/meta.php' );
+
 		$meta_obj = new nggMeta( $image->pid );
-					
-        $common = $meta_obj->get_common_meta();
-        $common['saved']  = true; 
-		$result = nggdb::update_image_meta($image->pid, $common);			
-		
+
+		$common = $meta_obj->get_common_meta();
+		$common['saved'] = true;
+		$result = nggdb::update_image_meta( $image->pid, $common );
+
 		return '1';
-		
+
 	}
-		
+
 	/**
 	 * Add images to database
 	 * 
@@ -702,60 +709,60 @@ class nggAdmin{
 	 * @param array $imageslist
 	 * @return array $image_ids Id's which are sucessful added
 	 */
-	static function add_Images($galleryID, $imageslist) {
-		
+	static function add_Images( $galleryID, $imageslist ) {
+
 		global $wpdb, $ngg;
-		
+
 		$image_ids = array();
-		
-		if ( is_array($imageslist) ) {
-			foreach($imageslist as $picture) {
-				
-                // filter function to rename/change/modify image before
-                $picture = apply_filters('ngg_pre_add_new_image', $picture, $galleryID);
-                
+
+		if ( is_array( $imageslist ) ) {
+			foreach ( $imageslist as $picture ) {
+
+				// filter function to rename/change/modify image before
+				$picture = apply_filters( 'ngg_pre_add_new_image', $picture, $galleryID );
+
 				// strip off the extension of the filename
 				$path_parts = pathinfo( $picture );
-				$alttext = ( !isset($path_parts['filename']) ) ? substr($path_parts['basename'], 0,strpos($path_parts['basename'], '.')) : $path_parts['filename'];
+				$alttext = ( ! isset ( $path_parts['filename'] ) ) ? substr( $path_parts['basename'], 0, strpos( $path_parts['basename'], '.' ) ) : $path_parts['filename'];
 				// save it to the database
-                $pic_id = nggdb::add_image( $galleryID, $picture, '', $alttext ); 
+				$pic_id = nggdb::add_image( $galleryID, $picture, '', $alttext );
 
-				if ( !empty($pic_id) ) 
+				if ( ! empty ( $pic_id ) )
 					$image_ids[] = $pic_id;
 
 				// add the metadata
 				nggAdmin::import_MetaData( $pic_id );
-				
+
 				// auto rotate
-				nggAdmin::rotate_image( $pic_id );		
+				nggAdmin::rotate_image( $pic_id );
 
 				// Autoresize image if required
-                if ($ngg->options['imgAutoResize']) {
-                	$imagetmp = nggdb::find_image( $pic_id );
-                	$sizetmp = @getimagesize ( $imagetmp->imagePath );
-                	$widthtmp  = $ngg->options['imgWidth'];
-                	$heighttmp = $ngg->options['imgHeight'];
-                	if (($sizetmp[0] > $widthtmp && $widthtmp) || ($sizetmp[1] > $heighttmp && $heighttmp)) {
-                			nggAdmin::resize_image( $pic_id );
-                	}
-                }
-				
+				if ( $ngg->options['imgAutoResize'] ) {
+					$imagetmp = nggdb::find_image( $pic_id );
+					$sizetmp = @getimagesize( $imagetmp->imagePath );
+					$widthtmp = $ngg->options['imgWidth'];
+					$heighttmp = $ngg->options['imgHeight'];
+					if ( ( $sizetmp[0] > $widthtmp && $widthtmp ) || ( $sizetmp[1] > $heighttmp && $heighttmp ) ) {
+						nggAdmin::resize_image( $pic_id );
+					}
+				}
+
 				// action hook for post process after the image is added to the database
-				$image = array( 'id' => $pic_id, 'filename' => $picture, 'galleryID' => $galleryID);
-				do_action('ngg_added_new_image', $image);
-									
-			} 
+				$image = array( 'id' => $pic_id, 'filename' => $picture, 'galleryID' => $galleryID );
+				do_action( 'ngg_added_new_image', $image );
+
+			}
 		} // is_array
-        
-        // delete dirsize after adding new images
-        delete_transient( 'dirsize_cache' );
-        
-		do_action('ngg_after_new_images_added', $galleryID, $image_ids );
-		
+
+		// delete dirsize after adding new images
+		delete_transient( 'dirsize_cache' );
+
+		do_action( 'ngg_after_new_images_added', $galleryID, $image_ids );
+
 		return $image_ids;
-		
+
 	}
-	
+
 	/**
 	 * Import some meta data into the database (if avialable)
 	 * 
@@ -763,59 +770,59 @@ class nggAdmin{
 	 * @param array|int $imagesIds
 	 * @return string result code
 	 */
-	static function import_MetaData($imagesIds) {
-			
+	static function import_MetaData( $imagesIds ) {
+
 		global $wpdb;
-		
-		require_once(NGGALLERY_ABSPATH . '/lib/image.php');
-		
-		if (!is_array($imagesIds))
-			$imagesIds = array($imagesIds);
-		
-		foreach($imagesIds as $imageID) {
-			
+
+		require_once ( NGGALLERY_ABSPATH . '/lib/image.php' );
+
+		if ( ! is_array( $imagesIds ) )
+			$imagesIds = array( $imagesIds );
+
+		foreach ( $imagesIds as $imageID ) {
+
 			$image = nggdb::find_image( $imageID );
-			if (!$image->error) {
+			if ( ! $image->error ) {
 
 				$meta = nggAdmin::get_MetaData( $image->pid );
-				
+
 				// get the title
-				$alttext = empty( $meta['title'] ) ? $image->alttext : $meta['title'];
-				
+				$alttext = empty ( $meta['title'] ) ? $image->alttext : $meta['title'];
+
 				// get the caption / description field
-				$description = empty( $meta['caption'] ) ? $image->description : $meta['caption'];
-					
+				$description = empty ( $meta['caption'] ) ? $image->description : $meta['caption'];
+
 				// get the file date/time from exif
 				$timestamp = $meta['timestamp'];
 				// first update database
-				$result = $wpdb->query( 
-					$wpdb->prepare("UPDATE $wpdb->nggpictures SET 
+				$result = $wpdb->query(
+					$wpdb->prepare( "UPDATE $wpdb->nggpictures SET 
 						alttext = %s, 
 						description = %s, 
 						imagedate = %s
-					WHERE pid = %d", $alttext, $description, $timestamp, $image->pid) );
+					WHERE pid = %d", $alttext, $description, $timestamp, $image->pid ) );
 
-				if ($result === false)
-					return ' <strong>' . esc_html( $image->filename ) . ' ' . __('(Error : Couldn\'t not update data base)', 'nggallery') . '</strong>';		
-				
+				if ( $result === false )
+					return ' <strong>' . esc_html( $image->filename ) . ' ' . __( '(Error : Couldn\'t not update data base)', 'nggallery' ) . '</strong>';
+
 				//this flag will inform us that the import is already one time performed
-				$meta['common']['saved']  = true; 
-				$result = nggdb::update_image_meta($image->pid, $meta['common']);
-				
-				if ($result === false)
-					return ' <strong>' . esc_html( $image->filename ) . ' ' . __('(Error : Couldn\'t not update meta data)', 'nggallery') . '</strong>';		
+				$meta['common']['saved'] = true;
+				$result = nggdb::update_image_meta( $image->pid, $meta['common'] );
+
+				if ( $result === false )
+					return ' <strong>' . esc_html( $image->filename ) . ' ' . __( '(Error : Couldn\'t not update meta data)', 'nggallery' ) . '</strong>';
 
 				// add the tags if we found some
-				if ($meta['keywords']) {
-					$taglist = explode(',', $meta['keywords']);
-					wp_set_object_terms($image->pid, $taglist, 'ngg_tag');
+				if ( $meta['keywords'] ) {
+					$taglist = explode( ',', $meta['keywords'] );
+					wp_set_object_terms( $image->pid, $taglist, 'ngg_tag' );
 				}
 
 			} else
-				return ' <strong>' . esc_html( $image->filename ) . ' ' . __('(Error : Couldn\'t not find image)', 'nggallery') . '</strong>';// error check
+				return ' <strong>' . esc_html( $image->filename ) . ' ' . __( '(Error : Couldn\'t not find image)', 'nggallery' ) . '</strong>';// error check
 		}
-		
-		return '1';		
+
+		return '1';
 	}
 
 	/**
@@ -826,25 +833,25 @@ class nggAdmin{
 	 * @param int $id image ID
 	 * @return array metadata
 	 */
-	static function get_MetaData($id) {
-		
-		require_once(NGGALLERY_ABSPATH . '/lib/meta.php');
-		
+	static function get_MetaData( $id ) {
+
+		require_once ( NGGALLERY_ABSPATH . '/lib/meta.php' );
+
 		$meta = array();
 
 		$pdata = new nggMeta( $id );
-		
-		$meta['title'] = trim ( $pdata->get_META('title') );		
-		$meta['caption'] = trim ( $pdata->get_META('caption') );	
-		$meta['keywords'] = trim ( $pdata->get_META('keywords') );
+
+		$meta['title'] = trim( $pdata->get_META( 'title' ) );
+		$meta['caption'] = trim( $pdata->get_META( 'caption' ) );
+		$meta['keywords'] = trim( $pdata->get_META( 'keywords' ) );
 		$meta['timestamp'] = $pdata->get_date_time();
 		// this contain other useful meta information
 		$meta['common'] = $pdata->get_common_meta();
-        // hook for addon plugin to add more meta fields
-        $meta = apply_filters('ngg_get_image_metadata', $meta, $pdata);
-		
+		// hook for addon plugin to add more meta fields
+		$meta = apply_filters( 'ngg_get_image_metadata', $meta, $pdata );
+
 		return $meta;
-		
+
 	}
 
 	/**
@@ -853,23 +860,23 @@ class nggAdmin{
 	 * 
 	 * @since V1.4.0
 	 * @param int $id
-	 * @return result
+	 * @return bool
 	 */
 	static function maybe_import_meta( $id ) {
-				
-		require_once(NGGALLERY_ABSPATH . '/lib/meta.php');
-				
+
+		require_once ( NGGALLERY_ABSPATH . '/lib/meta.php' );
+
 		$meta_obj = new nggMeta( $id );
-        
+
 		if ( $meta_obj->image->meta_data['saved'] != true ) {
-            $common = $meta_obj->get_common_meta();
-            //this flag will inform us that the import is already one time performed
-            $common['saved']  = true; 
-			$result = nggdb::update_image_meta($id, $common);
+			$common = $meta_obj->get_common_meta();
+			//this flag will inform us that the import is already one time performed
+			$common['saved'] = true;
+			$result = nggdb::update_image_meta( $id, $common );
 		} else
 			return false;
-		
-		return $result;		
+
+		return $result;
 
 	}
 
@@ -882,24 +889,24 @@ class nggAdmin{
 	 * @param string $file
 	 * @return bool
 	 */
-	static function unzip($dir, $file) {
-		
-		if(! class_exists('PclZip'))
-			require_once(ABSPATH . 'wp-admin/includes/class-pclzip.php');
-				
-		$archive = new PclZip($file);
+	static function unzip( $dir, $file ) {
+
+		if ( ! class_exists( 'PclZip' ) )
+			require_once ( ABSPATH . 'wp-admin/includes/class-pclzip.php' );
+
+		$archive = new PclZip( $file );
 
 		// extract all files in one folder
-		if ($archive->extract(PCLZIP_OPT_PATH, $dir, PCLZIP_OPT_REMOVE_ALL_PATH, 
-                                PCLZIP_CB_PRE_EXTRACT, 'ngg_getOnlyImages',
-                                PCLZIP_CB_POST_EXTRACT, 'ngg_checkExtract') == 0) {
-			nggGallery::show_error( 'Error : ' . $archive->errorInfo(true) );
+		if ( $archive->extract( PCLZIP_OPT_PATH, $dir, PCLZIP_OPT_REMOVE_ALL_PATH,
+			PCLZIP_CB_PRE_EXTRACT, 'ngg_getOnlyImages',
+			PCLZIP_CB_POST_EXTRACT, 'ngg_checkExtract' ) == 0 ) {
+			nggGallery::show_error( 'Error : ' . $archive->errorInfo( true ) );
 			return false;
 		}
 
 		return true;
 	}
- 
+
 	/**
 	 * nggAdmin::getOnlyImages()
 	 * 
@@ -908,29 +915,29 @@ class nggAdmin{
 	 * @param mixed $p_header
 	 * @return bool
 	 */
-	static function getOnlyImages($p_event, &$p_header)	{
-        // avoid null byte hack (THX to Dominic Szablewski)
-        if ( strpos($p_header['filename'], chr(0) ) !== false ) 
-            $p_header['filename'] = substr ( $p_header['filename'], 0, strpos($p_header['filename'], chr(0) ));        
-        // check for extension
-		$info = pathinfo($p_header['filename']);
+	static function getOnlyImages( $p_event, &$p_header ) {
+		// avoid null byte hack (THX to Dominic Szablewski)
+		if ( strpos( $p_header['filename'], chr( 0 ) ) !== false )
+			$p_header['filename'] = substr( $p_header['filename'], 0, strpos( $p_header['filename'], chr( 0 ) ) );
 		// check for extension
-		$ext = apply_filters('ngg_allowed_file_types', array('jpeg', 'jpg', 'png', 'gif') ); 
-		if ( in_array( strtolower($info['extension']), $ext) ) {
+		$info = pathinfo( $p_header['filename'] );
+		// check for extension
+		$ext = apply_filters( 'ngg_allowed_file_types', array( 'jpeg', 'jpg', 'png', 'gif' ) );
+		if ( in_array( strtolower( $info['extension'] ), $ext ) ) {
 			// For MAC skip the ".image" files
-			if ($info['basename'][0] ==  '.' )
+			if ( $info['basename'][0] == '.' )
 				return 0;
 			else {
-                // sanitize the file name before we do further processing
-                $info['basename'] = sanitize_file_name( $info['basename'] );
-                $p_header['filename'] = $info['dirname'] . '/' . $info['basename'];
-                return 1;
+				// sanitize the file name before we do further processing
+				$info['basename'] = sanitize_file_name( $info['basename'] );
+				$p_header['filename'] = $info['dirname'] . '/' . $info['basename'];
+				return 1;
 			}
-				
+
 		}
 		// ----- all other files are skipped
 		else {
-		  return 0;
+			return 0;
 		}
 	}
 
@@ -941,103 +948,103 @@ class nggAdmin{
 	 * @param int (optional) $galleryID
 	 * @return bool $result
 	 */
-	static function import_zipfile($galleryID) {
+	static function import_zipfile( $galleryID ) {
 
 		global $ngg, $wpdb;
-		
-		if (nggWPMU::check_quota())
+
+		if ( nggWPMU::check_quota() )
 			return false;
-		
-		$defaultpath = $ngg->options['gallerypath'];		
-		$zipurl = isset($_POST['zipurl'])?$_POST['zipurl']:"";
-		
+
+		$defaultpath = $ngg->options['gallerypath'];
+		$zipurl = isset ( $_POST['zipurl'] ) ? $_POST['zipurl'] : "";
+
 		// if someone entered a URL try to upload it
-		if (!empty($zipurl) && (function_exists('curl_init')) ) {
-			
-			if (!(preg_match('/^http(s)?:\/\//i', $zipurl) )) {
-				nggGallery::show_error( __('No valid URL path ','nggallery') );
-				return false; 
+		if ( ! empty ( $zipurl ) && ( function_exists( 'curl_init' ) ) ) {
+
+			if ( ! ( preg_match( '/^http(s)?:\/\//i', $zipurl ) ) ) {
+				nggGallery::show_error( __( 'No valid URL path ', 'nggallery' ) );
+				return false;
 			}
-			
-			$temp_zipfile = tempnam('/tmp', 'zipimport_');
-			$filename = basename($zipurl);
-			
+
+			$temp_zipfile = tempnam( '/tmp', 'zipimport_' );
+			$filename = basename( $zipurl );
+
 			//Grab the zip via cURL
-			$save = fopen ( $temp_zipfile, "w" );
-			$ch = curl_init ();
-			curl_setopt ( $ch, CURLOPT_FILE, $save );
-			curl_setopt ( $ch, CURLOPT_HEADER, 0 );
-			curl_setopt ( $ch, CURLOPT_BINARYTRANSFER, 1 );
-			curl_setopt ( $ch, CURLOPT_URL, $zipurl );
-			$success = curl_exec ( $ch );
-			if (!$success)
-				nggGallery::show_error( __('Import via cURL failed.','nggallery') . ' Error code ' . curl_errno( $ch ) . ' : ' . curl_error( $ch ) );
-			curl_close ( $ch );
-			fclose($save);
-			
-			if (!$success)
-				return false; 
-			
+			$save = fopen( $temp_zipfile, "w" );
+			$ch = curl_init();
+			curl_setopt( $ch, CURLOPT_FILE, $save );
+			curl_setopt( $ch, CURLOPT_HEADER, 0 );
+			curl_setopt( $ch, CURLOPT_BINARYTRANSFER, 1 );
+			curl_setopt( $ch, CURLOPT_URL, $zipurl );
+			$success = curl_exec( $ch );
+			if ( ! $success )
+				nggGallery::show_error( __( 'Import via cURL failed.', 'nggallery' ) . ' Error code ' . curl_errno( $ch ) . ' : ' . curl_error( $ch ) );
+			curl_close( $ch );
+			fclose( $save );
+
+			if ( ! $success )
+				return false;
+
 		} else {
-			
+
 			$temp_zipfile = $_FILES['zipfile']['tmp_name'];
-			$filename = $_FILES['zipfile']['name']; 
-						
+			$filename = $_FILES['zipfile']['name'];
+
 			// Chrome return a empty content-type : http://code.google.com/p/chromium/issues/detail?id=6800
-			if ( !preg_match('/chrome/i', $_SERVER['HTTP_USER_AGENT']) ) {
+			if ( ! preg_match( '/chrome/i', $_SERVER['HTTP_USER_AGENT'] ) ) {
 				// check if file is a zip file
-				if ( !preg_match('/(zip|download|octet-stream)/i', $_FILES['zipfile']['type']) ) {
-					@unlink($temp_zipfile); // del temp file
-					nggGallery::show_error(__('Uploaded file was no or a faulty zip file ! The server recognized : ','nggallery') . $_FILES['zipfile']['type']);
-					return false; 
+				if ( ! preg_match( '/(zip|download|octet-stream)/i', $_FILES['zipfile']['type'] ) ) {
+					@unlink( $temp_zipfile ); // del temp file
+					nggGallery::show_error( __( 'Uploaded file was no or a faulty zip file ! The server recognized : ', 'nggallery' ) . $_FILES['zipfile']['type'] );
+					return false;
 				}
 			}
 		}
 
 		// should this unpacked into a new folder ?		
-		if ( $galleryID == '0' ) {	
+		if ( $galleryID == '0' ) {
 			//cleanup and take the zipfile name as folder name
-			$foldername = sanitize_title(strtok ($filename, '.'));
+			$foldername = sanitize_title( strtok( $filename, '.' ) );
 			$foldername = $defaultpath . $foldername;
 		} else {
 			// get foldername if selected
-			$foldername = $wpdb->get_var("SELECT path FROM $wpdb->nggallery WHERE gid = '$galleryID' ");
+			$foldername = $wpdb->get_var( "SELECT path FROM $wpdb->nggallery WHERE gid = '$galleryID' " );
 		}
-		
-		if ( empty($foldername) ) {
-			nggGallery::show_error( __('Could not get a valid foldername', 'nggallery') );
+
+		if ( empty ( $foldername ) ) {
+			nggGallery::show_error( __( 'Could not get a valid foldername', 'nggallery' ) );
 			return false;
 		}
-		
+
 		// set complete folder path
 		$newfolder = WINABSPATH . $foldername;
 
 		// check first if the traget folder exist
-		if (!is_dir($newfolder)) {
+		if ( ! is_dir( $newfolder ) ) {
 			// create new directories
-			if (!wp_mkdir_p ($newfolder)) {
-				$message = sprintf(__('Unable to create directory %s. Is its parent directory writable by the server?', 'nggallery'), esc_html( $newfolder ) );
-				nggGallery::show_error($message);
+			if ( ! wp_mkdir_p( $newfolder ) ) {
+				$message = sprintf( __( 'Unable to create directory %s. Is its parent directory writable by the server?', 'nggallery' ), esc_html( $newfolder ) );
+				nggGallery::show_error( $message );
 				return false;
 			}
-			if (!wp_mkdir_p ($newfolder . '/thumbs')) {
-				nggGallery::show_error(__('Unable to create directory ', 'nggallery') . esc_html( $newfolder ). '/thumbs !');
+			if ( ! wp_mkdir_p( $newfolder . '/thumbs' ) ) {
+				nggGallery::show_error( __( 'Unable to create directory ', 'nggallery' ) . esc_html( $newfolder ) . '/thumbs !' );
 				return false;
 			}
-		} 
-		
-		// unzip and del temp file		
-		$result = nggAdmin::unzip($newfolder, $temp_zipfile);
-		@unlink($temp_zipfile);		
+		}
 
-		if ($result) {
-			$message = __('Zip-File successfully unpacked','nggallery') . '<br />';		
+		// unzip and del temp file		
+		$result = nggAdmin::unzip( $newfolder, $temp_zipfile );
+		@unlink( $temp_zipfile );
+
+		if ( $result ) {
+			$message = __( 'Zip-File successfully unpacked', 'nggallery' ) . '<br />';
 
 			// parse now the folder and add to database
 			nggAdmin::import_gallery( $foldername );
-			nggGallery::show_message($message);
+			nggGallery::show_message( $message );
 		}
-		
+
 		return true;
 	}
 
@@ -1048,11 +1055,11 @@ class nggAdmin{
 	 * @return void
 	 */
 	static function upload_images() {
-	
+
 		global $nggdb;
-		
+
 		// WPMU action
-		if (nggWPMU::check_quota())
+		if ( nggWPMU::check_quota() )
 			return;
 
 		// Images must be an array
@@ -1061,95 +1068,95 @@ class nggAdmin{
 		// get selected gallery
 		$galleryID = (int) $_POST['galleryselect'];
 
-		if ($galleryID == 0) {
-			nggGallery::show_error(__('No gallery selected !','nggallery'));
-			return;	
+		if ( $galleryID == 0 ) {
+			nggGallery::show_error( __( 'No gallery selected !', 'nggallery' ) );
+			return;
 		}
 
 		// get the path to the gallery	
-		$gallery = $nggdb->find_gallery($galleryID);
+		$gallery = $nggdb->find_gallery( $galleryID );
 
-		if ( empty($gallery->path) ){
-			nggGallery::show_error(__('Failure in database, no gallery path set !','nggallery'));
+		if ( empty ( $gallery->path ) ) {
+			nggGallery::show_error( __( 'Failure in database, no gallery path set !', 'nggallery' ) );
 			return;
-		} 
-	
+		}
+
 		// read list of images
-		$dirlist = nggAdmin::scandir($gallery->abspath);
-		
+		$dirlist = nggAdmin::scandir( $gallery->abspath );
+
 		$imagefiles = $_FILES['imagefiles'];
-		
-		if (is_array($imagefiles)) {
-			foreach ($imagefiles['name'] as $key => $value) {
+
+		if ( is_array( $imagefiles ) ) {
+			foreach ( $imagefiles['name'] as $key => $value ) {
 
 				// look only for uploded files
-				if ($imagefiles['error'][$key] == 0) {
-					
-					$temp_file = $imagefiles['tmp_name'][$key];
-					
+				if ( $imagefiles['error'][ $key ] == 0 ) {
+
+					$temp_file = $imagefiles['tmp_name'][ $key ];
+
 					//clean filename and extract extension
-					$filepart = nggGallery::fileinfo( $imagefiles['name'][$key] );
+					$filepart = nggGallery::fileinfo( $imagefiles['name'][ $key ] );
 					$filename = $filepart['basename'];
-						
+
 					// check for allowed extension and if it's an image file
-					$ext = array('jpg', 'png', 'gif'); 
-					if ( !in_array($filepart['extension'], $ext) || !@getimagesize($temp_file) ){ 
-						nggGallery::show_error('<strong>' . esc_html( $imagefiles['name'][$key] ) . ' </strong>' . __('is no valid image file!','nggallery'));
+					$ext = array( 'jpg', 'png', 'gif' );
+					if ( ! in_array( $filepart['extension'], $ext ) || ! @getimagesize( $temp_file ) ) {
+						nggGallery::show_error( '<strong>' . esc_html( $imagefiles['name'][ $key ] ) . ' </strong>' . __( 'is no valid image file!', 'nggallery' ) );
 						continue;
 					}
-	
+
 					// check if this filename already exist in the folder
 					$i = 0;
 					while ( in_array( $filename, $dirlist ) ) {
-						$filename = $filepart['filename'] . '_' . $i++ . '.' .$filepart['extension'];
+						$filename = $filepart['filename'] . '_' . $i++ . '.' . $filepart['extension'];
 					}
-					
+
 					$dest_file = $gallery->abspath . '/' . $filename;
-					
+
 					//check for folder permission
-					if ( !is_writeable($gallery->abspath) ) {
-						$message = sprintf(__('Unable to write to directory %s. Is this directory writable by the server?', 'nggallery'), esc_html($gallery->abspath) );
-						nggGallery::show_error($message);
-						return;				
+					if ( ! is_writeable( $gallery->abspath ) ) {
+						$message = sprintf( __( 'Unable to write to directory %s. Is this directory writable by the server?', 'nggallery' ), esc_html( $gallery->abspath ) );
+						nggGallery::show_error( $message );
+						return;
 					}
-					
+
 					// save temp file to gallery
-					if ( !@move_uploaded_file($temp_file, $dest_file) ){
-						nggGallery::show_error(__('Error, the file could not be moved to : ','nggallery') . esc_html( $dest_file ) );
-						nggAdmin::check_safemode( $gallery->abspath );		
-						continue;
-					} 
-					if ( !nggAdmin::chmod($dest_file) ) {
-						nggGallery::show_error(__('Error, the file permissions could not be set','nggallery'));
+					if ( ! @move_uploaded_file( $temp_file, $dest_file ) ) {
+						nggGallery::show_error( __( 'Error, the file could not be moved to : ', 'nggallery' ) . esc_html( $dest_file ) );
+						nggAdmin::check_safemode( $gallery->abspath );
 						continue;
 					}
-					
+					if ( ! nggAdmin::chmod( $dest_file ) ) {
+						nggGallery::show_error( __( 'Error, the file permissions could not be set', 'nggallery' ) );
+						continue;
+					}
+
 					// add to imagelist & dirlist
 					$imageslist[] = $filename;
 					$dirlist[] = $filename;
-	
+
 				}
 			}
 		}
-		
-		if (count($imageslist) > 0) {
-			
+
+		if ( count( $imageslist ) > 0 ) {
+
 			// add images to database		
-			$image_ids = nggAdmin::add_Images($galleryID, $imageslist);
+			$image_ids = nggAdmin::add_Images( $galleryID, $imageslist );
 
 			//create thumbnails
-			nggAdmin::do_ajax_operation( 'create_thumbnail' , $image_ids, __('Create new thumbnails','nggallery') );
-			
+			nggAdmin::do_ajax_operation( 'create_thumbnail', $image_ids, __( 'Create new thumbnails', 'nggallery' ) );
+
 			//add the preview image if needed
-			nggAdmin::set_gallery_preview ( $galleryID );
-			
-			nggGallery::show_message( count($image_ids) . __(' Image(s) successfully added','nggallery'));
+			nggAdmin::set_gallery_preview( $galleryID );
+
+			nggGallery::show_message( count( $image_ids ) . __( ' Image(s) successfully added', 'nggallery' ) );
 		}
-		
+
 		return;
 
 	}
-	
+
 	/**
 	 * checks data validation when uploading a file. Return '0' if success, else string with error reason.
 	 * 
@@ -1157,20 +1164,20 @@ class nggAdmin{
 	 * @param integer $galleryID
 	 * @return string $result
 	 */
-	static function check_upload_image($galleryID = 0) {
+	static function check_upload_image( $galleryID = 0 ) {
 
 		global $nggdb;
-		
-		if ($galleryID == 0)
-			return __('No gallery selected !', 'nggallery');
+
+		if ( $galleryID == 0 )
+			return __( 'No gallery selected !', 'nggallery' );
 
 		// WPMU action
-		if (nggWPMU::check_quota())
+		if ( nggWPMU::check_quota() )
 			return '0';
 
 		// Check the upload
-		if (!isset($_FILES['Filedata']) || !is_uploaded_file($_FILES['Filedata']['tmp_name']) || $_FILES['Filedata']['error'] != 0) 
-			return __('Invalid upload. Error Code : ', 'nggallery') . $_FILES['Filedata']['error'];
+		if ( ! isset ( $_FILES['Filedata'] ) || ! is_uploaded_file( $_FILES['Filedata']['tmp_name'] ) || $_FILES['Filedata']['error'] != 0 )
+			return __( 'Invalid upload. Error Code : ', 'nggallery' ) . $_FILES['Filedata']['error'];
 
 		// get the filename and extension
 		$temp_file = $_FILES['Filedata']['tmp_name'];
@@ -1179,40 +1186,40 @@ class nggAdmin{
 		$filename = $filepart['basename'];
 
 		// check for allowed extension
-		$ext = apply_filters('ngg_allowed_file_types', array('jpeg', 'jpg', 'png', 'gif') ); 
-		if (!in_array( strtolower( $filepart['extension'] ), $ext))
-			return esc_html( $_FILES[$key]['name'] ) . __('is no valid image file!', 'nggallery');
+		$ext = apply_filters( 'ngg_allowed_file_types', array( 'jpeg', 'jpg', 'png', 'gif' ) );
+		if ( ! in_array( strtolower( $filepart['extension'] ), $ext ) )
+			return esc_html( $_FILES[ $key ]['name'] ) . __( 'is no valid image file!', 'nggallery' );
 
 		// get the path to the gallery
-        $gallery = $nggdb->find_gallery( (int) $galleryID );	
-		if ( empty($gallery->path) ){
-			@unlink($temp_file);		
-			return __('Failure in database, no gallery path set !', 'nggallery');
-		} 
+		$gallery = $nggdb->find_gallery( (int) $galleryID );
+		if ( empty ( $gallery->path ) ) {
+			@unlink( $temp_file );
+			return __( 'Failure in database, no gallery path set !', 'nggallery' );
+		}
 
 		// read list of images
 		$imageslist = nggAdmin::scandir( WINABSPATH . $gallery->path );
 
 		// check if this filename already exist
 		$i = 0;
-		while (in_array($filename, $imageslist)) {
+		while ( in_array( $filename, $imageslist ) ) {
 			$filename = $filepart['filename'] . '_' . $i++ . '.' . $filepart['extension'];
 		}
-		
+
 		$dest_file = WINABSPATH . $gallery->path . '/' . $filename;
-				
+
 		// save temp file to gallery
-		if ( !@move_uploaded_file($_FILES["Filedata"]['tmp_name'], $dest_file) ){
-			nggAdmin::check_safemode(WINABSPATH . $gallery->path);	
-			return __('Error, the file could not be moved to : ','nggallery'). esc_html( $dest_file );
-		} 
-		
-		if ( !nggAdmin::chmod($dest_file) )
-			return __('Error, the file permissions could not be set','nggallery');
-		
+		if ( ! @move_uploaded_file( $_FILES["Filedata"]['tmp_name'], $dest_file ) ) {
+			nggAdmin::check_safemode( WINABSPATH . $gallery->path );
+			return __( 'Error, the file could not be moved to : ', 'nggallery' ) . esc_html( $dest_file );
+		}
+
+		if ( ! nggAdmin::chmod( $dest_file ) )
+			return __( 'Error, the file permissions could not be set', 'nggallery' );
+
 		return '0';
-	}	
-	
+	}
+
 	/**
 	 * Set correct file permissions (taken from wp core)
 	 * 
@@ -1220,16 +1227,16 @@ class nggAdmin{
 	 * @param string $filename
 	 * @return bool $result
 	 */
-	static function chmod($filename = '') {
+	static function chmod( $filename = '' ) {
 
-		$stat = @ stat( dirname($filename) );
+		$stat = @stat( dirname( $filename ) );
 		$perms = $stat['mode'] & 0000666; // Remove execute bits for files
-		if ( @chmod($filename, $perms) )
+		if ( @chmod( $filename, $perms ) )
 			return true;
-			
+
 		return false;
 	}
-	
+
 	/**
 	 * Check UID in folder and Script
 	 * Read http://www.php.net/manual/en/features.safe-mode.php to understand safe_mode
@@ -1238,24 +1245,24 @@ class nggAdmin{
 	 * @param string $foldername
 	 * @return bool $result
 	 */
-	static function check_safemode($foldername) {
+	static function check_safemode( $foldername ) {
 
 		if ( SAFE_MODE ) {
-			
-			$script_uid = ( ini_get('safe_mode_gid') ) ? getmygid() : getmyuid();
-			$folder_uid = fileowner($foldername);
 
-			if ($script_uid != $folder_uid) {
-				$message  = sprintf(__('SAFE MODE Restriction in effect! You need to create the folder <strong>%s</strong> manually','nggallery'), esc_html( $foldername ) );
-				$message .= '<br />' . sprintf(__('When safe_mode is on, PHP checks to see if the owner (%s) of the current script matches the owner (%s) of the file to be operated on by a file function or its directory','nggallery'), $script_uid, $folder_uid );
-				nggGallery::show_error($message);
+			$script_uid = ( ini_get( 'safe_mode_gid' ) ) ? getmygid() : getmyuid();
+			$folder_uid = fileowner( $foldername );
+
+			if ( $script_uid != $folder_uid ) {
+				$message = sprintf( __( 'SAFE MODE Restriction in effect! You need to create the folder <strong>%s</strong> manually', 'nggallery' ), esc_html( $foldername ) );
+				$message .= '<br />' . sprintf( __( 'When safe_mode is on, PHP checks to see if the owner (%s) of the current script matches the owner (%s) of the file to be operated on by a file function or its directory', 'nggallery' ), $script_uid, $folder_uid );
+				nggGallery::show_error( $message );
 				return false;
 			}
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Capability check. Check is the ID fit's to the user_ID
 	 * 
@@ -1263,20 +1270,20 @@ class nggAdmin{
 	 * @param int $check_ID is the user_id
 	 * @return bool $result
 	 */
-	static function can_manage_this_gallery($check_ID) {
-		
+	static function can_manage_this_gallery( $check_ID ) {
+
 		global $user_ID, $wp_roles;
-		
-		if ( !current_user_can('NextGEN Manage others gallery') ) {
-			$user=wp_get_current_user(); // get the current user ID
-			
-			if ( $user->ID != $check_ID)
+
+		if ( ! current_user_can( 'NextGEN Manage others gallery' ) ) {
+			$user = wp_get_current_user(); // get the current user ID
+
+			if ( $user->ID != $check_ID )
 				return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Move images from one folder to another
 	 * 
@@ -1285,76 +1292,76 @@ class nggAdmin{
 	 * @param int $dest_gid destination gallery
 	 * @return void
 	 */
-	static function move_images($pic_ids, $dest_gid) {
+	static function move_images( $pic_ids, $dest_gid ) {
 
 		$errors = '';
 		$count = 0;
 
-		if ( !is_array($pic_ids) )
-			$pic_ids = array($pic_ids);
-		
+		if ( ! is_array( $pic_ids ) )
+			$pic_ids = array( $pic_ids );
+
 		// Get destination gallery
-		$destination  = nggdb::find_gallery( $dest_gid );
+		$destination = nggdb::find_gallery( $dest_gid );
 		$dest_abspath = WINABSPATH . $destination->path;
-		
+
 		if ( $destination == null ) {
-			nggGallery::show_error(__('The destination gallery does not exist','nggallery'));
+			nggGallery::show_error( __( 'The destination gallery does not exist', 'nggallery' ) );
 			return;
 		}
-		
-		// Check for folder permission
-		if ( !is_writeable( $dest_abspath ) ) {
-			$message = sprintf(__('Unable to write to directory %s. Is this directory writable by the server?', 'nggallery'), esc_html( $dest_abspath ) );
-			nggGallery::show_error($message);
-			return;				
-		}
-				
-		// Get pictures
-		$images = nggdb::find_images_in_list($pic_ids);
 
-		foreach ($images as $image) {		
-			
+		// Check for folder permission
+		if ( ! is_writeable( $dest_abspath ) ) {
+			$message = sprintf( __( 'Unable to write to directory %s. Is this directory writable by the server?', 'nggallery' ), esc_html( $dest_abspath ) );
+			nggGallery::show_error( $message );
+			return;
+		}
+
+		// Get pictures
+		$images = nggdb::find_images_in_list( $pic_ids );
+
+		foreach ( $images as $image ) {
+
 			$i = 0;
 			$tmp_prefix = '';
-			
+
 			$destination_file_name = $image->filename;
 			// check if the filename already exist, then we add a copy_ prefix
-			while (file_exists( $dest_abspath . '/' . $destination_file_name)) {
-				$tmp_prefix = 'copy_' . ($i++) . '_';
+			while ( file_exists( $dest_abspath . '/' . $destination_file_name ) ) {
+				$tmp_prefix = 'copy_' . ( $i++ ) . '_';
 				$destination_file_name = $tmp_prefix . $image->filename;
 			}
-			
+
 			$destination_path = $dest_abspath . '/' . $destination_file_name;
 			$destination_thumbnail = $dest_abspath . '/thumbs/thumbs_' . $destination_file_name;
 
 			// Move files
-			if ( !@rename($image->imagePath, $destination_path) ) {
-				$errors .= sprintf(__('Failed to move image %1$s to %2$s','nggallery'), 
+			if ( ! @rename( $image->imagePath, $destination_path ) ) {
+				$errors .= sprintf( __( 'Failed to move image %1$s to %2$s', 'nggallery' ),
 					'<strong>' . esc_html( $image->filename ) . '</strong>', esc_html( $destination_path ) ) . '<br />';
-				continue;				
+				continue;
 			}
-			
-            // Move backup file, if possible
-            @rename($image->imagePath . '_backup', $destination_path . '_backup');
+
+			// Move backup file, if possible
+			@rename( $image->imagePath . '_backup', $destination_path . '_backup' );
 			// Move the thumbnail, if possible
-			@rename($image->thumbPath, $destination_thumbnail);
-			
+			@rename( $image->thumbPath, $destination_thumbnail );
+
 			// Change the gallery id in the database , maybe the filename
-			if ( nggdb::update_image($image->pid, $dest_gid, $destination_file_name) )
+			if ( nggdb::update_image( $image->pid, $dest_gid, $destination_file_name ) )
 				$count++;
 
 		}
 
 		if ( $errors != '' )
-			nggGallery::show_error($errors);
+			nggGallery::show_error( $errors );
 
 		$link = '<a href="' . admin_url() . 'admin.php?page=nggallery-manage&mode=image&gid=' . $destination->gid . '" >' . esc_html( $destination->title ) . '</a>';
-		$messages  = sprintf(__('Moved %1$s picture(s) to gallery : %2$s .','nggallery'), $count, $link);
-		nggGallery::show_message($messages);
+		$messages = sprintf( __( 'Moved %1$s picture(s) to gallery : %2$s .', 'nggallery' ), $count, $link );
+		nggGallery::show_message( $messages );
 
 		return;
 	}
-	
+
 	/**
 	 * Copy images to another gallery
 	 * 
@@ -1363,97 +1370,97 @@ class nggAdmin{
 	 * @param int $dest_gid destination gallery
 	 * @return void
 	 */
-	static function copy_images($pic_ids, $dest_gid) {
-	   
-        require_once(NGGALLERY_ABSPATH . '/lib/meta.php');
-		
+	static function copy_images( $pic_ids, $dest_gid ) {
+
+		require_once ( NGGALLERY_ABSPATH . '/lib/meta.php' );
+
 		$errors = $messages = '';
-		
-		if (!is_array($pic_ids))
-			$pic_ids = array($pic_ids);
-		
+
+		if ( ! is_array( $pic_ids ) )
+			$pic_ids = array( $pic_ids );
+
 		// Get destination gallery
 		$destination = nggdb::find_gallery( $dest_gid );
 		if ( $destination == null ) {
-			nggGallery::show_error(__('The destination gallery does not exist','nggallery'));
+			nggGallery::show_error( __( 'The destination gallery does not exist', 'nggallery' ) );
 			return;
 		}
-		
+
 		// Check for folder permission
-		if (!is_writeable(WINABSPATH.$destination->path)) {
-			$message = sprintf(__('Unable to write to directory %s. Is this directory writable by the server?', 'nggallery'), esc_html( WINABSPATH.$destination->path) );
-			nggGallery::show_error($message);
-			return;				
+		if ( ! is_writeable( WINABSPATH . $destination->path ) ) {
+			$message = sprintf( __( 'Unable to write to directory %s. Is this directory writable by the server?', 'nggallery' ), esc_html( WINABSPATH . $destination->path ) );
+			nggGallery::show_error( $message );
+			return;
 		}
-				
+
 		// Get pictures
-		$images = nggdb::find_images_in_list($pic_ids);
+		$images = nggdb::find_images_in_list( $pic_ids );
 		$destination_path = WINABSPATH . $destination->path;
-		
-		foreach ($images as $image) {		
+
+		foreach ( $images as $image ) {
 			// WPMU action
 			if ( nggWPMU::check_quota() )
 				return;
-			
+
 			$i = 0;
-			$tmp_prefix = ''; 
+			$tmp_prefix = '';
 			$destination_file_name = $image->filename;
-			while (file_exists($destination_path . '/' . $destination_file_name)) {
-				$tmp_prefix = 'copy_' . ($i++) . '_';
+			while ( file_exists( $destination_path . '/' . $destination_file_name ) ) {
+				$tmp_prefix = 'copy_' . ( $i++ ) . '_';
 				$destination_file_name = $tmp_prefix . $image->filename;
 			}
-			
+
 			$destination_file_path = $destination_path . '/' . $destination_file_name;
 			$destination_thumb_file_path = $destination_path . '/' . $image->thumbFolder . $image->thumbPrefix . $destination_file_name;
 
 			// Copy files
-			if ( !@copy($image->imagePath, $destination_file_path) ) {
-				$errors .= sprintf(__('Failed to copy image %1$s to %2$s','nggallery'), 
-					esc_html( $image->filename ), esc_html( $destination_file_path) ) . '<br />';
-				continue;				
+			if ( ! @copy( $image->imagePath, $destination_file_path ) ) {
+				$errors .= sprintf( __( 'Failed to copy image %1$s to %2$s', 'nggallery' ),
+					esc_html( $image->filename ), esc_html( $destination_file_path ) ) . '<br />';
+				continue;
 			}
-			
-            // Copy backup file, if possible
-            @copy($image->imagePath . '_backup', $destination_file_path . '_backup');
-            // Copy the thumbnail if possible
-			@copy($image->thumbPath, $destination_thumb_file_path);
-			
-			// Create new database entry for the image
-			$new_pid = nggdb::insert_image( $destination->gid, $destination_file_name, $image->alttext, $image->description, $image->exclude);
 
-			if (!isset($new_pid)) {				
-				$errors .= sprintf(__('Failed to copy database row for picture %s','nggallery'), $image->pid) . '<br />';
-				continue;				
+			// Copy backup file, if possible
+			@copy( $image->imagePath . '_backup', $destination_file_path . '_backup' );
+			// Copy the thumbnail if possible
+			@copy( $image->thumbPath, $destination_thumb_file_path );
+
+			// Create new database entry for the image
+			$new_pid = nggdb::insert_image( $destination->gid, $destination_file_name, $image->alttext, $image->description, $image->exclude );
+
+			if ( ! isset ( $new_pid ) ) {
+				$errors .= sprintf( __( 'Failed to copy database row for picture %s', 'nggallery' ), $image->pid ) . '<br />';
+				continue;
 			}
-				
+
 			// Copy tags
-			nggTags::copy_tags($image->pid, $new_pid);
-            
-            // Copy meta information
-            $meta = new nggMeta($image->pid);
-            nggdb::update_image_meta( $new_pid, $meta->image->meta_data);
-			
+			nggTags::copy_tags( $image->pid, $new_pid );
+
+			// Copy meta information
+			$meta = new nggMeta( $image->pid );
+			nggdb::update_image_meta( $new_pid, $meta->image->meta_data );
+
 			if ( $tmp_prefix != '' ) {
-				$messages .= sprintf(__('Image %1$s (%2$s) copied as image %3$s (%4$s) &raquo; The file already existed in the destination gallery.','nggallery'),
-					 $image->pid, esc_html($image->filename), $new_pid, esc_html($destination_file_name) ) . '<br />';
+				$messages .= sprintf( __( 'Image %1$s (%2$s) copied as image %3$s (%4$s) &raquo; The file already existed in the destination gallery.', 'nggallery' ),
+					$image->pid, esc_html( $image->filename ), $new_pid, esc_html( $destination_file_name ) ) . '<br />';
 			} else {
-				$messages .= sprintf(__('Image %1$s (%2$s) copied as image %3$s (%4$s)','nggallery'),
-					 $image->pid, esc_html($image->filename), $new_pid, esc_html($destination_file_name) ) . '<br />';
+				$messages .= sprintf( __( 'Image %1$s (%2$s) copied as image %3$s (%4$s)', 'nggallery' ),
+					$image->pid, esc_html( $image->filename ), $new_pid, esc_html( $destination_file_name ) ) . '<br />';
 			}
 
 		}
-		
+
 		// Finish by showing errors or success
 		if ( $errors == '' ) {
-			$link = '<a href="' . admin_url() . 'admin.php?page=nggallery-manage&mode=image&gid=' . $destination->gid . '" >' . esc_html($destination->title) . '</a>';
-			$messages .= '<hr />' . sprintf(__('Copied %1$s picture(s) to gallery: %2$s .','nggallery'), count($images), $link);
-		} 
+			$link = '<a href="' . admin_url() . 'admin.php?page=nggallery-manage&mode=image&gid=' . $destination->gid . '" >' . esc_html( $destination->title ) . '</a>';
+			$messages .= '<hr />' . sprintf( __( 'Copied %1$s picture(s) to gallery: %2$s .', 'nggallery' ), count( $images ), $link );
+		}
 
 		if ( $messages != '' )
-			nggGallery::show_message($messages);
+			nggGallery::show_message( $messages );
 
 		if ( $errors != '' )
-			nggGallery::show_error($errors);
+			nggGallery::show_error( $errors );
 
 		return;
 	}
@@ -1472,29 +1479,29 @@ class nggAdmin{
 	 */
 	static function do_ajax_operation( $operation, $image_array, $title = '', $mode = 'image', $data = array() ) {
 
-		if ( ! is_array( $image_array ) || empty( $image_array ) ) {
+		if ( ! is_array( $image_array ) || empty ( $image_array ) ) {
 			return;
 		}
 
 		$js_array = implode( ',', $image_array );
-		$data = json_encode($data);
+		$data = json_encode( $data );
 
 		//This initiates the AJAX operations.
 		?>
 		<script type="text/javascript">
 
-			images = [<?php echo esc_js($js_array); ?>];
+			images = [<?php echo esc_js( $js_array ); ?>];
 
 			nggAjaxOptions = {
-				operation: "<?php echo esc_js($operation) ?>",
+				operation: "<?php echo esc_js( $operation ) ?>",
 				ids: images,
-				header: "<?php echo esc_js($title) ?>",
+				header: "<?php echo esc_js( $title ) ?>",
 				maxStep: images.length,
-				mode: "<?php echo esc_js($mode) ?>",
+				mode: "<?php echo esc_js( $mode ) ?>",
 				data: <?php echo $data; ?>
 			};
 
-			jQuery(document).ready(function() {
+			jQuery(document).ready(function () {
 				nggProgressBar.init(nggAjaxOptions);
 				nggAjax.init(nggAjaxOptions);
 			});
@@ -1502,7 +1509,7 @@ class nggAdmin{
 
 		<?php
 	}
-	
+
 	/**
 	 * nggAdmin::set_gallery_preview() - define a preview pic after the first upload, can be changed in the gallery settings
 	 * 
@@ -1511,20 +1518,20 @@ class nggAdmin{
 	 * @return void
 	 */
 	static function set_gallery_preview( $galleryID ) {
-		
+
 		global $wpdb;
-		
+
 		$gallery = nggdb::find_gallery( $galleryID );
-		
+
 		// in the case no preview image is setup, we do this now
-		if ($gallery->previewpic == 0) {
-			$firstImage = $wpdb->get_var("SELECT pid FROM $wpdb->nggpictures WHERE exclude != 1 AND galleryid = '$galleryID' ORDER by pid DESC limit 0,1");
-			if ($firstImage) {
-				$wpdb->query("UPDATE $wpdb->nggallery SET previewpic = '$firstImage' WHERE gid = '$galleryID'");
-				wp_cache_delete($galleryID, 'ngg_gallery');
+		if ( $gallery->previewpic == 0 ) {
+			$firstImage = $wpdb->get_var( "SELECT pid FROM $wpdb->nggpictures WHERE exclude != 1 AND galleryid = '$galleryID' ORDER by pid DESC limit 0,1" );
+			if ( $firstImage ) {
+				$wpdb->query( "UPDATE $wpdb->nggallery SET previewpic = '$firstImage' WHERE gid = '$galleryID'" );
+				wp_cache_delete( $galleryID, 'ngg_gallery' );
 			}
 		}
-		
+
 		return;
 	}
 
@@ -1533,18 +1540,18 @@ class nggAdmin{
 	 * 
 	 * @class nggAdmin
 	 * @param int $galleryID
-	 * @return array (JSON)
+	 * @return bool|string (JSON)
 	 */
 	static function get_image_ids( $galleryID ) {
-		
-		if ( !function_exists('json_encode') )
-			return(-2);
-		
-		$gallery = nggdb::get_ids_from_gallery($galleryID, 'pid', 'ASC', false);
 
-		header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
-		$output = json_encode(array_map('intval', $gallery));
-		
+		if ( ! function_exists( 'json_encode' ) )
+			return ( -2 );
+
+		$gallery = nggdb::get_ids_from_gallery( $galleryID, 'pid', 'ASC', false );
+
+		header( 'Content-Type: text/plain; charset=' . get_option( 'blog_charset' ), true );
+		$output = json_encode( array_map( 'intval', $gallery ) );
+
 		return $output;
 	}
 
@@ -1556,37 +1563,37 @@ class nggAdmin{
 	 * @param int $code php upload error code
 	 * @return string message
 	 */
-	
-	static function decode_upload_error( $code ) {
-		
-	        switch ($code) {
-	            case UPLOAD_ERR_INI_SIZE:
-	                $message = __ ( 'The uploaded file exceeds the upload_max_filesize directive in php.ini', 'nggallery' );
-	                break;
-	            case UPLOAD_ERR_FORM_SIZE:
-	                $message = __ ( 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form', 'nggallery' );
-	                break;
-	            case UPLOAD_ERR_PARTIAL:
-	                $message = __ ( 'The uploaded file was only partially uploaded', 'nggallery' );
-	                break;
-	            case UPLOAD_ERR_NO_FILE:
-	                $message = __ ( 'No file was uploaded', 'nggallery' );
-	                break;
-	            case UPLOAD_ERR_NO_TMP_DIR:
-	                $message = __ ( 'Missing a temporary folder', 'nggallery' );
-	                break;
-	            case UPLOAD_ERR_CANT_WRITE:
-	                $message = __ ( 'Failed to write file to disk', 'nggallery' );
-	                break;
-	            case UPLOAD_ERR_EXTENSION:
-	                $message = __ ( 'File upload stopped by extension', 'nggallery' );
-	                break;
-	            default:
-	                $message = __ ( 'Unknown upload error', 'nggallery' );
-	                break;
-	        }
 
-	        return $message; 
+	static function decode_upload_error( $code ) {
+
+		switch ( $code ) {
+			case UPLOAD_ERR_INI_SIZE:
+				$message = __( 'The uploaded file exceeds the upload_max_filesize directive in php.ini', 'nggallery' );
+				break;
+			case UPLOAD_ERR_FORM_SIZE:
+				$message = __( 'The uploaded file exceeds the MAX_FILE_SIZE directive that was specified in the HTML form', 'nggallery' );
+				break;
+			case UPLOAD_ERR_PARTIAL:
+				$message = __( 'The uploaded file was only partially uploaded', 'nggallery' );
+				break;
+			case UPLOAD_ERR_NO_FILE:
+				$message = __( 'No file was uploaded', 'nggallery' );
+				break;
+			case UPLOAD_ERR_NO_TMP_DIR:
+				$message = __( 'Missing a temporary folder', 'nggallery' );
+				break;
+			case UPLOAD_ERR_CANT_WRITE:
+				$message = __( 'Failed to write file to disk', 'nggallery' );
+				break;
+			case UPLOAD_ERR_EXTENSION:
+				$message = __( 'File upload stopped by extension', 'nggallery' );
+				break;
+			default:
+				$message = __( 'Unknown upload error', 'nggallery' );
+				break;
+		}
+
+		return $message;
 	}
 
 } // END class nggAdmin
@@ -1598,8 +1605,8 @@ class nggAdmin{
  * @param mixed $p_header
  * @return
  */
-function ngg_getOnlyImages($p_event, &$p_header)	{
-	return nggAdmin::getOnlyImages($p_event, $p_header);
+function ngg_getOnlyImages( $p_event, &$p_header ) {
+	return nggAdmin::getOnlyImages( $p_event, $p_header );
 }
 
 /**
@@ -1609,15 +1616,15 @@ function ngg_getOnlyImages($p_event, &$p_header)	{
  * @param mixed $p_header
  * @return 1
  */
-function ngg_checkExtract($p_event, &$p_header)	{
-	
-    // look for valid extraction
-    if ($p_header['status'] == 'ok') {
-        // check if it's any image file, delete all other files
-        if ( !@getimagesize ( $p_header['filename'] ))
-            unlink($p_header['filename']);
-    }
-	
-    return 1;
+function ngg_checkExtract( $p_event, &$p_header ) {
+
+	// look for valid extraction
+	if ( $p_header['status'] == 'ok' ) {
+		// check if it's any image file, delete all other files
+		if ( ! @getimagesize( $p_header['filename'] ) )
+			unlink( $p_header['filename'] );
+	}
+
+	return 1;
 }
 ?>

--- a/admin/manage/class-ngg-image-list-table.php
+++ b/admin/manage/class-ngg-image-list-table.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
-	require_once( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
+	require_once ( ABSPATH . 'wp-admin/includes/class-wp-list-table.php' );
 }
 
 /**
@@ -30,26 +30,26 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 *
 	 * @param bool|string $search The search string, or false if we don't search.
 	 */
-	public function prepare_items($search = false) {
+	public function prepare_items( $search = false ) {
 
 		/**
 		 * @global $nggdb nggdb
 		 */
 		global $nggdb;
 
-		$columns  = $this->get_columns();
-		$hidden   = $this->get_hidden_columns();
+		$columns = $this->get_columns();
+		$hidden = $this->get_hidden_columns();
 		$sortable = $this->get_sortable_columns();
 
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 
-		if( $search ) {
+		if ( $search ) {
 			// look now for the images
 			$search_for_images = (array) $nggdb->search_for_images( $search );
-			$search_for_tags   = (array) nggTags::find_images_for_tags( $search , 'ASC' );
+			$search_for_tags = (array) nggTags::find_images_for_tags( $search, 'ASC' );
 
 			// finally merge the two results together
-			$this->items = array_merge( $search_for_images , $search_for_tags );
+			$this->items = array_merge( $search_for_images, $search_for_tags );
 
 			$this->set_pagination_args( array(
 				'total_items' => count( $this->items )
@@ -61,12 +61,12 @@ class NGG_Image_List_Table extends WP_List_Table {
 			 * Do the pagination.
 			 */
 			$currentPage = $this->get_pagenum();
-			$perPage     = $this->get_items_per_page('ngg_images_per_page', 50);
+			$perPage = $this->get_items_per_page( 'ngg_images_per_page', 50 );
 
-			$options    = get_option( 'ngg_options' );
+			$options = get_option( 'ngg_options' );
 			$gallery_id = (int) $_GET['gid'];
 
-			$start       = ( $currentPage - 1 ) * $perPage;
+			$start = ( $currentPage - 1 ) * $perPage;
 
 			$this->items = $nggdb->get_gallery( $gallery_id, $options['galSort'], $options['galSortDir'], false,
 				$perPage,
@@ -76,7 +76,7 @@ class NGG_Image_List_Table extends WP_List_Table {
 
 			$this->set_pagination_args( array(
 				'total_items' => $totalItems,
-				'per_page'    => $perPage
+				'per_page' => $perPage
 			) );
 		}
 	}
@@ -86,10 +86,10 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 *
 	 * @param string $which
 	 */
-	protected function bulk_actions($which = '') {
-		parent::bulk_actions($which);
+	protected function bulk_actions( $which = '' ) {
+		parent::bulk_actions( $which );
 
-		if($which === 'top') {
+		if ( $which === 'top' ) {
 			?>
 			<button type="submit" class="button-primary action manager-save" name="update_images">
 				<?php _e( "Save Changes", 'nggallery' ); ?>
@@ -102,7 +102,8 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 * Get the hidden columns from the screen options.
 	 */
 	public function get_hidden_columns() {
-		return (array) get_user_option( 'manage' . $this->screen->id . 'columnshidden' );;
+		return (array) get_user_option( 'manage' . $this->screen->id . 'columnshidden' );
+		;
 	}
 
 	/**
@@ -123,9 +124,9 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 */
 	protected function column_thumbnail( $item ) {
 		$out = '<a href="' . esc_url( add_query_arg( 'i', mt_rand(),
-				$item->imageURL ) ) . '" class="shutter" title="' . esc_attr( $item->filename ) . '">';
+			$item->imageURL ) ) . '" class="shutter" title="' . esc_attr( $item->filename ) . '">';
 		$out .= '<img class="thumb" src="' . esc_url( add_query_arg( 'i', mt_rand(),
-				$item->thumbURL ) ) . '" id="thumb' . $item->pid . '" /></a>';
+			$item->thumbURL ) ) . '" id="thumb' . $item->pid . '" /></a>';
 
 		return $out;
 	}
@@ -145,22 +146,29 @@ class NGG_Image_List_Table extends WP_List_Table {
 			</strong>
 		</a>
 		<br>
-		<span class="date"><?php echo $date ?></span>
-		<input type="text" class="datepicker" value="<?php echo $date ?>"/>
-		<span class="change"> <?php _e( 'Change Date', 'nggallery' ); ?></span>
-		<input type="hidden" class="rawdate" name="date[<?php echo $item->pid ?>]" value="<?php echo $item->imagedate ?>"/>
-		<?php if ( ! empty( $item->meta_data ) ) { ?>
-			<br><?php echo $item->meta_data['width'] ?> x <?php echo $item->meta_data['height'] ?><?php _e( 'pixel',
+		<span class="date">
+			<?php echo $date ?>
+		</span>
+		<input type="text" class="datepicker" value="<?php echo $date ?>" />
+		<span class="change">
+			<?php _e( 'Change Date', 'nggallery' ); ?>
+		</span>
+		<input type="hidden" class="rawdate" name="date[<?php echo $item->pid ?>]" value="<?php echo $item->imagedate ?>" />
+		<?php if ( ! empty ( $item->meta_data ) ) { ?>
+			<br>
+			<?php echo $item->meta_data['width'] ?> x
+			<?php echo $item->meta_data['height'] ?>
+			<?php _e( 'pixel',
 				'nggallery' ) ?>
 		<?php } ?>
 		<p>
 			<?php
-			$actions      = $this->get_row_actions( $item );
+			$actions = $this->get_row_actions( $item );
 			$action_count = count( $actions );
-			$i            = 0;
+			$i = 0;
 			echo '<div class="row-actions">';
 			foreach ( $actions as $action => $link ) {
-				++ $i;
+				++$i;
 				( $i == $action_count ) ? $sep = '' : $sep = ' | ';
 				echo "<span class='$action'>$link$sep</span>";
 			}
@@ -178,14 +186,14 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 * @return string
 	 */
 	protected function column_alt_title_desc( $item ) {
-		$img_alt_text    = nggGallery::suppress_injection( $item->alttext );
+		$img_alt_text = nggGallery::suppress_injection( $item->alttext );
 		$img_description = nggGallery::suppress_injection( $item->description );
 
 		$out = '<input placeholder="' . __( "Alt & title text",
-				'nggallery' ) . '" name="alttext[' . $item->pid . ']" type="text" style="width:95%; margin-bottom: 2px;" value="' . $img_alt_text . '"/>';
+			'nggallery' ) . '" name="alttext[' . $item->pid . ']" type="text" style="width:95%; margin-bottom: 2px;" value="' . $img_alt_text . '"/>';
 		$out .= '<br>';
 		$out .= '<textarea placeholder="' . __( "Description",
-				'nggallery' ) . '" name="description[' . $item->pid . ']" style="width:95%; margin: 1px;" rows="2">' . $img_description . '</textarea>';
+			'nggallery' ) . '" name="description[' . $item->pid . ']" style="width:95%; margin: 1px;" rows="2">' . $img_description . '</textarea>';
 
 		return $out;
 	}
@@ -194,18 +202,20 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 * Define what data to show on each column of the table
 	 *
 	 * @param  nggImage $item      Data
-	 * @param  String $column_name - Current column name
+	 * @param  string $column_name - Current column name
 	 *
-	 * @return Mixed
+	 * @return bool|string
 	 */
 	protected function column_default( $item, $column_name ) {
 		switch ( $column_name ) {
 			case 'id':
 				return '<input type="hidden" name="pid[]" value="' . $item->pid . '">' . $item->pid;
 			case 'tags':
-				$item->tags = wp_get_object_terms( $item->pid, 'ngg_tag', 'fields=names' );
-				if ( is_array( $item->tags ) ) {
-					$item->tags = implode( ', ', $item->tags );
+				$tags = wp_get_object_terms( $item->pid, 'ngg_tag', 'fields=names' );
+				if ( is_array( $tags ) ) {
+					$item->tags = implode( ', ', $tags );
+				} else {
+					$item->tags = $tags;
 				}
 
 				return '<textarea placeholder="' . __( "Separated by commas",
@@ -229,13 +239,13 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 */
 	public static function get_columns_static() {
 		$columns = array(
-			'cb'             => '<input type="checkbox" />',
-			'id'             => __( 'ID', 'nggallery' ),
-			'thumbnail'      => __( 'Thumbnail', 'nggallery' ),
-			'filename'       => __( 'Filename', 'nggallery' ),
+			'cb' => '<input type="checkbox" />',
+			'id' => __( 'ID', 'nggallery' ),
+			'thumbnail' => __( 'Thumbnail', 'nggallery' ),
+			'filename' => __( 'Filename', 'nggallery' ),
 			'alt_title_desc' => __( 'Alt & Title Text', 'nggallery' ) . '/' . __( 'Description', 'nggallery' ),
-			'tags'           => __( 'Tags', 'nggallery' ),
-			'exclude'        => __( 'Exclude', 'nggallery' )
+			'tags' => __( 'Tags', 'nggallery' ),
+			'exclude' => __( 'Exclude', 'nggallery' )
 		);
 
 		/**
@@ -261,32 +271,32 @@ class NGG_Image_List_Table extends WP_List_Table {
 	 */
 	private function get_row_actions( $item ) {
 
-		if(isset($_GET['paged'])) {
+		if ( isset ( $_GET['paged'] ) ) {
 			$paged = '&paged=' . $_GET['paged'];
 		} else {
 			$paged = '';
 		}
 
-		$url = $this->base . '&mode=image&gid=' .  $_GET['gid'] . $paged;
+		$url = $this->base . '&mode=image&gid=' . $_GET['gid'] . $paged;
 
 		$actions = array(
-			'view'         => '<a class="shutter" href="' . esc_url( $item->imageURL ) . '" title="' . esc_attr( sprintf( __( 'View "%s"' ),
-					sanitize_title( $item->filename ) ) ) . '">' . __( 'View', 'nggallery' ) . '</a>',
-			'meta'         => '<a class="ngg-dialog" data-action="show_meta" data-id="' . $item->pid . '" href="#" title="' . __( 'Show Meta data',
-					'nggallery' ) . '">' . __( 'Meta', 'nggallery' ) . '</a>',
+			'view' => '<a class="shutter" href="' . esc_url( $item->imageURL ) . '" title="' . esc_attr( sprintf( __( 'View "%s"' ),
+				sanitize_title( $item->filename ) ) ) . '">' . __( 'View', 'nggallery' ) . '</a>',
+			'meta' => '<a class="ngg-dialog" data-action="show_meta" data-id="' . $item->pid . '" href="#" title="' . __( 'Show Meta data',
+				'nggallery' ) . '">' . __( 'Meta', 'nggallery' ) . '</a>',
 			'custom_thumb' => '<a class="ngg-dialog" data-action="edit_thumb" data-id="' . $item->pid . '" href="#" title="' . __( 'Customize thumbnail',
-					'nggallery' ) . '">' . __( 'Edit thumb', 'nggallery' ) . '</a>',
-			'rotate'       => '<a class="ngg-dialog" data-action="rotate" data-id="' . $item->pid . '" href="#" title="' . __( 'Rotate',
-					'nggallery' ) . '">' . __( 'Rotate', 'nggallery' ) . '</a>',
+				'nggallery' ) . '">' . __( 'Edit thumb', 'nggallery' ) . '</a>',
+			'rotate' => '<a class="ngg-dialog" data-action="rotate" data-id="' . $item->pid . '" href="#" title="' . __( 'Rotate',
+				'nggallery' ) . '">' . __( 'Rotate', 'nggallery' ) . '</a>',
 		);
 		if ( file_exists( $item->imagePath . '_backup' ) ) {
 			$actions['recover'] = '<a class="confirm_recover" href="' . wp_nonce_url( $url . "&action=recover&pid=" . $item->pid, 'ngg_row_action' ) .
-			                      '" data-file="' . esc_attr($item->filename) . '">' .
-			                      __( 'Recover', 'nggallery' ) . '</a>';
+				'" data-file="' . esc_attr( $item->filename ) . '">' .
+				__( 'Recover', 'nggallery' ) . '</a>';
 		}
 		$actions['delete'] = '<a class="confirm_delete" href="' . wp_nonce_url( $url . "&action=delete&pid=" . $item->pid, 'ngg_row_action' ) .
-		                     '" class="delete column-delete" data-file="' . esc_attr($item->filename) . '">' .
-		                     __( 'Delete' ) . '</a>';
+			'" class="delete column-delete" data-file="' . esc_attr( $item->filename ) . '">' .
+			__( 'Delete' ) . '</a>';
 
 		$actions = apply_filters( 'ngg_manage_images_actions', $actions );
 
@@ -302,21 +312,21 @@ class NGG_Image_List_Table extends WP_List_Table {
 
 	protected function get_bulk_actions() {
 		return array(
-			'set_watermark'  => __( 'Set watermark', 'nggallery' ),
-			'new_thumbnail'  => __( 'Create new thumbnails', 'nggallery' ),
-			'resize_images'  => __( 'Resize images', 'nggallery' ),
-			'import_meta'    => __( 'Import metadata', 'nggallery' ),
+			'set_watermark' => __( 'Set watermark', 'nggallery' ),
+			'new_thumbnail' => __( 'Create new thumbnails', 'nggallery' ),
+			'resize_images' => __( 'Resize images', 'nggallery' ),
+			'import_meta' => __( 'Import metadata', 'nggallery' ),
 			'recover_images' => __( 'Recover from backup', 'nggallery' ),
-			'delete_images'  => __( 'Delete images', 'nggallery' ),
-			'rotate_cw'      => __( 'Rotate images clockwise', 'nggallery' ),
-			'rotate_ccw'     => __( 'Rotate images counter-clockwise', 'nggallery' ),
-			'copy_to'        => __( 'Copy to...', 'nggallery' ),
-			'move_to'        => __( 'Move to...', 'nggallery' ),
-			'add_tags'       => __( 'Add tags', 'nggallery' ),
-			'delete_tags'    => __( 'Delete tags', 'nggallery' ),
+			'delete_images' => __( 'Delete images', 'nggallery' ),
+			'rotate_cw' => __( 'Rotate images clockwise', 'nggallery' ),
+			'rotate_ccw' => __( 'Rotate images counter-clockwise', 'nggallery' ),
+			'copy_to' => __( 'Copy to...', 'nggallery' ),
+			'move_to' => __( 'Move to...', 'nggallery' ),
+			'add_tags' => __( 'Add tags', 'nggallery' ),
+			'delete_tags' => __( 'Delete tags', 'nggallery' ),
 			'overwrite_tags' => __( 'Overwrite tags', 'nggallery' ),
-			'set_title'      => __( 'Set alt & title text', 'nggallery' ),
-			'set_descr'      => __( 'Set description', 'nggallery' ),
+			'set_title' => __( 'Set alt & title text', 'nggallery' ),
+			'set_descr' => __( 'Set description', 'nggallery' ),
 		);
 	}
 }

--- a/admin/manage/class-ngg-manager.php
+++ b/admin/manage/class-ngg-manager.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once( NGGALLERY_ABSPATH . '/admin/interface-ngg-displayable.php' );
+include_once ( NGGALLERY_ABSPATH . '/admin/interface-ngg-displayable.php' );
 
 /**
  * Class NGG_Manager
@@ -18,14 +18,14 @@ abstract class NGG_Manager implements NGG_Displayable {
 		/**
 		 * Do a bulk action.
 		 */
-		if ( ( isset( $_POST['action'] ) || isset( $_POST['action2'] ) ) && isset ( $_POST['doaction'] ) ) {
+		if ( ( isset ( $_POST['action'] ) || isset ( $_POST['action2'] ) ) && isset ( $_POST['doaction'] ) ) {
 			$this->handle_bulk_actions();
 		}
 
 		/**
 		 * Do the operations with a dialog.
 		 */
-		if ( isset( $_POST['TB_bulkaction'] ) && isset( $_POST['TB_action'] ) ) {
+		if ( isset ( $_POST['TB_bulkaction'] ) && isset ( $_POST['TB_action'] ) ) {
 			$this->handle_dialog_actions();
 		}
 	}
@@ -54,16 +54,26 @@ abstract class NGG_Manager implements NGG_Displayable {
 				<table width="100%">
 					<tr valign="top">
 						<td>
-							<strong><?php _e( 'Resize Images to', 'nggallery' ); ?>:</strong>
+							<strong>
+								<?php _e( 'Resize Images to', 'nggallery' ); ?>:
+							</strong>
 						</td>
 						<td>
-							<label for="imgWidth"><?php _e( 'Width', 'nggallery' ) ?></label>
-							<input type="number" min="0" class="small-text" id="imgWidth" name="imgWidth" value="<?php echo $options['imgWidth']; ?>">
-							<label for="imgHeight"><?php _e( 'Height', 'nggallery' ) ?></label>
-							<input type="number" min="0" size="5" name="imgHeight" id="imgHeight" class="small-text" value="<?php echo $options['imgHeight']; ?>">
+							<label for="imgWidth">
+								<?php _e( 'Width', 'nggallery' ) ?>
+							</label>
+							<input type="number" min="0" class="small-text" id="imgWidth" name="imgWidth"
+								value="<?php echo $options['imgWidth']; ?>">
+							<label for="imgHeight">
+								<?php _e( 'Height', 'nggallery' ) ?>
+							</label>
+							<input type="number" min="0" size="5" name="imgHeight" id="imgHeight" class="small-text"
+								value="<?php echo $options['imgHeight']; ?>">
 
-							<p class="description"><?php _e( 'Width and height (in pixels). NextCellent Gallery will keep the ratio size.',
-									'nggallery' ) ?></p>
+							<p class="description">
+								<?php _e( 'Width and height (in pixels). NextCellent Gallery will keep the ratio size.',
+									'nggallery' ) ?>
+							</p>
 						</td>
 					</tr>
 				</table>
@@ -78,14 +88,24 @@ abstract class NGG_Manager implements NGG_Displayable {
 				<input type="hidden" name="TB_action" value="new_thumbnails">
 				<table width="100%">
 					<tr valign="top">
-						<th align="left"><?php _e( 'Size', 'nggallery' ) ?></th>
+						<th align="left">
+							<?php _e( 'Size', 'nggallery' ) ?>
+						</th>
 						<td>
-							<label for="thumbwidth"><?php _e( 'Width', 'nggallery' ) ?></label>
-							<input id="thumbwidth" class="small-text" type="number" min="0" name="thumbwidth" value="<?php echo $options['thumbwidth']; ?>">
-							<label for="thumbheight"><?php _e( 'Height', 'nggallery' ) ?></label>
-							<input id="thumbheight" class="small-text" type="number" step="1" min="0" name="thumbheight" value="<?php echo $options['thumbheight']; ?>">
+							<label for="thumbwidth">
+								<?php _e( 'Width', 'nggallery' ) ?>
+							</label>
+							<input id="thumbwidth" class="small-text" type="number" min="0" name="thumbwidth"
+								value="<?php echo $options['thumbwidth']; ?>">
+							<label for="thumbheight">
+								<?php _e( 'Height', 'nggallery' ) ?>
+							</label>
+							<input id="thumbheight" class="small-text" type="number" step="1" min="0" name="thumbheight"
+								value="<?php echo $options['thumbheight']; ?>">
 
-							<p class="description"><?php _e( 'These values are maximum values ', 'nggallery' ) ?></p>
+							<p class="description">
+								<?php _e( 'These values are maximum values ', 'nggallery' ) ?>
+							</p>
 						</td>
 					</tr>
 					<tr valign="top">
@@ -121,7 +141,7 @@ abstract class NGG_Manager implements NGG_Displayable {
 			<!-- /#entertags -->
 			<!-- #settext -->
 			<form id="settext_dialog" method="POST" accept-charset="utf-8">
-				<?php wp_nonce_field('ngg_thickbox_form') ?>
+				<?php wp_nonce_field( 'ngg_thickbox_form' ) ?>
 				<input type="hidden" class="TB_type" name="TB_type" value="">
 				<input type="hidden" id="settext_imagelist" name="TB_imagelist" value="">
 				<input type="hidden" id="settext_bulkaction" name="TB_bulkaction" value="">
@@ -147,8 +167,10 @@ abstract class NGG_Manager implements NGG_Displayable {
 					<label>
 						<?php _e( 'Select the destination gallery:', 'nggallery' ); ?><br>
 						<select id="dest_gid" name="dest_gid" style="width: 300px">
-							<option value="0" selected="selected"><?php _e( "Select or search for a gallery",
-									'nggallery' ); ?></option>
+							<option value="0" selected="selected">
+								<?php _e( "Select or search for a gallery",
+									'nggallery' ); ?>
+							</option>
 						</select>
 					</label>
 				</div>
@@ -166,13 +188,13 @@ abstract class NGG_Manager implements NGG_Displayable {
 	protected function print_scripts() {
 		?>
 		<script type="text/javascript">
-			jQuery(function() {
-				jQuery("[id^=doaction]").click(function(event) {
+			jQuery(function () {
+				jQuery("[id^=doaction]").click(function (event) {
 					return handleBulkActions(event);
 				});
 				jQuery("#dest_gid").nggAutocomplete({
 					type: 'gallery',
-					domain: "<?php echo home_url('index.php', is_ssl() ? 'https' : 'http'); ?>"
+					domain: "<?php echo home_url( 'index.php', is_ssl() ? 'https' : 'http' ); ?>"
 				});
 				if (jQuery("#page_type").val() === 'gallery') {
 					jQuery('.TB_type').val('gallery');
@@ -190,7 +212,7 @@ abstract class NGG_Manager implements NGG_Displayable {
 				var $selected = jQuery("input[name^=doaction]:checkbox:checked");
 
 				if ($selected.length < 1) {
-					alert('<?php echo esc_js(__('No images selected', 'nggallery')); ?>');
+					alert('<?php echo esc_js( __( 'No images selected', 'nggallery' ) ); ?>');
 					return false;
 				}
 
@@ -204,63 +226,63 @@ abstract class NGG_Manager implements NGG_Displayable {
 				 */
 				switch ($selector.val()) {
 					case "-1":
-						alert('<?php echo esc_js(__('No action selected.', 'nggallery')); ?>');
+						alert('<?php echo esc_js( __( 'No action selected.', 'nggallery' ) ); ?>');
 						break;
 					case 'resize_images':
-						bulkDialog('resize_images', '<?php echo esc_js(__('Resize images','nggallery')); ?>', $selected);
+						bulkDialog('resize_images', '<?php echo esc_js( __( 'Resize images', 'nggallery' ) ); ?>', $selected);
 						break;
 					case 'new_thumbnail':
-						bulkDialog('new_thumbnail', '<?php echo esc_js(__('Create new thumbnails','nggallery')); ?>', $selected);
+						bulkDialog('new_thumbnail', '<?php echo esc_js( __( 'Create new thumbnails', 'nggallery' ) ); ?>', $selected);
 						break;
 					case 'import_meta':
-						ajaxOperation(cp + 'import_metadata', '<?php echo esc_js(__('Import metadata','nggallery')); ?>', $selected, true);
+						ajaxOperation(cp + 'import_metadata', '<?php echo esc_js( __( 'Import metadata', 'nggallery' ) ); ?>', $selected, true);
 						break;
 					case 'recover_images':
-						ajaxOperation(cp + 'recover_image', '<?php echo esc_js(__('Recover from backup','nggallery')); ?>', $selected, true);
+						ajaxOperation(cp + 'recover_image', '<?php echo esc_js( __( 'Recover from backup', 'nggallery' ) ); ?>', $selected, true);
 						break;
 					case 'set_watermark':
-						ajaxOperation(cp + 'set_watermark', '<?php echo esc_js(__('Set watermark','nggallery')); ?>', $selected, true);
+						ajaxOperation(cp + 'set_watermark', '<?php echo esc_js( __( 'Set watermark', 'nggallery' ) ); ?>', $selected, true);
 						break;
 					case "copy_to":
 						set_TB_command('select_gallery', 'copy_to');
-						bulkDialog('select_gallery', '<?php echo esc_js(__('Copy image to...','nggallery')); ?>', $selected);
+						bulkDialog('select_gallery', '<?php echo esc_js( __( 'Copy image to...', 'nggallery' ) ); ?>', $selected);
 						break;
 					case "move_to":
 						set_TB_command('select_gallery', 'move_to');
-						bulkDialog('select_gallery', '<?php echo esc_js(__('Move image to...','nggallery')); ?>', $selected);
+						bulkDialog('select_gallery', '<?php echo esc_js( __( 'Move image to...', 'nggallery' ) ); ?>', $selected);
 						break;
 					case "add_tags":
 						set_TB_command('tags', 'add_tags');
-						bulkDialog('tags', '<?php echo esc_js(__('Add new tags','nggallery')); ?>', $selected);
+						bulkDialog('tags', '<?php echo esc_js( __( 'Add new tags', 'nggallery' ) ); ?>', $selected);
 						break;
 					case "delete_tags":
 						set_TB_command('tags', 'delete_tags');
-						bulkDialog('tags', '<?php echo esc_js(__('Delete tags','nggallery')); ?>', $selected);
+						bulkDialog('tags', '<?php echo esc_js( __( 'Delete tags', 'nggallery' ) ); ?>', $selected);
 						break;
 					case "overwrite_tags":
 						set_TB_command('tags', 'overwrite_tags');
-						bulkDialog('tags', '<?php echo esc_js(__('Overwrite','nggallery')); ?>', $selected);
+						bulkDialog('tags', '<?php echo esc_js( __( 'Overwrite', 'nggallery' ) ); ?>', $selected);
 						break;
 					case "set_title":
 						set_TB_command('settext', 'set_title');
-						bulkDialog('settext', '<?php echo esc_js(__('Set alt and title text','nggallery')); ?>', $selected);
+						bulkDialog('settext', '<?php echo esc_js( __( 'Set alt and title text', 'nggallery' ) ); ?>', $selected);
 						break;
 					case "set_descr":
 						set_TB_command('settext', 'set_descr');
-						bulkDialog('settext', '<?php echo esc_js(__('Set description','nggallery')); ?>', $selected);
+						bulkDialog('settext', '<?php echo esc_js( __( 'Set description', 'nggallery' ) ); ?>', $selected);
 						break;
 					case 'rotate_cw':
-						ajaxOperation('rotate_cw', '<?php echo esc_js(__('Rotate images','nggallery')); ?>', $selected);
+						ajaxOperation('rotate_cw', '<?php echo esc_js( __( 'Rotate images', 'nggallery' ) ); ?>', $selected);
 						break;
 					case 'rotate_ccw':
-						ajaxOperation('rotate_ccw', '<?php echo esc_js(__('Rotate images','nggallery')); ?>', $selected);
+						ajaxOperation('rotate_ccw', '<?php echo esc_js( __( 'Rotate images', 'nggallery' ) ); ?>', $selected);
 						break;
 					default:
 						console.log($selected);
-						var images = $selected.map(function() {
+						var images = $selected.map(function () {
 							return this.value;
 						}).get();
-						var message = '<?php echo sprintf(esc_js(__("You are about to start bulk edits for %s galleries\n\n 'Cancel' to stop, 'OK' to proceed.", 'nggallery' )), "' + images.length + '") ?>';
+						var message = '<?php echo sprintf( esc_js( __( "You are about to start bulk edits for %s galleries\n\n 'Cancel' to stop, 'OK' to proceed.", 'nggallery' ) ), "' + images.length + '" ) ?>';
 						return confirm(message);
 				}
 				return false;
@@ -272,12 +294,12 @@ abstract class NGG_Manager implements NGG_Displayable {
 
 			function ajaxOperation(command, title, $selected, warning) {
 
-				var images = $selected.map(function() {
+				var images = $selected.map(function () {
 					return this.value;
 				}).get();
 
 				if (warning) {
-					var message = '<?php echo sprintf(esc_js(__("You are about to start bulk edits for %s galleries\n\n 'Cancel' to stop, 'OK' to proceed.", 'nggallery' )), "' + images.length + '") ?>';
+					var message = '<?php echo sprintf( esc_js( __( "You are about to start bulk edits for %s galleries\n\n 'Cancel' to stop, 'OK' to proceed.", 'nggallery' ) ), "' + images.length + '" ) ?>';
 
 					if (!confirm(message)) {
 						return false;
@@ -297,7 +319,7 @@ abstract class NGG_Manager implements NGG_Displayable {
 
 			function bulkDialog(id, title, $selected) {
 				jQuery('#' + id + "_bulkaction").val(id);
-				jQuery('#' + id + "_imagelist").val($selected.map(function() {
+				jQuery('#' + id + "_imagelist").val($selected.map(function () {
 					return this.value;
 				}).get().join(','));
 				showDialog('#' + id + "_dialog", title);
@@ -306,7 +328,7 @@ abstract class NGG_Manager implements NGG_Displayable {
 			function showDialog(id, title, onSubmit) {
 
 				if (typeof onSubmit === 'undefined' || onSubmit === null) {
-					onSubmit = function(dialog) {
+					onSubmit = function (dialog) {
 						jQuery(dialog).submit();
 					}
 				}
@@ -316,23 +338,23 @@ abstract class NGG_Manager implements NGG_Displayable {
 					resizable: true,
 					modal: true,
 					title: title,
-					close: function() {
+					close: function () {
 						jQuery(this).dialog('destroy');
 					},
 					buttons: [
 						{
-							text: "<?php echo esc_js(__('Cancel','nggallery')); ?>",
+							text: "<?php echo esc_js( __( 'Cancel', 'nggallery' ) ); ?>",
 							'class': "button dialog-cancel",
 							'type': "reset",
-							click: function() {
+							click: function () {
 								jQuery(this).dialog('close');
 							}
 						},
 						{
-							text: "<?php echo esc_js(__('OK','nggallery')); ?>",
+							text: "<?php echo esc_js( __( 'OK', 'nggallery' ) ); ?>",
 							'class': "button-primary",
 							'type': "submit",
-							click: function() {
+							click: function () {
 								onSubmit(this);
 							}
 						}
@@ -366,21 +388,21 @@ abstract class NGG_Manager implements NGG_Displayable {
 		switch ( $_POST['TB_action'] ) {
 			case 'resize_images':
 				$data = array(
-					'width'     => (int) $_POST['imgWidth'],
-					'height'    => (int) $_POST['imgHeight']
+					'width' => (int) $_POST['imgWidth'],
+					'height' => (int) $_POST['imgHeight']
 				);
 				$command = 'resize_image';
-				$title   = __( 'Resize images', 'nggallery' );
+				$title = __( 'Resize images', 'nggallery' );
 				nggAdmin::do_ajax_operation( $command, $list, $title, $mode, $data );
 				return;
 			case 'new_thumbnails':
 				$data = array(
-					'width'     => (int) $_POST['thumbwidth'],
-					'height'    => (int) $_POST['thumbheight'],
-					'fix'       => isset( $_POST['thumb_fix'] ) ? true : false
+					'width' => (int) $_POST['thumbwidth'],
+					'height' => (int) $_POST['thumbheight'],
+					'fix' => isset ( $_POST['thumb_fix'] ) ? true : false
 				);
 				$command = 'create_thumbnail';
-				$title   = __( 'Create new thumbnails', 'nggallery' );
+				$title = __( 'Create new thumbnails', 'nggallery' );
 				nggAdmin::do_ajax_operation( $command, $list, $title, $mode, $data );
 				return;
 			case 'copy_to':
@@ -412,7 +434,7 @@ abstract class NGG_Manager implements NGG_Displayable {
 						$old_tags = wp_get_object_terms( $pic_id, 'ngg_tag', 'fields=names' );
 						// get the slugs, to vaoid  case sensitive problems
 						$slug_array = array_map( 'sanitize_title', $tag_list );
-						$old_tags   = array_map( 'sanitize_title', $old_tags );
+						$old_tags = array_map( 'sanitize_title', $old_tags );
 						// compare them and return the diff
 						$new_tags = array_diff( $old_tags, $slug_array );
 						wp_set_object_terms( $pic_id, $new_tags, 'ngg_tag' );
@@ -436,20 +458,20 @@ abstract class NGG_Manager implements NGG_Displayable {
 				$new_title = $_POST['text'];
 				if ( is_array( $list ) ) {
 					foreach ( $list as $pic_id ) {
-						nggdb::update_image($pic_id, false, false, false, $new_title);
+						nggdb::update_image( $pic_id, false, false, false, $new_title );
 					}
 				}
-				nggGallery::show_message( __('Image title updated', 'nggallery') );
+				nggGallery::show_message( __( 'Image title updated', 'nggallery' ) );
 
 				return;
 			case 'set_descr':
 				$new_descr = $_POST['text'];
 				if ( is_array( $list ) ) {
 					foreach ( $list as $pic_id ) {
-						nggdb::update_image($pic_id, false, false, $new_descr);
+						nggdb::update_image( $pic_id, false, false, $new_descr );
 					}
 				}
-				nggGallery::show_message( __('Image description updated', 'nggallery') );
+				nggGallery::show_message( __( 'Image description updated', 'nggallery' ) );
 
 				return;
 			default:
@@ -471,9 +493,10 @@ abstract class NGG_Manager implements NGG_Displayable {
 		global $wpdb, $ngg;
 
 		$action = array_filter( array( $_POST['action'] => true,
-									   $_POST['action2'] => true,
-									   "-1" => false ));
-		$action = count( $action ) === 1 ? key( $action ) : '';
+			$_POST['action2'] => true,
+			"-1" => false ) );
+
+		$action = count( $action ) === 1 ? array_key_first( $action ) : '';
 		$action = sanitize_text_field( $action );
 
 		if ( $action === "delete_gallery" ) {

--- a/lib/core.php
+++ b/lib/core.php
@@ -1,31 +1,31 @@
 <?php
 /**
-* Main PHP class for the WordPress plugin NextGEN Gallery
-*
-* @author Alex Rabe
-*
-*
-*/
+ * Main PHP class for the WordPress plugin NextGEN Gallery
+ *
+ * @author Alex Rabe
+ *
+ *
+ */
 class nggGallery {
 
 	/**
-	* Show a error messages
-	*/
-	static function show_error($message) {
+	 * Show a error messages
+	 */
+	static function show_error( $message ) {
 		echo '<div class="error" id="error"><p>' . $message . '</p></div>';
 	}
 
 	/**
-	* Show a system messages
-	*/
-	static function show_message($message) {
+	 * Show a system messages
+	 */
+	static function show_message( $message ) {
 		echo '<div class="updated fade" id="message"><p>' . $message . '</p></div>';
 	}
 
 	/**
-	* get the thumbnail url to the image
-	*/
-	static function get_thumbnail_url($imageID, $picturepath = '', $fileName = ''){
+	 * get the thumbnail url to the image
+	 */
+	static function get_thumbnail_url( $imageID, $picturepath = '', $fileName = '' ) {
 
 		// get the complete url to the thumbnail
 		global $wpdb;
@@ -34,72 +34,72 @@ class nggGallery {
 		$imageID = (int) $imageID;
 
 		// get gallery values
-		if ( empty($fileName) ) {
-			list($fileName, $picturepath ) = $wpdb->get_row("SELECT p.filename, g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' ", ARRAY_N);
+		if ( empty ( $fileName ) ) {
+			list( $fileName, $picturepath ) = $wpdb->get_row( "SELECT p.filename, g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' ", ARRAY_N );
 		}
 
-		if ( empty($picturepath) ) {
-			$picturepath = $wpdb->get_var("SELECT g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' ");
+		if ( empty ( $picturepath ) ) {
+			$picturepath = $wpdb->get_var( "SELECT g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' " );
 		}
 
 		// set gallery url
-		$folder_url 	= site_url() . '/' . $picturepath.nggGallery::get_thumbnail_folder($picturepath, FALSE);
-		$thumbnailURL	= $folder_url . 'thumbs_' . $fileName;
+		$folder_url = site_url() . '/' . $picturepath . nggGallery::get_thumbnail_folder( $picturepath, FALSE );
+		$thumbnailURL = $folder_url . 'thumbs_' . $fileName;
 
 		return $thumbnailURL;
 	}
 
 	/**
-	* get the complete url to the image
-	*/
-	static function get_image_url($imageID, $picturepath = '', $fileName = '') {
+	 * get the complete url to the image
+	 */
+	static function get_image_url( $imageID, $picturepath = '', $fileName = '' ) {
 		global $wpdb;
 
 		// safety first
 		$imageID = (int) $imageID;
 
 		// get gallery values
-		if (empty($fileName)) {
-			list($fileName, $picturepath ) = $wpdb->get_row("SELECT p.filename, g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' ", ARRAY_N);
+		if ( empty ( $fileName ) ) {
+			list( $fileName, $picturepath ) = $wpdb->get_row( "SELECT p.filename, g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' ", ARRAY_N );
 		}
 
-		if (empty($picturepath)) {
-			$picturepath = $wpdb->get_var("SELECT g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' ");
+		if ( empty ( $picturepath ) ) {
+			$picturepath = $wpdb->get_var( "SELECT g.path FROM $wpdb->nggpictures AS p INNER JOIN $wpdb->nggallery AS g ON (p.galleryid = g.gid) WHERE p.pid = '$imageID' " );
 		}
 
 		// set gallery url
-		$imageURL 	= site_url() . '/' . $picturepath . '/' . $fileName;
+		$imageURL = site_url() . '/' . $picturepath . '/' . $fileName;
 
 		return $imageURL;
 	}
 
 	/**
-	* nggGallery::get_thumbnail_folder()
-	*
-	* @param mixed $gallerypath
-	* @param bool $include_Abspath
-	* @return string $foldername
-	*/
-	static function create_thumbnail_folder($gallerypath, $include_Abspath = TRUE) {
-		if (!$include_Abspath) {
+	 * nggGallery::get_thumbnail_folder()
+	 *
+	 * @param mixed $gallerypath
+	 * @param bool $include_Abspath
+	 * @return string $foldername
+	 */
+	static function create_thumbnail_folder( $gallerypath, $include_Abspath = TRUE ) {
+		if ( ! $include_Abspath ) {
 			$gallerypath = WINABSPATH . $gallerypath;
 		}
 
-		if (!file_exists($gallerypath)) {
+		if ( ! file_exists( $gallerypath ) ) {
 			return FALSE;
 		}
 
-		if (is_dir($gallerypath . '/thumbs/')) {
+		if ( is_dir( $gallerypath . '/thumbs/' ) ) {
 			return '/thumbs/';
 		}
 
-		if (is_admin()) {
-			if (!is_dir($gallerypath . '/thumbs/')) {
-				if ( !wp_mkdir_p($gallerypath . '/thumbs/') ) {
-					if (SAFE_MODE) {
-						nggAdmin::check_safemode($gallerypath . '/thumbs/');
+		if ( is_admin() ) {
+			if ( ! is_dir( $gallerypath . '/thumbs/' ) ) {
+				if ( ! wp_mkdir_p( $gallerypath . '/thumbs/' ) ) {
+					if ( SAFE_MODE ) {
+						nggAdmin::check_safemode( $gallerypath . '/thumbs/' );
 					} else {
-						nggGallery::show_error(__('Unable to create directory ', 'nggallery') . $gallerypath . '/thumbs !');
+						nggGallery::show_error( __( 'Unable to create directory ', 'nggallery' ) . $gallerypath . '/thumbs !' );
 					}
 					return FALSE;
 				}
@@ -112,103 +112,103 @@ class nggGallery {
 	}
 
 	/**
-	* nggGallery::get_thumbnail_folder()
-	*
-	* @param mixed $gallerypath
-	* @param bool $include_Abspath
-	* @deprecated use create_thumbnail_folder() if needed;
-	* @return string $foldername
-	*/
-	static function get_thumbnail_folder($gallerypath, $include_Abspath = TRUE) {
-		return nggGallery::create_thumbnail_folder($gallerypath, $include_Abspath);
+	 * nggGallery::get_thumbnail_folder()
+	 *
+	 * @param mixed $gallerypath
+	 * @param bool $include_Abspath
+	 * @deprecated use create_thumbnail_folder() if needed;
+	 * @return string $foldername
+	 */
+	static function get_thumbnail_folder( $gallerypath, $include_Abspath = TRUE ) {
+		return nggGallery::create_thumbnail_folder( $gallerypath, $include_Abspath );
 	}
 
 	/**
-	* nggGallery::get_thumbnail_prefix() - obsolete
-	*
-	* @param string $gallerypath
-	* @param bool   $include_Abspath
-	* @deprecated prefix is now fixed to "thumbs_";
-	* @return string  "thumbs_";
-	*/
-	static function get_thumbnail_prefix($gallerypath, $include_Abspath = TRUE) {
+	 * nggGallery::get_thumbnail_prefix() - obsolete
+	 *
+	 * @param string $gallerypath
+	 * @param bool   $include_Abspath
+	 * @deprecated prefix is now fixed to "thumbs_";
+	 * @return string  "thumbs_";
+	 */
+	static function get_thumbnail_prefix( $gallerypath, $include_Abspath = TRUE ) {
 		return 'thumbs_';
 	}
 
 	/**
-	* nggGallery::get_option() - get the options and overwrite them with custom meta settings
-	*
-	* @param string $key
-	* @return array $options
-	*/
-	static function get_option($key) {
-        global $post;
+	 * nggGallery::get_option() - get the options and overwrite them with custom meta settings
+	 *
+	 * @param string $key
+	 * @return array $options
+	 */
+	static function get_option( $key ) {
+		global $post;
 
 		// get first the options from the database
-		$options = get_option($key);
+		$options = get_option( $key );
 
-        if ( $post == null )
-            return $options;
+		if ( $post == null )
+			return $options;
 
 		// Get all key/value data for the current post.
 		$meta_array = get_post_custom();
 
 		// Ensure that this is a array
-		if ( !is_array($meta_array) )
-			$meta_array = array($meta_array);
+		if ( ! is_array( $meta_array ) )
+			$meta_array = array( $meta_array );
 
 		// assign meta key to db setting key
 		$meta_tags = array(
 			'string' => array(
-				'ngg_gal_ShowOrder' 		=> 'galShowOrder',
-				'ngg_gal_Sort' 				=> 'galSort',
-				'ngg_gal_SortDirection' 	=> 'galSortDir',
-				'ngg_gal_ShowDescription'	=> 'galShowDesc',
-				'ngg_ir_Audio' 				=> 'irAudio',
-				'ngg_ir_Overstretch'		=> 'irOverstretch',
-				'ngg_ir_Transition'			=> 'irTransition',
-				'ngg_ir_Backcolor' 			=> 'irBackcolor',
-				'ngg_ir_Frontcolor' 		=> 'irFrontcolor',
-				'ngg_ir_Lightcolor' 		=> 'irLightcolor',
-                'ngg_slideshowFX'			=> 'slideFx',
+				'ngg_gal_ShowOrder' => 'galShowOrder',
+				'ngg_gal_Sort' => 'galSort',
+				'ngg_gal_SortDirection' => 'galSortDir',
+				'ngg_gal_ShowDescription' => 'galShowDesc',
+				'ngg_ir_Audio' => 'irAudio',
+				'ngg_ir_Overstretch' => 'irOverstretch',
+				'ngg_ir_Transition' => 'irTransition',
+				'ngg_ir_Backcolor' => 'irBackcolor',
+				'ngg_ir_Frontcolor' => 'irFrontcolor',
+				'ngg_ir_Lightcolor' => 'irLightcolor',
+				'ngg_slideshowFX' => 'slideFx',
 			),
 
 			'int' => array(
-				'ngg_gal_Images' 			=> 'galImages',
-				'ngg_gal_Columns'			=> 'galColumns',
-				'ngg_paged_Galleries'		=> 'galPagedGalleries',
-				'ngg_ir_Width' 				=> 'irWidth',
-				'ngg_ir_Height' 			=> 'irHeight',
-				'ngg_ir_Rotatetime' 		=> 'irRotatetime'
+				'ngg_gal_Images' => 'galImages',
+				'ngg_gal_Columns' => 'galColumns',
+				'ngg_paged_Galleries' => 'galPagedGalleries',
+				'ngg_ir_Width' => 'irWidth',
+				'ngg_ir_Height' => 'irHeight',
+				'ngg_ir_Rotatetime' => 'irRotatetime'
 			),
 
 			'bool' => array(
-				'ngg_gal_ShowSlide'			=> 'galShowSlide',
-				'ngg_gal_ShowPiclense'		=> 'usePicLens',
-				'ngg_gal_ImageBrowser' 		=> 'galImgBrowser',
-				'ngg_gal_HideImages' 		=> 'galHiddenImg',
-				'ngg_ir_Shuffle' 			=> 'irShuffle',
-				'ngg_ir_LinkFromDisplay' 	=> 'irLinkfromdisplay',
-				'ngg_ir_ShowNavigation'		=> 'irShownavigation',
-				'ngg_ir_ShowWatermark' 		=> 'irWatermark',
-				'ngg_ir_Kenburns' 			=> 'irKenburns'
+				'ngg_gal_ShowSlide' => 'galShowSlide',
+				'ngg_gal_ShowPiclense' => 'usePicLens',
+				'ngg_gal_ImageBrowser' => 'galImgBrowser',
+				'ngg_gal_HideImages' => 'galHiddenImg',
+				'ngg_ir_Shuffle' => 'irShuffle',
+				'ngg_ir_LinkFromDisplay' => 'irLinkfromdisplay',
+				'ngg_ir_ShowNavigation' => 'irShownavigation',
+				'ngg_ir_ShowWatermark' => 'irWatermark',
+				'ngg_ir_Kenburns' => 'irKenburns'
 			)
 		);
 
-		foreach ($meta_tags as $typ => $meta_keys){
-			foreach ($meta_keys as $key => $db_value){
+		foreach ( $meta_tags as $typ => $meta_keys ) {
+			foreach ( $meta_keys as $key => $db_value ) {
 				// if the kex exist overwrite it with the custom field
-				if (array_key_exists($key, $meta_array)){
-					switch ($typ) {
-					case 'string':
-						$options[$db_value] = (string) esc_attr($meta_array[$key][0]);
-						break;
-					case 'int':
-						$options[$db_value] = (int) $meta_array[$key][0];
-						break;
-					case 'bool':
-						$options[$db_value] = (bool) $meta_array[$key][0];
-						break;
+				if ( array_key_exists( $key, $meta_array ) ) {
+					switch ( $typ ) {
+						case 'string':
+							$options[ $db_value ] = (string) esc_attr( $meta_array[ $key ][0] );
+							break;
+						case 'int':
+							$options[ $db_value ] = (int) $meta_array[ $key ][0];
+							break;
+						case 'bool':
+							$options[ $db_value ] = (bool) $meta_array[ $key ][0];
+							break;
 					}
 				}
 			}
@@ -218,24 +218,24 @@ class nggGallery {
 	}
 
 	/**
-	* nggGallery::scale_image() - Scale down a image
-	*
-	* @param mixed $location (filename)
-	* @param int $maxw - max width
-	* @param int $maxh -  max height
-	* @return array (width, heigth)
-	*/
-	static function scale_image($location, $maxw = 0, $maxh = 0){
-		$img = @getimagesize($location);
-		if ($img){
+	 * nggGallery::scale_image() - Scale down a image
+	 *
+	 * @param mixed $location (filename)
+	 * @param int $maxw - max width
+	 * @param int $maxh -  max height
+	 * @return array (width, heigth)
+	 */
+	static function scale_image( $location, $maxw = 0, $maxh = 0 ) {
+		$img = @getimagesize( $location );
+		if ( $img ) {
 			$w = $img[0];
 			$h = $img[1];
 
-			$dim = array('w','h');
-			foreach($dim AS $val) {
+			$dim = array( 'w', 'h' );
+			foreach ( $dim as $val ) {
 				$max = "max{$val}";
-				if(${$val} > ${$max} && ${$max}){
-					$alt = ($val == 'w') ? 'h' : 'w';
+				if ( ${$val} > ${$max} && ${$max} ) {
+					$alt = ( $val == 'w' ) ? 'h' : 'w';
 					$ratio = ${$alt} / ${$val};
 					${$val} = ${$max};
 					${$alt} = ${$val} * $ratio;
@@ -248,59 +248,59 @@ class nggGallery {
 	}
 
 	/**
-	* Renders a section of user display code.  The code is first checked for in the current theme display directory
-	* before defaulting to the plugin
-	* Call the function :	nggGallery::render ('template_name', array ('var1' => $var1, 'var2' => $var2));
-	*
-	* @autor John Godley
-	* @param string $template_name Name of the template file (without extension)
-	* @param string $vars Array of variable name=>value that is available to the display code (optional)
-	* @param bool $callback In case we check we didn't find template we tested it one time more (optional)
-	* @return void
-	**/
-	static function render($template_name, $vars = array (), $callback = false) {
-		foreach ($vars AS $key => $val) {
+	 * Renders a section of user display code.  The code is first checked for in the current theme display directory
+	 * before defaulting to the plugin
+	 * Call the function :	nggGallery::render ('template_name', array ('var1' => $var1, 'var2' => $var2));
+	 *
+	 * @autor John Godley
+	 * @param string $template_name Name of the template file (without extension)
+	 * @param string $vars Array of variable name=>value that is available to the display code (optional)
+	 * @param bool $callback In case we check we didn't find template we tested it one time more (optional)
+	 * @return void
+	 **/
+	static function render( $template_name, $vars = array(), $callback = false ) {
+		foreach ( $vars as $key => $val ) {
 			$$key = $val;
 		}
 
 		// hook into the render feature to allow other plugins to include templates
 		$custom_template = apply_filters( 'ngg_render_template', false, $template_name );
 
-		if ( ( $custom_template != false ) &&  file_exists ($custom_template) ) {
+		if ( ( $custom_template != false ) && file_exists( $custom_template ) ) {
 			include ( $custom_template );
-		//search in theme folder
-		} elseif (file_exists (get_stylesheet_directory() . "/nggallery/$template_name.php")) {
-			include (get_stylesheet_directory() . "/nggallery/$template_name.php");
-		//search in WP_CONTENT_DIR
-		} elseif (file_exists (WP_CONTENT_DIR . "/ngg_styles/$template_name.php")) {
-			include (WP_CONTENT_DIR . "/ngg_styles/$template_name.php");
-		//use defaults
-		} elseif (file_exists (NGGALLERY_ABSPATH . "/view/$template_name.php")) {
-			include (NGGALLERY_ABSPATH . "/view/$template_name.php");
+			//search in theme folder
+		} elseif ( file_exists( get_stylesheet_directory() . "/nggallery/$template_name.php" ) ) {
+			include ( get_stylesheet_directory() . "/nggallery/$template_name.php" );
+			//search in WP_CONTENT_DIR
+		} elseif ( file_exists( WP_CONTENT_DIR . "/ngg_styles/$template_name.php" ) ) {
+			include ( WP_CONTENT_DIR . "/ngg_styles/$template_name.php" );
+			//use defaults
+		} elseif ( file_exists( NGGALLERY_ABSPATH . "/view/$template_name.php" ) ) {
+			include ( NGGALLERY_ABSPATH . "/view/$template_name.php" );
 		} elseif ( $callback === true ) {
-            echo "<p>Rendering of template $template_name.php failed</p>";
+			echo "<p>Rendering of template $template_name.php failed</p>";
 		} else {
-            //test without the "-template" name one time more
+			//test without the "-template" name one time more
 
-            $explode = explode('-', $template_name, 2);
-            $template_name = array_shift($explode);
-            nggGallery::render ($template_name, $vars , true);
+			$explode = explode( '-', $template_name, 2 );
+			$template_name = array_shift( $explode );
+			nggGallery::render( $template_name, $vars, true );
 		}
 	}
 
 	/**
-	* Captures an section of user display code.
-	*
-	* @autor John Godley
-	* @param string $template_name Name of the template file (without extension)
-	* @param string $vars Array of variable name=>value that is available to the display code (optional)
-	* @return string
-	**/
-	static function capture ($template_name, $vars = array ()) {
-		ob_start ();
-		nggGallery::render ($template_name, $vars);
-		$output = ob_get_contents ();
-		ob_end_clean ();
+	 * Captures an section of user display code.
+	 *
+	 * @autor John Godley
+	 * @param string $template_name Name of the template file (without extension)
+	 * @param array $vars Array of variable name=>value that is available to the display code (optional)
+	 * @return string
+	 **/
+	static function capture( $template_name, $vars = array() ) {
+		ob_start();
+		nggGallery::render( $template_name, $vars );
+		$output = ob_get_contents();
+		ob_end_clean();
 
 		return $output;
 	}
@@ -312,9 +312,9 @@ class nggGallery {
 	 */
 	static function graphic_library() {
 
-		$ngg_options = get_option('ngg_options');
+		$ngg_options = get_option( 'ngg_options' );
 
-		if ( $ngg_options['graphicLibrary'] == 'im')
+		if ( $ngg_options['graphicLibrary'] == 'im' )
 			return NGGALLERY_ABSPATH . '/lib/imagemagick.inc.php';
 		else
 			return NGGALLERY_ABSPATH . '/lib/gd.thumbnail.inc.php';
@@ -322,38 +322,38 @@ class nggGallery {
 	}
 
 
-    /**
-     * Find where is the gallery stylesheet located.
-     *
-     * Combines several techniques to find out where is the current
-     * gallery stylesheet located.
-     * 20140924: Simplification & Documentation
-     * 20140924: included
-     *
-     * @since 1.9.13
-     * @access static
-     *
-     * @see (none)
-     * @link Filter List http://wpgetready.com/wiki/nextcellent-plugin/nextcellent-filter-list/
-     * @global type $varname Short description.
-     *
-     * @param (none)
-     *
-     * @return bool|mixed|string|void
-     */
+	/**
+	 * Find where is the gallery stylesheet located.
+	 *
+	 * Combines several techniques to find out where is the current
+	 * gallery stylesheet located.
+	 * 20140924: Simplification & Documentation
+	 * 20140924: included
+	 *
+	 * @since 1.9.13
+	 * @access static
+	 *
+	 * @see (none)
+	 * @link Filter List http://wpgetready.com/wiki/nextcellent-plugin/nextcellent-filter-list/
+	 * @global type $varname Short description.
+	 *
+	 * @param (none)
+	 *
+	 * @return bool|mixed|string|void
+	 */
 
 	static function get_theme_css_file() {
-  		//Allow to include a custom stylesheet, return stylesheet uri
+		//Allow to include a custom stylesheet, return stylesheet uri
 		$stylesheet = apply_filters( 'ngg_load_stylesheet', false );
-        //Is there a stylsheet customization?
+		//Is there a stylsheet customization?
 		if ( $stylesheet !== false ) {
-            return ($stylesheet); //Yes, return it
-        }
-        //No filter customization. Is the user putting a custom stylesheet on his/her theme?
-        if ( file_exists (get_stylesheet_directory() . '/nggallery.css') ) {
-            return get_stylesheet_directory_uri() . '/nggallery.css'; //Yes, return uri to the custom style
-        }
-        //No filter and no custom style. Bye bye
+			return ( $stylesheet ); //Yes, return it
+		}
+		//No filter customization. Is the user putting a custom stylesheet on his/her theme?
+		if ( file_exists( get_stylesheet_directory() . '/nggallery.css' ) ) {
+			return get_stylesheet_directory_uri() . '/nggallery.css'; //Yes, return uri to the custom style
+		}
+		//No filter and no custom style. Bye bye
 		return false;
 	}
 
@@ -364,38 +364,38 @@ class nggGallery {
 	 * @param string $name (optional) required for wpml to determine the type of translation
 	 * @return string $in localized
 	 */
-	static function i18n($in, $name = null) {
+	static function i18n( $in, $name = null ) {
 
 		if ( function_exists( 'langswitch_filter_langs_with_message' ) )
-			$in = langswitch_filter_langs_with_message($in);
+			$in = langswitch_filter_langs_with_message( $in );
 
-		if ( function_exists( 'polyglot_filter' ))
-			$in = polyglot_filter($in);
+		if ( function_exists( 'polyglot_filter' ) )
+			$in = polyglot_filter( $in );
 
-		if ( function_exists( 'qtrans_useCurrentLanguageIfNotFoundUseDefaultLanguage' ))
-			$in = qtrans_useCurrentLanguageIfNotFoundUseDefaultLanguage($in);
+		if ( function_exists( 'qtrans_useCurrentLanguageIfNotFoundUseDefaultLanguage' ) )
+			$in = qtrans_useCurrentLanguageIfNotFoundUseDefaultLanguage( $in );
 
-        if (is_string($name) && !empty($name) && function_exists('icl_translate'))
-            $in = icl_translate('plugin_ngg', $name, $in, true);
+		if ( is_string( $name ) && ! empty ( $name ) && function_exists( 'icl_translate' ) )
+			$in = icl_translate( 'plugin_ngg', $name, $in, true );
 
-		$in = apply_filters('localization', $in);
+		$in = apply_filters( 'localization', $in );
 
 		return $in;
 	}
 
-    /**
-     * This function register strings for the use with WPML plugin (see http://wpml.org/ )
-     *
-     * @param object $image
-     * @return void
-     */
-    static function RegisterString($image) {
-        if (function_exists('icl_register_string')) {
-            global $wpdb;
-            icl_register_string('plugin_ngg', 'pic_' . $image->pid . '_description', $image->description, TRUE);
-            icl_register_string('plugin_ngg', 'pic_' . $image->pid . '_alttext', $image->alttext, TRUE);
-        }
-    }
+	/**
+	 * This function register strings for the use with WPML plugin (see http://wpml.org/ )
+	 *
+	 * @param object $image
+	 * @return void
+	 */
+	static function RegisterString( $image ) {
+		if ( function_exists( 'icl_register_string' ) ) {
+			global $wpdb;
+			icl_register_string( 'plugin_ngg', 'pic_' . $image->pid . '_description', $image->description, TRUE );
+			icl_register_string( 'plugin_ngg', 'pic_' . $image->pid . '_alttext', $image->alttext, TRUE );
+		}
+	}
 
 	/**
 	 * Check the memory_limit and calculate a recommended memory size
@@ -405,31 +405,31 @@ class nggGallery {
 	 */
 	static function check_memory_limit() {
 
-		if ( (function_exists('memory_get_usage')) && (ini_get('memory_limit')) ) {
+		if ( ( function_exists( 'memory_get_usage' ) ) && ( ini_get( 'memory_limit' ) ) ) {
 
 			// get memory limit
-			$memory_limit = ini_get('memory_limit');
-			if ($memory_limit != '')
-				$memory_limit = intval(substr($memory_limit, 0, -1)) * 1024 * 1024;
+			$memory_limit = ini_get( 'memory_limit' );
+			if ( $memory_limit != '' )
+				$memory_limit = intval( substr( $memory_limit, 0, -1 ) ) * 1024 * 1024;
 
 			// calculate the free memory
 			$freeMemory = $memory_limit - memory_get_usage();
 
 			// build the test sizes
 			$sizes = array();
-			$sizes[] = array ( 'width' => 800,  'height' => 600);
-			$sizes[] = array ( 'width' => 1024, 'height' => 768);
-			$sizes[] = array ( 'width' => 1280, 'height' => 960);  // 1MP
-			$sizes[] = array ( 'width' => 1600, 'height' => 1200); // 2MP
-			$sizes[] = array ( 'width' => 2016, 'height' => 1512); // 3MP
-			$sizes[] = array ( 'width' => 2272, 'height' => 1704); // 4MP
-			$sizes[] = array ( 'width' => 2560, 'height' => 1920); // 5MP
+			$sizes[] = array( 'width' => 800, 'height' => 600 );
+			$sizes[] = array( 'width' => 1024, 'height' => 768 );
+			$sizes[] = array( 'width' => 1280, 'height' => 960 );  // 1MP
+			$sizes[] = array( 'width' => 1600, 'height' => 1200 ); // 2MP
+			$sizes[] = array( 'width' => 2016, 'height' => 1512 ); // 3MP
+			$sizes[] = array( 'width' => 2272, 'height' => 1704 ); // 4MP
+			$sizes[] = array( 'width' => 2560, 'height' => 1920 ); // 5MP
 
 			// test the classic sizes
-			foreach ($sizes as $size){
+			foreach ( $sizes as $size ) {
 				// very, very rough estimation
-				if ($freeMemory < round( $size['width'] * $size['height'] * 5.09 )) {
-                	$result = sprintf(  __( 'Note : Based on your server memory limit you should not upload larger images then <strong>%d x %d</strong> pixel', 'nggallery' ), $size['width'], $size['height']);
+				if ( $freeMemory < round( $size['width'] * $size['height'] * 5.09 ) ) {
+					$result = sprintf( __( 'Note : Based on your server memory limit you should not upload larger images then <strong>%d x %d</strong> pixel', 'nggallery' ), $size['width'], $size['height'] );
 					return $result;
 				}
 			}
@@ -446,22 +446,22 @@ class nggGallery {
 	static function fileinfo( $name ) {
 
 		//Sanitizes a filename replacing whitespace with dashes
-		$name = sanitize_file_name($name);
+		$name = sanitize_file_name( $name );
 
 		//get the parts of the name
-		$filepart = pathinfo ( strtolower($name) );
+		$filepart = pathinfo( strtolower( $name ) );
 
-		if ( empty($filepart) )
+		if ( empty ( $filepart ) )
 			return false;
 
 		// required until PHP 5.2.0
-		if ( empty($filepart['filename']) )
-			$filepart['filename'] = substr($filepart['basename'],0 ,strlen($filepart['basename']) - (strlen($filepart['extension']) + 1) );
+		if ( empty ( $filepart['filename'] ) )
+			$filepart['filename'] = substr( $filepart['basename'], 0, strlen( $filepart['basename'] ) - ( strlen( $filepart['extension'] ) + 1 ) );
 
 		$filepart['filename'] = sanitize_title_with_dashes( $filepart['filename'] );
 
 		//extension jpeg will not be recognized by the slideshow, so we rename it
-		$filepart['extension'] = ($filepart['extension'] == 'jpeg') ? 'jpg' : $filepart['extension'];
+		$filepart['extension'] = ( $filepart['extension'] == 'jpeg' ) ? 'jpg' : $filepart['extension'];
 
 		//combine the new file name
 		$filepart['basename'] = $filepart['filename'] . '.' . $filepart['extension'];
@@ -480,8 +480,8 @@ class nggGallery {
 
 		global $_ngg_capabilites;
 
-		if ( is_array($_ngg_capabilites) )
-			if ( in_array($capability , $_ngg_capabilites) )
+		if ( is_array( $_ngg_capabilites ) )
+			if ( in_array( $capability, $_ngg_capabilites ) )
 				return current_user_can( $capability );
 
 		return true;
@@ -496,7 +496,7 @@ class nggGallery {
 	 */
 	static function current_user_can_form( $capability ) {
 
-		if ( !nggGallery::current_user_can( $capability ))
+		if ( ! nggGallery::current_user_can( $capability ) )
 			echo 'disabled="disabled"';
 	}
 
@@ -508,120 +508,120 @@ class nggGallery {
 	 * @param bool $register the new capability automatic to the admin role
 	 * @return void
 	 */
-	static function add_capabilites( $capability , $register = true ) {
+	static function add_capabilites( $capability, $register = true ) {
 		global $_ngg_capabilites;
 
-		if ( !is_array($_ngg_capabilites) )
+		if ( ! is_array( $_ngg_capabilites ) )
 			$_ngg_capabilites = array();
 
 		$_ngg_capabilites[] = $capability;
 
 		if ( $register ) {
-			$role = get_role('administrator');
-			if ( !empty($role) )
+			$role = get_role( 'administrator' );
+			if ( ! empty ( $role ) )
 				$role->add_cap( $capability );
 		}
 
 	}
 
-    /**
-     * Check for mobile user agent
-     *
-     * @since 1.6.0
-     * @author Part taken from WPtouch plugin (http://www.bravenewcode.com)
-     * @return bool $result of  check
-     */
-    static function detect_mobile_phone() {
+	/**
+	 * Check for mobile user agent
+	 *
+	 * @since 1.6.0
+	 * @author Part taken from WPtouch plugin (http://www.bravenewcode.com)
+	 * @return bool $result of  check
+	 */
+	static function detect_mobile_phone() {
 
-        $useragents = array();
+		$useragents = array();
 
-        // Check if WPtouch is running
-        if ( function_exists('bnc_wptouch_get_user_agents') )
-            $useragents = bnc_wptouch_get_user_agents();
-        else {
-        	$useragents = array(
-                "iPhone",  			 // Apple iPhone
-        		"iPod", 			 // Apple iPod touch
-        		"Android", 			 // 1.5+ Android
-        		"dream", 		     // Pre 1.5 Android
-        		"CUPCAKE", 			 // 1.5+ Android
-        		"blackberry9500",	 // Storm
-        		"blackberry9530",	 // Storm
-        		"blackberry9520",	 // Storm	v2
-        		"blackberry9550",	 // Storm v2
-        		"blackberry9800",	 // Torch
-        		"webOS",			 // Palm Pre Experimental
-        		"incognito", 		 // Other iPhone browser
-        		"webmate" 			 // Other iPhone browser
-        	);
+		// Check if WPtouch is running
+		if ( function_exists( 'bnc_wptouch_get_user_agents' ) )
+			$useragents = bnc_wptouch_get_user_agents();
+		else {
+			$useragents = array(
+				"iPhone",  			 // Apple iPhone
+				"iPod", 			 // Apple iPod touch
+				"Android", 			 // 1.5+ Android
+				"dream", 		     // Pre 1.5 Android
+				"CUPCAKE", 			 // 1.5+ Android
+				"blackberry9500",	 // Storm
+				"blackberry9530",	 // Storm
+				"blackberry9520",	 // Storm	v2
+				"blackberry9550",	 // Storm v2
+				"blackberry9800",	 // Torch
+				"webOS",			 // Palm Pre Experimental
+				"incognito", 		 // Other iPhone browser
+				"webmate" 			 // Other iPhone browser
+			);
 
-        	asort( $useragents );
-         }
+			asort( $useragents );
+		}
 
-        // Godfather Steve says no to flash
-        if ( is_array($useragents) )
-            $useragents[] = "iPad";  // Apple iPad;
+		// Godfather Steve says no to flash
+		if ( is_array( $useragents ) )
+			$useragents[] = "iPad";  // Apple iPad;
 
-        // WPtouch User Agent Filter
-        $useragents = apply_filters( 'wptouch_user_agents', $useragents );
+		// WPtouch User Agent Filter
+		$useragents = apply_filters( 'wptouch_user_agents', $useragents );
 
- 		foreach ( $useragents as $useragent ) {
+		foreach ( $useragents as $useragent ) {
 			if ( preg_match( "#$useragent#i", $_SERVER['HTTP_USER_AGENT'] ) )
 				return true;
 		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * get_memory_usage
-     *
-     * @access only for debug purpose
-     * @since 1.8.3
-     * @param string $text
-     * @return void
-     */
-    static function get_memory( $text = '' ) {
-        global $memory;
+	/**
+	 * get_memory_usage
+	 *
+	 * @access only for debug purpose
+	 * @since 1.8.3
+	 * @param string $text
+	 * @return void
+	 */
+	static function get_memory( $text = '' ) {
+		global $memory;
 
-        $memory_peak = memory_get_usage();
-        $diff = 0;
+		$memory_peak = memory_get_usage();
+		$diff = 0;
 
-		if ( isset($memory) )
-            $diff = $memory_peak - $memory;
+		if ( isset ( $memory ) )
+			$diff = $memory_peak - $memory;
 
-        $exp = ($diff < 0) ? '-' : '';
-        $diff = ($exp == '-') ? 0 - $diff : $diff;
+		$exp = ( $diff < 0 ) ? '-' : '';
+		$diff = ( $exp == '-' ) ? 0 - $diff : $diff;
 
-        $memory = $memory_peak;
+		$memory = $memory_peak;
 
-        $unit = array('b','kb','mb','gb','tb','pb');
-        $rounded = @round($diff/pow(1024,($i=floor(log($diff,1024)))),2).' '.$unit[$i];
+		$unit = array( 'b', 'kb', 'mb', 'gb', 'tb', 'pb' );
+		$rounded = @round( $diff / pow( 1024, ( $i = floor( log( $diff, 1024 ) ) ) ), 2 ) . ' ' . $unit[ $i ];
 
-        echo $text . ': ' . $exp . $rounded .'<br />';
+		echo $text . ': ' . $exp . $rounded . '<br />';
 
-    }
+	}
 
-    /**
-     * Show NextGEN Version in header
-     * @since 1.9.0
-     *
-     * @return void
-     */
-    static function nextgen_version() {
-        global $ngg;
-        echo apply_filters('show_nextgen_version', '<!-- <meta name="NextGEN" version="'. $ngg->version . '" /> -->' . "\n");
-    }
+	/**
+	 * Show NextGEN Version in header
+	 * @since 1.9.0
+	 *
+	 * @return void
+	 */
+	static function nextgen_version() {
+		global $ngg;
+		echo apply_filters( 'show_nextgen_version', '<!-- <meta name="NextGEN" version="' . $ngg->version . '" /> -->' . "\n" );
+	}
 
-    /**
-     * Prevents injection filtering HTML Code
-     * 20140604: Improved based on suggestions of jayque9
-     * http://wordpress.org/support/topic/prevent-removal-of-html-code-from-image-descriptions
-     */
-    static function suppress_injection
-    ($html_text) {
-        global $allowedposttags;
-        return wp_kses(stripslashes($html_text),$allowedposttags);
-    }
+	/**
+	 * Prevents injection filtering HTML Code
+	 * 20140604: Improved based on suggestions of jayque9
+	 * http://wordpress.org/support/topic/prevent-removal-of-html-code-from-image-descriptions
+	 */
+	static function suppress_injection
+	( $html_text ) {
+		global $allowedposttags;
+		return wp_kses( stripslashes( $html_text ), $allowedposttags );
+	}
 }
 ?>

--- a/lib/gd.thumbnail.inc.php
+++ b/lib/gd.thumbnail.inc.php
@@ -14,392 +14,395 @@
  *
  */
 class ngg_Thumbnail {
-    /**
-     * Error message to display, if any
-     *
-     * @var string
-     */
-    var $errmsg;
-    /**
-     * Whether or not there is an error
-     *
-     * @var boolean
-     */
-    var $error;
-    /**
-     * Format of the image file
-     *
-     * @var string
-     */
-    var $format;
-    /**
-     * File name and path of the image file
-     *
-     * @var string
-     */
-    var $fileName;
-    /**
-     * Current dimensions of working image
-     *
-     * @var array
-     */
-    var $currentDimensions;
-    /**
-     * New dimensions of working image
-     *
-     * @var array
-     */
-    var $newDimensions;
-    /**
-     * Image resource for newly manipulated image
-     *
-     * @var resource
-     * @access private
-     */
-    var $newImage;
-    /**
-     * Image resource for image before previous manipulation
-     *
-     * @var resource
-     * @access private
-     */
-    var $oldImage;
-    /**
-     * Image resource for image being currently manipulated
-     *
-     * @var resource
-     * @access private
-     */
-    var $workingImage;
-    /**
-     * Percentage to resize image by
-     *
-     * @var int
-     * @access private
-     */
-    var $percent;
-    /**
-     * Maximum width of image during resize
-     *
-     * @var int
-     * @access private
-     */
-    var $maxWidth;
-    /**
-     * Maximum height of image during resize
-     *
-     * @var int
-     * @access private
-     */
-    var $maxHeight;
-    /**
-     * Image for Watermark
-     *
-     * @var string
-     * 
-     */
-    var $watermarkImgPath;
-    /**
-     * Text for Watermark
-     *
-     * @var string
-     * 
-     */
-    var $watermarkText;
-    /**
-     * Image Resource ID for Watermark
-     *
-     * @var string
-     * 
-     */
-    function __construct($fileName,$no_ErrorImage = false) {
-        //make sure the GD library is installed
-    	if(!function_exists("gd_info")) {
-        	echo 'You do not have the GD Library installed.  This class requires the GD library to function properly.' . "\n";
-        	echo 'visit http://us2.php.net/manual/en/ref.image.php for more information';
-        	exit;
-        }
-    	//initialize variables
-        $this->errmsg               = '';
-        $this->error                = false;
-        $this->currentDimensions    = array();
-        $this->newDimensions        = array();
-        $this->fileName             = $fileName;
-        $this->percent              = 100;
-        $this->maxWidth             = 0;
-        $this->maxHeight            = 0;
-        $this->watermarkImgPath		= '';
-        $this->watermarkText		= '';
+	/**
+	 * Error message to display, if any
+	 *
+	 * @var string
+	 */
+	var $errmsg;
+	/**
+	 * Whether or not there is an error
+	 *
+	 * @var boolean
+	 */
+	var $error;
+	/**
+	 * Format of the image file
+	 *
+	 * @var string
+	 */
+	var $format;
+	/**
+	 * File name and path of the image file
+	 *
+	 * @var string
+	 */
+	var $fileName;
+	/**
+	 * Current dimensions of working image
+	 *
+	 * @var array
+	 */
+	var $currentDimensions;
+	/**
+	 * New dimensions of working image
+	 *
+	 * @var array
+	 */
+	var $newDimensions;
+	/**
+	 * Image resource for newly manipulated image
+	 *
+	 * @var resource
+	 * @access private
+	 */
+	var $newImage;
+	/**
+	 * Image resource for image before previous manipulation
+	 *
+	 * @var resource
+	 * @access private
+	 */
+	var $oldImage;
+	/**
+	 * Image resource for image being currently manipulated
+	 *
+	 * @var resource
+	 * @access private
+	 */
+	var $workingImage;
+	/**
+	 * Percentage to resize image by
+	 *
+	 * @var int
+	 * @access private
+	 */
+	var $percent;
+	/**
+	 * Maximum width of image during resize
+	 *
+	 * @var int
+	 * @access private
+	 */
+	var $maxWidth;
+	/**
+	 * Maximum height of image during resize
+	 *
+	 * @var int
+	 * @access private
+	 */
+	var $maxHeight;
+	/**
+	 * Image for Watermark
+	 *
+	 * @var string
+	 * 
+	 */
+	var $watermarkImgPath;
+	/**
+	 * Text for Watermark
+	 *
+	 * @var string
+	 * 
+	 */
+	var $watermarkText;
+	/**
+	 * Image Resource ID for Watermark
+	 *
+	 * @var string
+	 * 
+	 */
+	function __construct( $fileName, $no_ErrorImage = false ) {
+		//make sure the GD library is installed
+		if ( ! function_exists( "gd_info" ) ) {
+			echo 'You do not have the GD Library installed.  This class requires the GD library to function properly.' . "\n";
+			echo 'visit http://us2.php.net/manual/en/ref.image.php for more information';
+			exit;
+		}
+		//initialize variables
+		$this->errmsg = '';
+		$this->error = false;
+		$this->currentDimensions = array();
+		$this->newDimensions = array();
+		$this->fileName = $fileName;
+		$this->percent = 100;
+		$this->maxWidth = 0;
+		$this->maxHeight = 0;
+		$this->watermarkImgPath = '';
+		$this->watermarkText = '';
 
-        //check to see if file exists
-        if(!file_exists($this->fileName)) {
-            $this->errmsg = 'File not found';
-            $this->error = true;
-        }
-        //check to see if file is readable
-        elseif(!is_readable($this->fileName)) {
-            $this->errmsg = 'File is not readable';
-            $this->error = true;
-        }
-        
-        //if there are no errors, determine the file format
-        if($this->error == false) {
-    		$data = @getimagesize($this->fileName);
-    		if (isset($data) && is_array($data)) {
-    		  $extensions = array('1' => 'GIF', '2' => 'JPG', '3' => 'PNG');
-    		  $extension = array_key_exists($data[2], $extensions) ?  $extensions[$data[2]] : '';
-                if($extension) {
-                    $this->format = $extension;
-                } else {
-                    $this->errmsg = 'Unknown file format';
-                    $this->error = true;
-                }
-            } else {
-                $this->errmsg = 'File is not an image';
-                $this->error = true;
-            }
-        }
-        
+		//check to see if file exists
+		if ( ! file_exists( $this->fileName ) ) {
+			$this->errmsg = 'File not found';
+			$this->error = true;
+		}
+		//check to see if file is readable
+		elseif ( ! is_readable( $this->fileName ) ) {
+			$this->errmsg = 'File is not readable';
+			$this->error = true;
+		}
+
+		//if there are no errors, determine the file format
+		if ( $this->error == false ) {
+			$data = @getimagesize( $this->fileName );
+			if ( isset( $data ) && is_array( $data ) ) {
+				$extensions = array( '1' => 'GIF', '2' => 'JPG', '3' => 'PNG' );
+				$extension = array_key_exists( $data[2], $extensions ) ? $extensions[ $data[2] ] : '';
+				if ( $extension ) {
+					$this->format = $extension;
+				} else {
+					$this->errmsg = 'Unknown file format';
+					$this->error = true;
+				}
+			} else {
+				$this->errmsg = 'File is not an image';
+				$this->error = true;
+			}
+		}
+
 		// increase memory-limit if possible, GD needs this for large images
 		// @ini_set('memory_limit', '128M');
-        
-		if($this->error == false) { 
-        // Check memory consumption if file exists
-			$this->checkMemoryForImage($this->fileName);
+
+		if ( $this->error == false ) {
+			// Check memory consumption if file exists
+			$this->checkMemoryForImage( $this->fileName );
 		}
 
-        //initialize resources if no errors
-        if($this->error == false) { 
+		//initialize resources if no errors
+		if ( $this->error == false ) {
 
-            switch($this->format) {            	
-                case 'GIF':
-                    $this->oldImage = imagecreatefromgif($this->fileName);
-                    break;
-                case 'JPG':
-		    $this->oldImage = imagecreatefromjpeg($this->fileName);
-                    break;
-                case 'PNG':
-                    $this->oldImage = imagecreatefrompng($this->fileName);
+			switch ( $this->format ) {
+				case 'GIF':
+					$this->oldImage = imagecreatefromgif( $this->fileName );
 					break;
-            }
-			if (!$this->oldImage) { 
+				case 'JPG':
+					$this->oldImage = imagecreatefromjpeg( $this->fileName );
+					break;
+				case 'PNG':
+					$this->oldImage = imagecreatefrompng( $this->fileName );
+					break;
+			}
+			if ( ! $this->oldImage ) {
 				$this->errmsg = 'Create Image failed. Check memory limit';
-		        $this->error = true;
-		    } else {
-	            $size = GetImageSize($this->fileName);
-    	        $this->currentDimensions = array('width'=>$size[0],'height'=>$size[1]);
-	            $this->newImage = $this->oldImage;
-	        }
-        }
-
-
-        if($this->error == true) {
-        	if(!$no_ErrorImage)
-            	$this->showErrorImage();
-            return;
-        }
-    }
-
-    /**
-     * Calculate the memory limit
-     *
-     */
-	function checkMemoryForImage( $filename ){
-		
-		if ( (function_exists('memory_get_usage')) && (ini_get('memory_limit')) ) {
-			$imageInfo = getimagesize($filename);
-			switch($this->format) {            	
-                case 'GIF':
-                	// measured factor 1 is better
-                    $CHANNEL = 1;
-                    break;
-                case 'JPG':
-                    $CHANNEL = $imageInfo['channels'];
-                    break;
-                case 'PNG':
-					// didn't get the channel for png
-                    $CHANNEL = 3;
-					break;
-            }
-		    $MB = 1048576;  // number of bytes in 1M
-		    $K64 = 65536;    // number of bytes in 64K
-		    $TWEAKFACTOR = 1.68;  // Or whatever works for you
-		    $memoryNeeded = round( ( $imageInfo[0] * $imageInfo[1]
-		                                           * $imageInfo['bits']
-		                                           * $CHANNEL / 8
-		                             + $K64
-		                           ) * $TWEAKFACTOR
-		                         );
-		    $memoryNeeded = memory_get_usage() + $memoryNeeded;
-			// get memory limit
-			$memory_limit = ini_get('memory_limit');
-            
-            // PHP docs : Note that to have no memory limit, set this directive to -1.
-            if ($memory_limit == -1 ) return;
-            
-            // Just check megabyte limits, not higher
-            if ( strtolower(substr($memory_limit, -1)) == 'm' ) {
-                
-    			if ($memory_limit != '') {
-    				$memory_limit = substr($memory_limit, 0, -1) * 1024 * 1024;
-    			}
-    			
-    			if ($memoryNeeded > $memory_limit) {
-    				$memoryNeeded = round ($memoryNeeded / 1024 / 1024, 2);
-    				$this->errmsg = 'Exceed Memory limit. Require : '.$memoryNeeded. " MByte" ;
-    		        $this->error = true;
-    	        }
-            }
+				$this->error = true;
+			} else {
+				$size = GetImageSize( $this->fileName );
+				$this->currentDimensions = array( 'width' => $size[0], 'height' => $size[1] );
+				$this->newImage = $this->oldImage;
+			}
 		}
-	    return;
+
+
+		if ( $this->error == true ) {
+			if ( ! $no_ErrorImage )
+				$this->showErrorImage();
+			return;
+		}
 	}
 
-    /**
-     * Must be called to free up allocated memory after all manipulations are done
-     *
-     */
-    function destruct() {
-        if(is_resource($this->newImage)) @ImageDestroy($this->newImage);
-        if(is_resource($this->oldImage)) @ImageDestroy($this->oldImage);
-        if(is_resource($this->workingImage)) @ImageDestroy($this->workingImage);
-    }
+	/**
+	 * Calculate the memory limit
+	 *
+	 */
+	function checkMemoryForImage( $filename ) {
 
-    /**
-     * Returns the current width of the image
-     *
-     * @return int
-     */
-    function getCurrentWidth() {
-        return $this->currentDimensions['width'];
-    }
+		if ( ( function_exists( 'memory_get_usage' ) ) && ( ini_get( 'memory_limit' ) ) ) {
+			$imageInfo = getimagesize( $filename );
+			switch ( $this->format ) {
+				case 'GIF':
+					// measured factor 1 is better
+					$CHANNEL = 1;
+					break;
+				case 'JPG':
+					$CHANNEL = $imageInfo['channels'];
+					break;
+				case 'PNG':
+					// didn't get the channel for png
+					$CHANNEL = 3;
+					break;
+			}
+			$MB = 1048576;  // number of bytes in 1M
+			$K64 = 65536;    // number of bytes in 64K
+			$TWEAKFACTOR = 1.68;  // Or whatever works for you
+			$memoryNeeded = round( ( $imageInfo[0] * $imageInfo[1]
+				* $imageInfo['bits']
+				* $CHANNEL / 8
+				+ $K64
+			) * $TWEAKFACTOR
+			);
+			$memoryNeeded = memory_get_usage() + $memoryNeeded;
+			// get memory limit
+			$memory_limit = ini_get( 'memory_limit' );
 
-    /**
-     * Returns the current height of the image
-     *
-     * @return int
-     */
-    function getCurrentHeight() {
-        return $this->currentDimensions['height'];
-    }
+			// PHP docs : Note that to have no memory limit, set this directive to -1.
+			if ( $memory_limit == -1 )
+				return;
 
-    /**
-     * Calculates new image width
-     *
-     * @param int $width
-     * @param int $height
-     * @return array
-     */
-    function calcWidth($width,$height) {
-        $newWp = (100 * $this->maxWidth) / $width;
-        $newHeight = ($height * $newWp) / 100;
-        return array('newWidth'=>intval($this->maxWidth),'newHeight'=>intval($newHeight));
-    }
+			// Just check megabyte limits, not higher
+			if ( strtolower( substr( $memory_limit, -1 ) ) == 'm' ) {
 
-    /**
-     * Calculates new image height
-     *
-     * @param int $width
-     * @param int $height
-     * @return array
-     */
-    function calcHeight($width,$height) {
-        $newHp = (100 * $this->maxHeight) / $height;
-        $newWidth = ($width * $newHp) / 100;
-        return array('newWidth'=>intval($newWidth),'newHeight'=>intval($this->maxHeight));
-    }
+				if ( $memory_limit != '' ) {
+					$memory_limit = substr( $memory_limit, 0, -1 ) * 1024 * 1024;
+				}
 
-    /**
-     * Calculates new image size based on percentage
-     *
-     * @param int $width
-     * @param int $height
-     * @return array
-     */
-    function calcPercent($width,$height) {
-        $newWidth = ($width * $this->percent) / 100;
-        $newHeight = ($height * $this->percent) / 100;
-        return array('newWidth'=>intval($newWidth),'newHeight'=>intval($newHeight));
-    }
-
-    /**
-     * Calculates new image size based on width and height, while constraining to maxWidth and maxHeight
-     *
-     * @param int $width
-     * @param int $height
-     */
-    function calcImageSize($width,$height) {
-        $newSize = array('newWidth'=>$width,'newHeight'=>$height);
-
-        if($this->maxWidth > 0) {
-
-            $newSize = $this->calcWidth($width,$height);
-
-            if($this->maxHeight > 0 && $newSize['newHeight'] > $this->maxHeight) {
-                $newSize = $this->calcHeight($newSize['newWidth'],$newSize['newHeight']);
-            }
-
-            //$this->newDimensions = $newSize;
-        }
-
-        if($this->maxHeight > 0) {
-            $newSize = $this->calcHeight($width,$height);
-
-            if($this->maxWidth > 0 && $newSize['newWidth'] > $this->maxWidth) {
-                $newSize = $this->calcWidth($newSize['newWidth'],$newSize['newHeight']);
-            }
-
-            //$this->newDimensions = $newSize;
-        }
-
-        $this->newDimensions = $newSize;
-    }
-
-    /**
-     * Calculates new image size based percentage
-     *
-     * @param int $width
-     * @param int $height
-     */
-    function calcImageSizePercent($width,$height) {
-        if($this->percent > 0) {
-            $this->newDimensions = $this->calcPercent($width,$height);
-        }
-    }
-
-    /**
-     * Displays error image
-     *
-     */
-    function showErrorImage() {
-        header('Content-type: image/png');
-        $errImg = ImageCreate(220,25);
-        $bgColor = imagecolorallocate($errImg,0,0,0);
-        $fgColor1 = imagecolorallocate($errImg,255,255,255);
-        $fgColor2 = imagecolorallocate($errImg,255,0,0);
-        imagestring($errImg,3,6,6,'Error:',$fgColor2);
-        imagestring($errImg,3,55,6,$this->errmsg,$fgColor1);
-        imagepng($errImg);
-        imagedestroy($errImg);
-    }
-
-    /**
-     * Resizes image to fixed Width x Height
-     * 
-     * @param int $Width
-     * @param int $Height
-     */
-    function resizeFix($Width = 0, $Height = 0, $deprecated = 3) {
-        $this->newWidth = $Width;
-        $this->newHeight = $Height;
-
-		if(function_exists("ImageCreateTrueColor")) {
-			$this->workingImage = ImageCreateTrueColor($this->newWidth,$this->newHeight);
+				if ( $memoryNeeded > $memory_limit ) {
+					$memoryNeeded = round( $memoryNeeded / 1024 / 1024, 2 );
+					$this->errmsg = 'Exceed Memory limit. Require : ' . $memoryNeeded . " MByte";
+					$this->error = true;
+				}
+			}
 		}
-		else {
-			$this->workingImage = ImageCreate($this->newWidth,$this->newHeight);
+		return;
+	}
+
+	/**
+	 * Must be called to free up allocated memory after all manipulations are done
+	 *
+	 */
+	function destruct() {
+		if ( is_resource( $this->newImage ) )
+			@ImageDestroy( $this->newImage );
+		if ( is_resource( $this->oldImage ) )
+			@ImageDestroy( $this->oldImage );
+		if ( is_resource( $this->workingImage ) )
+			@ImageDestroy( $this->workingImage );
+	}
+
+	/**
+	 * Returns the current width of the image
+	 *
+	 * @return int
+	 */
+	function getCurrentWidth() {
+		return $this->currentDimensions['width'];
+	}
+
+	/**
+	 * Returns the current height of the image
+	 *
+	 * @return int
+	 */
+	function getCurrentHeight() {
+		return $this->currentDimensions['height'];
+	}
+
+	/**
+	 * Calculates new image width
+	 *
+	 * @param int $width
+	 * @param int $height
+	 * @return array
+	 */
+	function calcWidth( $width, $height ) {
+		$newWp = ( 100 * $this->maxWidth ) / $width;
+		$newHeight = ( $height * $newWp ) / 100;
+		return array( 'newWidth' => intval( $this->maxWidth ), 'newHeight' => intval( $newHeight ) );
+	}
+
+	/**
+	 * Calculates new image height
+	 *
+	 * @param int $width
+	 * @param int $height
+	 * @return array
+	 */
+	function calcHeight( $width, $height ) {
+		$newHp = ( 100 * $this->maxHeight ) / $height;
+		$newWidth = ( $width * $newHp ) / 100;
+		return array( 'newWidth' => intval( $newWidth ), 'newHeight' => intval( $this->maxHeight ) );
+	}
+
+	/**
+	 * Calculates new image size based on percentage
+	 *
+	 * @param int $width
+	 * @param int $height
+	 * @return array
+	 */
+	function calcPercent( $width, $height ) {
+		$newWidth = ( $width * $this->percent ) / 100;
+		$newHeight = ( $height * $this->percent ) / 100;
+		return array( 'newWidth' => intval( $newWidth ), 'newHeight' => intval( $newHeight ) );
+	}
+
+	/**
+	 * Calculates new image size based on width and height, while constraining to maxWidth and maxHeight
+	 *
+	 * @param int $width
+	 * @param int $height
+	 */
+	function calcImageSize( $width, $height ) {
+		$newSize = array( 'newWidth' => $width, 'newHeight' => $height );
+
+		if ( $this->maxWidth > 0 ) {
+
+			$newSize = $this->calcWidth( $width, $height );
+
+			if ( $this->maxHeight > 0 && $newSize['newHeight'] > $this->maxHeight ) {
+				$newSize = $this->calcHeight( $newSize['newWidth'], $newSize['newHeight'] );
+			}
+
+			//$this->newDimensions = $newSize;
 		}
 
-//		ImageCopyResampled(
+		if ( $this->maxHeight > 0 ) {
+			$newSize = $this->calcHeight( $width, $height );
+
+			if ( $this->maxWidth > 0 && $newSize['newWidth'] > $this->maxWidth ) {
+				$newSize = $this->calcWidth( $newSize['newWidth'], $newSize['newHeight'] );
+			}
+
+			//$this->newDimensions = $newSize;
+		}
+
+		$this->newDimensions = $newSize;
+	}
+
+	/**
+	 * Calculates new image size based percentage
+	 *
+	 * @param int $width
+	 * @param int $height
+	 */
+	function calcImageSizePercent( $width, $height ) {
+		if ( $this->percent > 0 ) {
+			$this->newDimensions = $this->calcPercent( $width, $height );
+		}
+	}
+
+	/**
+	 * Displays error image
+	 *
+	 */
+	function showErrorImage() {
+		header( 'Content-type: image/png' );
+		$errImg = ImageCreate( 220, 25 );
+		$bgColor = imagecolorallocate( $errImg, 0, 0, 0 );
+		$fgColor1 = imagecolorallocate( $errImg, 255, 255, 255 );
+		$fgColor2 = imagecolorallocate( $errImg, 255, 0, 0 );
+		imagestring( $errImg, 3, 6, 6, 'Error:', $fgColor2 );
+		imagestring( $errImg, 3, 55, 6, $this->errmsg, $fgColor1 );
+		imagepng( $errImg );
+		imagedestroy( $errImg );
+	}
+
+	/**
+	 * Resizes image to fixed Width x Height
+	 * 
+	 * @param int $Width
+	 * @param int $Height
+	 */
+	function resizeFix( $Width = 0, $Height = 0, $deprecated = 3 ) {
+		$newWidth = $Width;
+		$newHeight = $Height;
+
+		if ( function_exists( "ImageCreateTrueColor" ) ) {
+			$this->workingImage = ImageCreateTrueColor( $newWidth, $newHeight );
+		} else {
+			$this->workingImage = ImageCreate( $newWidth, $newHeight );
+		}
+
+		//		ImageCopyResampled(
 		$this->imagecopyresampled(
 			$this->workingImage,
 			$this->oldImage,
@@ -407,39 +410,38 @@ class ngg_Thumbnail {
 			0,
 			0,
 			0,
-			$this->newWidth,
-			$this->newHeight,
+			$newWidth,
+			$newHeight,
 			$this->currentDimensions['width'],
 			$this->currentDimensions['height']
 		);
 
 		$this->oldImage = $this->workingImage;
 		$this->newImage = $this->workingImage;
-		$this->currentDimensions['width'] = $this->newWidth;
-		$this->currentDimensions['height'] = $this->newHeight;
+		$this->currentDimensions['width'] = $newWidth;
+		$this->currentDimensions['height'] = $newHeight;
 	}
 
 
-    /**
-     * Resizes image to maxWidth x maxHeight
-     *
-     * @param int $maxWidth
-     * @param int $maxHeight
-     */
-    function resize($maxWidth = 0, $maxHeight = 0, $deprecated = 3) {
-        $this->maxWidth = $maxWidth;
-        $this->maxHeight = $maxHeight;
+	/**
+	 * Resizes image to maxWidth x maxHeight
+	 *
+	 * @param int $maxWidth
+	 * @param int $maxHeight
+	 */
+	function resize( $maxWidth = 0, $maxHeight = 0, $deprecated = 3 ) {
+		$this->maxWidth = $maxWidth;
+		$this->maxHeight = $maxHeight;
 
-        $this->calcImageSize($this->currentDimensions['width'],$this->currentDimensions['height']);
+		$this->calcImageSize( $this->currentDimensions['width'], $this->currentDimensions['height'] );
 
-		if(function_exists("ImageCreateTrueColor")) {
-			$this->workingImage = ImageCreateTrueColor($this->newDimensions['newWidth'],$this->newDimensions['newHeight']);
+		if ( function_exists( "ImageCreateTrueColor" ) ) {
+			$this->workingImage = ImageCreateTrueColor( $this->newDimensions['newWidth'], $this->newDimensions['newHeight'] );
+		} else {
+			$this->workingImage = ImageCreate( $this->newDimensions['newWidth'], $this->newDimensions['newHeight'] );
 		}
-		else {
-			$this->workingImage = ImageCreate($this->newDimensions['newWidth'],$this->newDimensions['newHeight']);
-		}
 
-//		ImageCopyResampled(
+		//		ImageCopyResampled(
 		$this->imagecopyresampled(
 			$this->workingImage,
 			$this->oldImage,
@@ -464,16 +466,15 @@ class ngg_Thumbnail {
 	 *
 	 * @param int $percent
 	 */
-	function resizePercent($percent = 0) {
-	    $this->percent = $percent;
+	function resizePercent( $percent = 0 ) {
+		$this->percent = $percent;
 
-	    $this->calcImageSizePercent($this->currentDimensions['width'],$this->currentDimensions['height']);
+		$this->calcImageSizePercent( $this->currentDimensions['width'], $this->currentDimensions['height'] );
 
-		if(function_exists("ImageCreateTrueColor")) {
-			$this->workingImage = ImageCreateTrueColor($this->newDimensions['newWidth'],$this->newDimensions['newHeight']);
-		}
-		else {
-			$this->workingImage = ImageCreate($this->newDimensions['newWidth'],$this->newDimensions['newHeight']);
+		if ( function_exists( "ImageCreateTrueColor" ) ) {
+			$this->workingImage = ImageCreateTrueColor( $this->newDimensions['newWidth'], $this->newDimensions['newHeight'] );
+		} else {
+			$this->workingImage = ImageCreate( $this->newDimensions['newWidth'], $this->newDimensions['newHeight'] );
 		}
 
 		$this->ImageCopyResampled(
@@ -500,31 +501,32 @@ class ngg_Thumbnail {
 	 *
 	 * @param int $cropSize
 	 */
-	function cropFromCenter($cropSize) {
-	    if($cropSize > $this->currentDimensions['width']) $cropSize = $this->currentDimensions['width'];
-	    if($cropSize > $this->currentDimensions['height']) $cropSize = $this->currentDimensions['height'];
+	function cropFromCenter( $cropSize ) {
+		if ( $cropSize > $this->currentDimensions['width'] )
+			$cropSize = $this->currentDimensions['width'];
+		if ( $cropSize > $this->currentDimensions['height'] )
+			$cropSize = $this->currentDimensions['height'];
 
-	    $cropX = intval(($this->currentDimensions['width'] - $cropSize) / 2);
-	    $cropY = intval(($this->currentDimensions['height'] - $cropSize) / 2);
+		$cropX = intval( ( $this->currentDimensions['width'] - $cropSize ) / 2 );
+		$cropY = intval( ( $this->currentDimensions['height'] - $cropSize ) / 2 );
 
-	    if(function_exists("ImageCreateTrueColor")) {
-			$this->workingImage = ImageCreateTrueColor($cropSize,$cropSize);
-		}
-		else {
-			$this->workingImage = ImageCreate($cropSize,$cropSize);
+		if ( function_exists( "ImageCreateTrueColor" ) ) {
+			$this->workingImage = ImageCreateTrueColor( $cropSize, $cropSize );
+		} else {
+			$this->workingImage = ImageCreate( $cropSize, $cropSize );
 		}
 
 		$this->imagecopyresampled(
-            $this->workingImage,
-            $this->oldImage,
-            0,
-            0,
-            $cropX,
-            $cropY,
-            $cropSize,
-            $cropSize,
-            $cropSize,
-            $cropSize
+			$this->workingImage,
+			$this->oldImage,
+			0,
+			0,
+			$cropX,
+			$cropY,
+			$cropSize,
+			$cropSize,
+			$cropSize,
+			$cropSize
 		);
 
 		$this->oldImage = $this->workingImage;
@@ -541,34 +543,39 @@ class ngg_Thumbnail {
 	 * @param int $width
 	 * @param int $height
 	 */
-	function crop($startX, $startY, $width, $height) {
-	    //make sure the cropped area is not greater than the size of the image
-	    if($width > $this->currentDimensions['width']) $width = $this->currentDimensions['width'];
-	    if($height > $this->currentDimensions['height']) $height = $this->currentDimensions['height'];
-	    //make sure not starting outside the image
-	    if(($startX + $width) > $this->currentDimensions['width']) $startX = ($this->currentDimensions['width'] - $width);
-	    if(($startY + $height) > $this->currentDimensions['height']) $startY = ($this->currentDimensions['height'] - $height);
-	    if($startX < 0) $startX = 0;
-	    if($startY < 0) $startY = 0;
+	function crop( $startX, $startY, $width, $height ) {
+		//make sure the cropped area is not greater than the size of the image
+		if ( $width > $this->currentDimensions['width'] )
+			$width = $this->currentDimensions['width'];
+		if ( $height > $this->currentDimensions['height'] )
+			$height = $this->currentDimensions['height'];
+		//make sure not starting outside the image
+		if ( ( $startX + $width ) > $this->currentDimensions['width'] )
+			$startX = ( $this->currentDimensions['width'] - $width );
+		if ( ( $startY + $height ) > $this->currentDimensions['height'] )
+			$startY = ( $this->currentDimensions['height'] - $height );
+		if ( $startX < 0 )
+			$startX = 0;
+		if ( $startY < 0 )
+			$startY = 0;
 
-	    if(function_exists("ImageCreateTrueColor")) {
-			$this->workingImage = ImageCreateTrueColor($width,$height);
-		}
-		else {
-			$this->workingImage = ImageCreate($width,$height);
+		if ( function_exists( "ImageCreateTrueColor" ) ) {
+			$this->workingImage = ImageCreateTrueColor( $width, $height );
+		} else {
+			$this->workingImage = ImageCreate( $width, $height );
 		}
 
 		$this->imagecopyresampled(
-            $this->workingImage,
-            $this->oldImage,
-            0,
-            0,
-            $startX,
-            $startY,
-            $width,
-            $height,
-            $width,
-            $height
+			$this->workingImage,
+			$this->oldImage,
+			0,
+			0,
+			$startX,
+			$startY,
+			$width,
+			$height,
+			$width,
+			$height
 		);
 
 		$this->oldImage = $this->workingImage;
@@ -583,36 +590,33 @@ class ngg_Thumbnail {
 	 * @param int $quality
 	 * @param string $name
 	 */
-	function show($quality=100,$name = '') {
-	    switch($this->format) {
-	        case 'GIF':
-	            if($name != '') {
-	               @ImageGif($this->newImage,$name) or $this->error = true;
-	            }
-	            else {
-	               header('Content-type: image/gif');
-	               ImageGif($this->newImage);
-	            }
-	            break;
-	        case 'JPG':
-	            if($name != '') {
-	               @ImageJpeg($this->newImage,$name,$quality) or $this->error = true;
-	            }
-	            else {
-	               header('Content-type: image/jpeg');
-	               ImageJpeg($this->newImage,NULL,$quality);
-	            }
-	            break;
-	        case 'PNG':
-	            if($name != '') {
-	            	@ImagePng($this->newImage,$name) or $this->error = true;
-	            }
-	            else {
-	               header('Content-type: image/png');
-	               ImagePng($this->newImage);
-	            }
-	            break;
-	    }
+	function show( $quality = 100, $name = '' ) {
+		switch ( $this->format ) {
+			case 'GIF':
+				if ( $name != '' ) {
+					@ImageGif( $this->newImage, $name ) or $this->error = true;
+				} else {
+					header( 'Content-type: image/gif' );
+					ImageGif( $this->newImage );
+				}
+				break;
+			case 'JPG':
+				if ( $name != '' ) {
+					@ImageJpeg( $this->newImage, $name, $quality ) or $this->error = true;
+				} else {
+					header( 'Content-type: image/jpeg' );
+					ImageJpeg( $this->newImage, NULL, $quality );
+				}
+				break;
+			case 'PNG':
+				if ( $name != '' ) {
+					@ImagePng( $this->newImage, $name ) or $this->error = true;
+				} else {
+					header( 'Content-type: image/png' );
+					ImagePng( $this->newImage );
+				}
+				break;
+		}
 	}
 
 	/**
@@ -622,17 +626,17 @@ class ngg_Thumbnail {
 	 * @param int $quality
 	 * @return bool errorstate
 	 */
-	function save($name,$quality=100) {
-	    $this->show($quality,$name);
-	    if ($this->error == true) {
-	    	$this->errmsg = 'Create Image failed. Check safe mode settings';
-	    	return false;
-	    }
-        
-        if( function_exists('do_action') )
-	       do_action('ngg_ajax_image_save', $name);
+	function save( $name, $quality = 100 ) {
+		$this->show( $quality, $name );
+		if ( $this->error == true ) {
+			$this->errmsg = 'Create Image failed. Check safe mode settings';
+			return false;
+		}
 
-	    return true;
+		if ( function_exists( 'do_action' ) )
+			do_action( 'ngg_ajax_image_save', $name );
+
+		return true;
 	}
 
 	/**
@@ -644,53 +648,53 @@ class ngg_Thumbnail {
 	 * @param bool $border
 	 * @param string $borderColor
 	 */
-	function createReflection($percent,$reflection,$white,$border = true,$borderColor = '#a4a4a4') {
-        $width = $this->currentDimensions['width'];
-        $height = $this->currentDimensions['height'];
+	function createReflection( $percent, $reflection, $white, $border = true, $borderColor = '#a4a4a4' ) {
+		$width = $this->currentDimensions['width'];
+		$height = $this->currentDimensions['height'];
 
-        $reflectionHeight = intval($height * ($reflection / 100));
-        $newHeight = $height + $reflectionHeight;
-        $reflectedPart = $height * ($percent / 100);
+		$reflectionHeight = intval( $height * ( $reflection / 100 ) );
+		$newHeight = $height + $reflectionHeight;
+		$reflectedPart = $height * ( $percent / 100 );
 
-        $this->workingImage = ImageCreateTrueColor($width,$newHeight);
+		$this->workingImage = ImageCreateTrueColor( $width, $newHeight );
 
-        ImageAlphaBlending($this->workingImage,true);
+		ImageAlphaBlending( $this->workingImage, true );
 
-        $colorToPaint = ImageColorAllocateAlpha($this->workingImage,255,255,255,0);
-        ImageFilledRectangle($this->workingImage,0,0,$width,$newHeight,$colorToPaint);
+		$colorToPaint = ImageColorAllocateAlpha( $this->workingImage, 255, 255, 255, 0 );
+		ImageFilledRectangle( $this->workingImage, 0, 0, $width, $newHeight, $colorToPaint );
 
-        imagecopyresampled(
-                            $this->workingImage,
-                            $this->newImage,
-                            0,
-                            0,
-                            0,
-                            $reflectedPart,
-                            $width,
-                            $reflectionHeight,
-                            $width,
-                            ($height - $reflectedPart));
-        $this->imageFlipVertical();
+		imagecopyresampled(
+			$this->workingImage,
+			$this->newImage,
+			0,
+			0,
+			0,
+			$reflectedPart,
+			$width,
+			$reflectionHeight,
+			$width,
+			( $height - $reflectedPart ) );
+		$this->imageFlipVertical();
 
-        imagecopy($this->workingImage,$this->newImage,0,0,0,0,$width,$height);
+		imagecopy( $this->workingImage, $this->newImage, 0, 0, 0, 0, $width, $height );
 
-        imagealphablending($this->workingImage,true);
+		imagealphablending( $this->workingImage, true );
 
-        for($i=0;$i<$reflectionHeight;$i++) {
-            $colorToPaint = imagecolorallocatealpha($this->workingImage,255,255,255,($i/$reflectionHeight*-1+1)*$white);
-            imagefilledrectangle($this->workingImage,0,$height+$i,$width,$height+$i,$colorToPaint);
-        }
+		for ( $i = 0; $i < $reflectionHeight; $i++ ) {
+			$colorToPaint = imagecolorallocatealpha( $this->workingImage, 255, 255, 255, ( $i / $reflectionHeight * -1 + 1 ) * $white );
+			imagefilledrectangle( $this->workingImage, 0, $height + $i, $width, $height + $i, $colorToPaint );
+		}
 
-        if($border == true) {
-            $rgb = $this->hex2rgb($borderColor,false);
-            $colorToPaint = imagecolorallocate($this->workingImage,$rgb[0],$rgb[1],$rgb[2]);
-            imageline($this->workingImage,0,0,$width,0,$colorToPaint); //top line
-            imageline($this->workingImage,0,$height,$width,$height,$colorToPaint); //bottom line
-            imageline($this->workingImage,0,0,0,$height,$colorToPaint); //left line
-            imageline($this->workingImage,$width-1,0,$width-1,$height,$colorToPaint); //right line
-        }
+		if ( $border == true ) {
+			$rgb = $this->hex2rgb( $borderColor, false );
+			$colorToPaint = imagecolorallocate( $this->workingImage, $rgb[0], $rgb[1], $rgb[2] );
+			imageline( $this->workingImage, 0, 0, $width, 0, $colorToPaint ); //top line
+			imageline( $this->workingImage, 0, $height, $width, $height, $colorToPaint ); //bottom line
+			imageline( $this->workingImage, 0, 0, 0, $height, $colorToPaint ); //left line
+			imageline( $this->workingImage, $width - 1, 0, $width - 1, $height, $colorToPaint ); //right line
+		}
 
-        $this->oldImage = $this->workingImage;
+		$this->oldImage = $this->workingImage;
 		$this->newImage = $this->workingImage;
 		$this->currentDimensions['width'] = $width;
 		$this->currentDimensions['height'] = $newHeight;
@@ -703,79 +707,79 @@ class ngg_Thumbnail {
 	 * @param bool $vert flip the image in vertical mode
 	 */
 	function flipImage( $horz = false, $vert = false ) {
-		
-		$sx = $vert ? ($this->currentDimensions['width'] - 1) : 0;
-		$sy = $horz ? ($this->currentDimensions['height'] - 1) : 0;
+
+		$sx = $vert ? ( $this->currentDimensions['width'] - 1 ) : 0;
+		$sy = $horz ? ( $this->currentDimensions['height'] - 1 ) : 0;
 		$sw = $vert ? -$this->currentDimensions['width'] : $this->currentDimensions['width'];
 		$sh = $horz ? -$this->currentDimensions['height'] : $this->currentDimensions['height'];
-		
-		$this->workingImage = imagecreatetruecolor( $this->currentDimensions['width'], $this->currentDimensions['height'] ); 
-		
-		$this->imagecopyresampled($this->workingImage, $this->oldImage, 0, 0, $sx, $sy, $this->currentDimensions['width'], $this->currentDimensions['height'], $sw, $sh) ;
+
+		$this->workingImage = imagecreatetruecolor( $this->currentDimensions['width'], $this->currentDimensions['height'] );
+
+		$this->imagecopyresampled( $this->workingImage, $this->oldImage, 0, 0, $sx, $sy, $this->currentDimensions['width'], $this->currentDimensions['height'], $sw, $sh );
 		$this->oldImage = $this->workingImage;
 		$this->newImage = $this->workingImage;
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Rotate an image clockwise or counter clockwise
 	 *
 	 * @param string $direction could be CW or CCW
 	 */
 	function rotateImage( $dir = 'CW' ) {
-		
-		$angle = ($dir == 'CW') ? 90 : -90;
-		
-		if ( function_exists('imagerotate') ) {
-			$transparency = imagecolorallocatealpha($this->oldImage, 255, 255, 255, 127);
-			$this->workingImage = imagerotate($this->oldImage, 360 - $angle, $transparency); // imagerotate() rotates CCW
-			imagealphablending($this->workingImage, true);
-			imagesavealpha($this->workingImage, true);
-			$this->currentDimensions['width']  = imagesx($this->workingImage);
-			$this->currentDimensions['height'] = imagesy($this->workingImage);
+
+		$angle = ( $dir == 'CW' ) ? 90 : -90;
+
+		if ( function_exists( 'imagerotate' ) ) {
+			$transparency = imagecolorallocatealpha( $this->oldImage, 255, 255, 255, 127 );
+			$this->workingImage = imagerotate( $this->oldImage, 360 - $angle, $transparency ); // imagerotate() rotates CCW
+			imagealphablending( $this->workingImage, true );
+			imagesavealpha( $this->workingImage, true );
+			$this->currentDimensions['width'] = imagesx( $this->workingImage );
+			$this->currentDimensions['height'] = imagesy( $this->workingImage );
 			$this->oldImage = $this->workingImage;
 			$this->newImage = $this->workingImage;
 			return true;
 		}
-		
-		$this->workingImage = imagecreatetruecolor( $this->currentDimensions['height'], $this->currentDimensions['width'] ); 
-		
-		imagealphablending($this->workingImage, false); 
-		imagesavealpha($this->workingImage, true); 
 
-		switch ($angle) {
-			
-			case 90 :
-				for( $x = 0; $x < $this->currentDimensions['width']; $x++ ) { 
-	   	            for( $y = 0; $y < $this->currentDimensions['height']; $y++ ) { 
-	  	                if ( !imagecopy($this->workingImage, $this->oldImage, $this->currentDimensions['height'] - $y - 1, $x, $x, $y, 1, 1) ) 
-	  	                    return false; 
-	 	            } 
-	  	        } 
-			break;
-			
-			case -90 :
-				for( $x = 0; $x < $this->currentDimensions['width']; $x++ ) { 
-	 	            for( $y = 0; $y < $this->currentDimensions['height']; $y++ ) { 
-	 	                if ( !imagecopy($this->workingImage, $this->oldImage, $y, $this->currentDimensions['width'] - $x - 1, $x, $y, 1, 1) ) 
-	 	                    return false; 
-	 	            } 
-	 	        } 
-			break;
-						
-			default : 
+		$this->workingImage = imagecreatetruecolor( $this->currentDimensions['height'], $this->currentDimensions['width'] );
+
+		imagealphablending( $this->workingImage, false );
+		imagesavealpha( $this->workingImage, true );
+
+		switch ( $angle ) {
+
+			case 90:
+				for ( $x = 0; $x < $this->currentDimensions['width']; $x++ ) {
+					for ( $y = 0; $y < $this->currentDimensions['height']; $y++ ) {
+						if ( ! imagecopy( $this->workingImage, $this->oldImage, $this->currentDimensions['height'] - $y - 1, $x, $x, $y, 1, 1 ) )
+							return false;
+					}
+				}
+				break;
+
+			case -90:
+				for ( $x = 0; $x < $this->currentDimensions['width']; $x++ ) {
+					for ( $y = 0; $y < $this->currentDimensions['height']; $y++ ) {
+						if ( ! imagecopy( $this->workingImage, $this->oldImage, $y, $this->currentDimensions['width'] - $x - 1, $x, $y, 1, 1 ) )
+							return false;
+					}
+				}
+				break;
+
+			default:
 				return false;
 		}
 
-		$this->currentDimensions['width']  = imagesx($this->workingImage);
-	    $this->currentDimensions['height'] = imagesy($this->workingImage);			
-	    $this->oldImage = $this->workingImage;
+		$this->currentDimensions['width'] = imagesx( $this->workingImage );
+		$this->currentDimensions['height'] = imagesy( $this->workingImage );
+		$this->oldImage = $this->workingImage;
 		$this->newImage = $this->workingImage;
-		
-	    return true;
-		
-	}	
+
+		return true;
+
+	}
 
 	/**
 	 * Inverts working image, used by reflection function
@@ -783,14 +787,14 @@ class ngg_Thumbnail {
 	 * @access	private
 	 */
 	function imageFlipVertical() {
-	    $x_i = imagesx($this->workingImage);
-	    $y_i = imagesy($this->workingImage);
+		$x_i = imagesx( $this->workingImage );
+		$y_i = imagesy( $this->workingImage );
 
-	    for($x = 0; $x < $x_i; $x++) {
-	        for($y = 0; $y < $y_i; $y++) {
-	            imagecopy($this->workingImage,$this->workingImage,$x,$y_i - $y - 1, $x, $y, 1, 1);
-	        }
-	    }
+		for ( $x = 0; $x < $x_i; $x++ ) {
+			for ( $y = 0; $y < $y_i; $y++ ) {
+				imagecopy( $this->workingImage, $this->workingImage, $x, $y_i - $y - 1, $x, $y, 1, 1 );
+			}
+		}
 	}
 
 	/**
@@ -800,145 +804,161 @@ class ngg_Thumbnail {
 	 * @param bool $asString
 	 * @return array|string
 	 */
-	function hex2rgb($hex, $asString = false) {
-        // strip off any leading #
-        if (0 === strpos($hex, '#')) {
-           $hex = substr($hex, 1);
-        } else if (0 === strpos($hex, '&H')) {
-           $hex = substr($hex, 2);
-        }
+	function hex2rgb( $hex, $asString = false ) {
+		// strip off any leading #
+		if ( 0 === strpos( $hex, '#' ) ) {
+			$hex = substr( $hex, 1 );
+		} else if ( 0 === strpos( $hex, '&H' ) ) {
+			$hex = substr( $hex, 2 );
+		}
 
-        // break into hex 3-tuple
-        $cutpoint = ceil(strlen($hex) / 2)-1;
-        $rgb = explode(':', wordwrap($hex, $cutpoint, ':', $cutpoint), 3);
+		// break into hex 3-tuple
+		$cutpoint = ceil( strlen( $hex ) / 2 ) - 1;
+		$rgb = explode( ':', wordwrap( $hex, $cutpoint, ':', $cutpoint ), 3 );
 
-        // convert each tuple to decimal
-        $rgb[0] = (isset($rgb[0]) ? hexdec($rgb[0]) : 0);
-        $rgb[1] = (isset($rgb[1]) ? hexdec($rgb[1]) : 0);
-        $rgb[2] = (isset($rgb[2]) ? hexdec($rgb[2]) : 0);
+		// convert each tuple to decimal
+		$rgb[0] = ( isset( $rgb[0] ) ? hexdec( $rgb[0] ) : 0 );
+		$rgb[1] = ( isset( $rgb[1] ) ? hexdec( $rgb[1] ) : 0 );
+		$rgb[2] = ( isset( $rgb[2] ) ? hexdec( $rgb[2] ) : 0 );
 
-        return ($asString ? "{$rgb[0]} {$rgb[1]} {$rgb[2]}" : $rgb);
-    }
-    
+		return ( $asString ? "{$rgb[0]} {$rgb[1]} {$rgb[2]}" : $rgb );
+	}
+
 	/**
-     * Based on the Watermark function by Marek Malcherek  
-     * http://www.malcherek.de
-     *
- 	 * @param string $color
+	 * Based on the Watermark function by Marek Malcherek  
+	 * http://www.malcherek.de
+	 *
+	 * @param string $color
 	 * @param string $wmFont
 	 * @param int $wmSize
- 	 * @param int $wmOpaque
-     */
-	function watermarkCreateText($wmFont, $color = '000000', $wmSize = 10, $wmOpaque = 90 ){
+	 * @param int $wmOpaque
+	 */
+	function watermarkCreateText( $wmFont, $color = '000000', $wmSize = 10, $wmOpaque = 90 ) {
 		// set font path
-		$wmFontPath = NGGALLERY_ABSPATH."fonts/".$wmFont;
-		if ( !is_readable($wmFontPath))
-			return;	
-			
-		// This function requires both the GD library and the FreeType library. 
-		if ( !function_exists('ImageTTFBBox') )
+		$wmFontPath = NGGALLERY_ABSPATH . "fonts/" . $wmFont;
+		if ( ! is_readable( $wmFontPath ) )
 			return;
-	
-		$TextSize = @ImageTTFBBox($wmSize, 0, $wmFontPath, $this->watermarkText) or die;
-		$TextWidth = abs($TextSize[2]) + abs($TextSize[0]);
-		$TextHeight = abs($TextSize[7]) + abs($TextSize[1]);
+
+		// This function requires both the GD library and the FreeType library. 
+		if ( ! function_exists( 'ImageTTFBBox' ) )
+			return;
+
+		$TextSize = @ImageTTFBBox( $wmSize, 0, $wmFontPath, $this->watermarkText ) or die;
+		$TextWidth = abs( $TextSize[2] ) + abs( $TextSize[0] );
+		$TextHeight = abs( $TextSize[7] ) + abs( $TextSize[1] );
 		// Create Image for Text
-		$this->workingImage = ImageCreateTrueColor($TextWidth, $TextHeight);
-		ImageSaveAlpha($this->workingImage, true);
-		ImageAlphaBlending($this->workingImage, false);
-		$bgText = imagecolorallocatealpha($this->workingImage, 255, 255, 255, 127);
-		imagefill($this->workingImage, 0, 0, $bgText);
-		$wmTransp = 127 -( $wmOpaque * 1.27 );
-		$rgb = $this->hex2rgb($color,false);
-		$TextColor = imagecolorallocatealpha($this->workingImage, $rgb[0], $rgb[1], $rgb[2], $wmTransp);
-		
+		$this->workingImage = ImageCreateTrueColor( $TextWidth, $TextHeight );
+		ImageSaveAlpha( $this->workingImage, true );
+		ImageAlphaBlending( $this->workingImage, false );
+		$bgText = imagecolorallocatealpha( $this->workingImage, 255, 255, 255, 127 );
+		imagefill( $this->workingImage, 0, 0, $bgText );
+		$wmTransp = 127 - ( $wmOpaque * 1.27 );
+		$rgb = $this->hex2rgb( $color, false );
+		$TextColor = imagecolorallocatealpha( $this->workingImage, $rgb[0], $rgb[1], $rgb[2], $wmTransp );
+
 		// Create Text on image
-		imagettftext($this->workingImage, $wmSize, 0, 0, abs($TextSize[5]), $TextColor, $wmFontPath, $this->watermarkText);
+		imagettftext( $this->workingImage, $wmSize, 0, 0, abs( $TextSize[5] ), $TextColor, $wmFontPath, $this->watermarkText );
 		$this->watermarkImgPath = $this->workingImage;
 
-		return;		
+		return;
 	}
-    
-    /**
-     * Modfied Watermark function by Steve Peart 
-     * http://parasitehosting.com/
-     *
- 	 * @param string $relPOS
+
+	/**
+	 * Modfied Watermark function by Steve Peart 
+	 * http://parasitehosting.com/
+	 *
+	 * @param string $relPOS
 	 * @param int $xPOS
- 	 * @param int $yPOS
-     */
-    function watermarkImage( $relPOS = 'botRight', $xPOS = 0, $yPOS = 0) {
-    	
-	if (!is_resource($this->watermarkImgPath) && ! $this->watermarkImgPath instanceof \GdImage) {
-		// Would you really want to use anything other than a png? 
-		$this->workingImage = @imagecreatefrompng($this->watermarkImgPath);
-		// if it's not a valid file die...
-		if (empty($this->workingImage) or (!$this->workingImage))
-			return;
+	 * @param int $yPOS
+	 */
+	function watermarkImage( $relPOS = 'botRight', $xPOS = 0, $yPOS = 0 ) {
+
+		if ( ! is_resource( $this->watermarkImgPath ) && ! $this->watermarkImgPath instanceof \GdImage ) {
+			// Would you really want to use anything other than a png? 
+			$this->workingImage = @imagecreatefrompng( $this->watermarkImgPath );
+			// if it's not a valid file die...
+			if ( empty( $this->workingImage ) or ( ! $this->workingImage ) )
+				return;
 		}
-		
-		imagealphablending($this->workingImage, false);
-		imagesavealpha($this->workingImage, true);
-		$sourcefile_width=imageSX($this->oldImage);
-		$sourcefile_height=imageSY($this->oldImage);
-		$watermarkfile_width=imageSX($this->workingImage);
-		$watermarkfile_height=imageSY($this->workingImage);
-		switch(substr($relPOS, 0, 3)){
-			case 'top': $dest_y = 0 + $yPOS; break;
-			case 'mid': $dest_y = ($sourcefile_height / 2) - ($watermarkfile_height / 2); break;
-			case 'bot': $dest_y = $sourcefile_height - $watermarkfile_height - $yPOS; break;
-			default   : $dest_y = 0; break;
+
+		imagealphablending( $this->workingImage, false );
+		imagesavealpha( $this->workingImage, true );
+		$sourcefile_width = imageSX( $this->oldImage );
+		$sourcefile_height = imageSY( $this->oldImage );
+		$watermarkfile_width = imageSX( $this->workingImage );
+		$watermarkfile_height = imageSY( $this->workingImage );
+		switch ( substr( $relPOS, 0, 3 ) ) {
+			case 'top':
+				$dest_y = 0 + $yPOS;
+				break;
+			case 'mid':
+				$dest_y = ( $sourcefile_height / 2 ) - ( $watermarkfile_height / 2 );
+				break;
+			case 'bot':
+				$dest_y = $sourcefile_height - $watermarkfile_height - $yPOS;
+				break;
+			default:
+				$dest_y = 0;
+				break;
 		}
-		switch(substr($relPOS, 3)){
-			case 'Left'	:	$dest_x = 0 + $xPOS; break;
-			case 'Center':	$dest_x = ($sourcefile_width / 2) - ($watermarkfile_width / 2); break;
-			case 'Right':	$dest_x = $sourcefile_width - $watermarkfile_width - $xPOS; break;
-			default : 		$dest_x = 0; break;
+		switch ( substr( $relPOS, 3 ) ) {
+			case 'Left':
+				$dest_x = 0 + $xPOS;
+				break;
+			case 'Center':
+				$dest_x = ( $sourcefile_width / 2 ) - ( $watermarkfile_width / 2 );
+				break;
+			case 'Right':
+				$dest_x = $sourcefile_width - $watermarkfile_width - $xPOS;
+				break;
+			default:
+				$dest_x = 0;
+				break;
 		}
-		
+
 		// debug	
 		// $this->errmsg = 'X '.$dest_x.' Y '.$dest_y;
 		// $this->showErrorImage();
 
 		// if a gif, we have to upsample it to a truecolor image
-		if($this->format == 'GIF') {
-			$tempimage = imagecreatetruecolor($sourcefile_width,$sourcefile_height);
-			imagecopy($tempimage, $this->oldImage, 0, 0, 0, 0,$sourcefile_width, $sourcefile_height);
+		if ( $this->format == 'GIF' ) {
+			$tempimage = imagecreatetruecolor( $sourcefile_width, $sourcefile_height );
+			imagecopy( $tempimage, $this->oldImage, 0, 0, 0, 0, $sourcefile_width, $sourcefile_height );
 			$this->newImage = $tempimage;
 		}
-		
-		imagecopy($this->newImage, $this->workingImage, $dest_x, $dest_y, 0, 0,$watermarkfile_width, $watermarkfile_height);
+
+		imagecopy( $this->newImage, $this->workingImage, $dest_x, $dest_y, 0, 0, $watermarkfile_width, $watermarkfile_height );
 	}
-	
-    /**
-     * Modfied imagecopyresampled function to save transparent images
-     * See : http://www.akemapa.com/2008/07/10/php-gd-resize-transparent-image-png-gif/
-     * @since 1.9.0
-     * 
-     * @param resource $dst_image
-     * @param resource $src_image
-     * @param int $dst_x
-     * @param int $dst_y
-     * @param int $src_x
-     * @param int $src_y
-     * @param int $dst_w
-     * @param int $dst_h
-     * @param int $src_w
-     * @param int $src_h
-     * @return bool
-     */
-    function imagecopyresampled( &$dst_image , $src_image , $dst_x , $dst_y , $src_x , $src_y , $dst_w , $dst_h , $src_w , $src_h) {
-        
-        // Check if this image is PNG or GIF, then set if Transparent  
-        if( $this->format == 'GIF' || $this->format == 'PNG'){
-            imagealphablending($dst_image, false);
-            imagesavealpha($dst_image, true);
-            $transparent = imagecolorallocatealpha($dst_image, 255, 255, 255, 127);
-            imagefilledrectangle($dst_image, 0, 0, $dst_w, $dst_h, $transparent);
-        }
-        
-        imagecopyresampled($dst_image , $src_image , $dst_x , $dst_y , $src_x , $src_y , $dst_w , $dst_h , $src_w , $src_h);
-        return true;         
-    }
+
+	/**
+	 * Modfied imagecopyresampled function to save transparent images
+	 * See : http://www.akemapa.com/2008/07/10/php-gd-resize-transparent-image-png-gif/
+	 * @since 1.9.0
+	 * 
+	 * @param resource $dst_image
+	 * @param resource $src_image
+	 * @param int $dst_x
+	 * @param int $dst_y
+	 * @param int $src_x
+	 * @param int $src_y
+	 * @param int $dst_w
+	 * @param int $dst_h
+	 * @param int $src_w
+	 * @param int $src_h
+	 * @return bool
+	 */
+	function imagecopyresampled( &$dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h ) {
+
+		// Check if this image is PNG or GIF, then set if Transparent  
+		if ( $this->format == 'GIF' || $this->format == 'PNG' ) {
+			imagealphablending( $dst_image, false );
+			imagesavealpha( $dst_image, true );
+			$transparent = imagecolorallocatealpha( $dst_image, 255, 255, 255, 127 );
+			imagefilledrectangle( $dst_image, 0, 0, $dst_w, $dst_h, $transparent );
+		}
+
+		imagecopyresampled( $dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h );
+		return true;
+	}
 }
 ?>

--- a/lib/image.php
+++ b/lib/image.php
@@ -1,236 +1,269 @@
 <?php
-if ( !class_exists('nggImage') ) :
-/**
-* Image PHP class for the WordPress plugin NextGEN Gallery
-* 
-* @author Alex Rabe 
-*  
-*/
-class nggImage{
-	
-	/**** Public variables ****/	
-	var $errmsg			=	'';			// Error message to display, if any
-	var $error			=	FALSE; 		// Error state
-	var $imageURL		=	'';			// URL Path to the image
-	var $thumbURL		=	'';			// URL Path to the thumbnail
-	var $imagePath		=	'';			// Server Path to the image
-	var $thumbPath		=	'';			// Server Path to the thumbnail
-	var $href			=	'';			// A href link code
-	
-	// TODO: remove thumbPrefix and thumbFolder (constants)
-	var $thumbPrefix	=	'thumbs_';	// FolderPrefix to the thumbnail
-	var $thumbFolder	=	'/thumbs/';	// Foldername to the thumbnail
-	
-	/**** Image Data ****/
-	var $galleryid		=	0;			// Gallery ID
-	var $pid			=	0;			// Image ID	
-	var $filename		=	'';			// Image filename
-	var $description	=	'';			// Image description	
-	var $alttext		=	'';			// Image alttext	
-	var $imagedate		=	'';			// Image date/time	
-	var $exclude		=	'';			// Image exclude
-	var $thumbcode		=	'';			// Image effect code
-
-	/**** Gallery Data ****/
-	var $name			=	'';			// Gallery name
-	var $path			=	'';			// Gallery path	
-	var $title			=	'';			// Gallery title
-	var $pageid			=	0;			// Gallery page ID
-	var $previewpic		=	0;			// Gallery preview pic		
-
-	var $permalink		=	'';
-	var $tags			=   '';
-		
+if ( ! class_exists( 'nggImage' ) ) :
 	/**
-	 * Constructor
+	 * Image PHP class for the WordPress plugin NextGEN Gallery
 	 * 
-	 * @param object $gallery The nggGallery object representing the gallery containing this image
-	 * @return void
+	 * @author Alex Rabe 
+	 *  
 	 */
-	function __construct($gallery) {			
-			
-		//This must be an object
-		$gallery = (object) $gallery;
+	class nggImage {
 
-		// Build up the object
-		foreach ($gallery as $key => $value)
-			$this->$key = $value ;
-		
-		// Finish initialisation
-		$this->name			= $gallery->name;
-		$this->path			= $gallery->path;
-		$this->title		= stripslashes($gallery->title);
-		$this->pageid		= $gallery->pageid;		
-		$this->previewpic	= $gallery->previewpic;
-	
-		// set urls and paths
-        //20140217:this->path can't be used, because it can contain parameters
-        //for example: mysite/mycategory?lang=en causing improper URL format and also plugin incompatibility (Qtranslate for example.
-		$this->imageURL		= site_url() . '/' . $this->path . '/' . $this->filename;
-		$this->thumbURL 	= site_url() . '/' . $this->path . '/thumbs/thumbs_' . $this->filename;
-		$this->imagePath	= WINABSPATH.$this->path . '/' . $this->filename;
-		$this->thumbPath	= WINABSPATH.$this->path . '/thumbs/thumbs_' . $this->filename;
-        $this->meta_data	= @unserialize($this->meta_data) ;
-		$this->imageHTML	= $this->get_href_link();
-		$this->thumbHTML	= $this->get_href_thumb_link();
-		
-		do_action_ref_array('ngg_get_image', array(&$this));
-        
-        // Note wp_cache_add will increase memory needs (4-8 kb)
-		//wp_cache_add($this->pid, $this, 'ngg_image');
-		// Get tags only if necessary
-		unset($this->tags);
-	}
-	
-	/**
-	* Get the thumbnail code (to add effects on thumbnail click)
-	*
-	* Applies the filter 'ngg_get_thumbcode'
-	*/
-	function get_thumbcode($galleryname = '') {
-	   
-        // clean up the name
-        $galleryname = sanitize_title( $galleryname );
-        
-		// read the option setting
-		$ngg_options = get_option('ngg_options');
-		
-		// get the effect code
-		if ($ngg_options['thumbEffect'] != "none")
-			$this->thumbcode = stripslashes($ngg_options['thumbCode']);		
-		
-		// for highslide to a different approach	
-		if ($ngg_options['thumbEffect'] == "highslide") {
-			$this->thumbcode = str_replace("%GALLERY_NAME%", "'" . $galleryname . "'", $this->thumbcode);
-		} else {
-			$this->thumbcode = str_replace("%GALLERY_NAME%", $galleryname, $this->thumbcode);
+		/**** Public variables ****/
+		public string $name = '';			// Gallery/image and album name
+		private string $errmsg = '';			// Error message to display, if any
+		public bool $error = FALSE; 		// Error state
+		public string $imageURL = '';			// URL Path to the image
+		public string $thumbURL = '';			// URL Path to the thumbnail
+		public string $imagePath = '';			// Server Path to the image
+		public string $thumbPath = '';			// Server Path to the thumbnail
+		public string $href = '';			// A href link code
+
+		// TODO: remove thumbPrefix and thumbFolder (constants)
+		private string $thumbPrefix = 'thumbs_';	// FolderPrefix to the thumbnail
+		private string $thumbFolder = '/thumbs/';	// Foldername to the thumbnail
+
+		/**** Image Data ****/
+		public int $galleryid = 0;			// Gallery ID
+		public int $pid = 0;			// Image ID	
+		public string $filename = '';			// Image filename
+		public string $description = '';			// Image description	
+		public string $alttext = '';			// Image alttext	
+		public string $imagedate = '';			// Image date/time	
+		public string $exclude = '';			// Image exclude
+		public string $thumbcode = '';			// Image effect code
+		public string $tags = '';
+		public $image_slug;
+		public string $imageHTML;
+		public string $thumbHTML;
+		public bool $hidden;
+		public string $style;
+		public string $pidlink;
+		public string $url;
+		public string $thumbnailURL;
+		public string $size;
+		public string $caption;
+		public string $href_link;
+		public string $previous_image_link;
+		public string $next_image_link;
+		public int $previous_pid;
+		public string $next_pid;
+		public int $number;
+		public int $total;
+		public string $linktitle;
+		public string $anchor;
+
+		/**** Gallery Data ****/
+		public string $path = '';			// Gallery path	
+		public string $title = '';			// Gallery title
+		public int $pageid = 0;			// Gallery page ID
+		public int $previewpic = 0;			// Gallery preview pic	
+		public int $gid;
+		public $galdesc;
+		public string $abspath;
+
+		public string $permalink = '';
+		public $post_id;
+		public $sortorder;
+		public $meta_data;
+		public $slug;
+		public int $author;
+
+		/**** Album Data ****/
+		public array $gallery_ids;
+		public int $id;
+		public string $albumdesc;
+
+
+		/**
+		 * Constructor
+		 * 
+		 * @param object $gallery The nggGallery object representing the gallery containing this image
+		 * @return void
+		 */
+		function __construct( object $gallery ) {
+
+			// This must be an object
+			// $gallery = (object) $gallery;
+
+			// Build up the object
+			foreach ( $gallery as $key => $value )
+				$this->$key = $value;
+
+			// Finish initialisation
+			$this->name = $gallery->name;
+			$this->path = $gallery->path;
+			$this->title = stripslashes( $gallery->title );
+			$this->pageid = $gallery->pageid;
+			$this->previewpic = $gallery->previewpic;
+
+			// set urls and paths
+			//20140217:this->path can't be used, because it can contain parameters
+			//for example: mysite/mycategory?lang=en causing improper URL format and also plugin incompatibility (Qtranslate for example.
+			$this->imageURL = site_url() . '/' . $this->path . '/' . $this->filename;
+			$this->thumbURL = site_url() . '/' . $this->path . '/thumbs/thumbs_' . $this->filename;
+			$this->imagePath = WINABSPATH . $this->path . '/' . $this->filename;
+			$this->thumbPath = WINABSPATH . $this->path . '/thumbs/thumbs_' . $this->filename;
+			$this->meta_data = @unserialize( $this->meta_data );
+			$this->imageHTML = $this->get_href_link();
+			$this->thumbHTML = $this->get_href_thumb_link();
+
+			do_action_ref_array( 'ngg_get_image', array(&$this ) );
+
+			// Note wp_cache_add will increase memory needs (4-8 kb)
+			//wp_cache_add($this->pid, $this, 'ngg_image');
+			// Get tags only if necessary
+			unset( $this->tags );
 		}
 
 		/**
-		 * The list of available variables:
-		 * - %GALLERY_NAME% - The name of the gallery
-		 * - %IMG_WIDTH% - The width of the full image.
-		 * - %IMG_HEIGHT% - The height of the full image.
+		 * Get the thumbnail code (to add effects on thumbnail click)
+		 *
+		 * Applies the filter 'ngg_get_thumbcode'
 		 */
-		if (isset($this->meta_data['width']) && isset($this->meta_data['width'])) {
-			$this->thumbcode = str_replace(array('%IMG_WIDTH%', '%IMG_HEIGHT%'), array($this->meta_data['width'], $this->meta_data['height']), $this->thumbcode);
+		function get_thumbcode( $galleryname = '' ) {
+
+			// clean up the name
+			$galleryname = sanitize_title( $galleryname );
+
+			// read the option setting
+			$ngg_options = get_option( 'ngg_options' );
+
+			// get the effect code
+			if ( $ngg_options['thumbEffect'] != "none" )
+				$this->thumbcode = stripslashes( $ngg_options['thumbCode'] );
+
+			// for highslide to a different approach	
+			if ( $ngg_options['thumbEffect'] == "highslide" ) {
+				$this->thumbcode = str_replace( "%GALLERY_NAME%", "'" . $galleryname . "'", $this->thumbcode );
+			} else {
+				$this->thumbcode = str_replace( "%GALLERY_NAME%", $galleryname, $this->thumbcode );
+			}
+
+			/**
+			 * The list of available variables:
+			 * - %GALLERY_NAME% - The name of the gallery
+			 * - %IMG_WIDTH% - The width of the full image.
+			 * - %IMG_HEIGHT% - The height of the full image.
+			 */
+			if ( isset ( $this->meta_data['width'] ) && isset ( $this->meta_data['width'] ) ) {
+				$this->thumbcode = str_replace( array( '%IMG_WIDTH%', '%IMG_HEIGHT%' ), array( $this->meta_data['width'], $this->meta_data['height'] ), $this->thumbcode );
+			}
+
+			return apply_filters( 'ngg_get_thumbcode', $this->thumbcode, $this );
 		}
 
-		return apply_filters('ngg_get_thumbcode', $this->thumbcode, $this);
-	}
-	
-	function get_href_link() {
-		// create the a href link from the picture
-		$this->href  = "\n".'<a href="'.$this->imageURL.'" title="'.htmlspecialchars( stripslashes( nggGallery::i18n($this->description, 'pic_' . $this->pid . '_description') ) ).'" '.$this->get_thumbcode($this->name).'>'."\n\t";
-		$this->href .= '<img alt="'.$this->alttext.'" src="'.$this->imageURL.'"/>'."\n".'</a>'."\n";
+		function get_href_link() {
+			// create the a href link from the picture
+			$this->href = "\n" . '<a href="' . $this->imageURL . '" title="' . htmlspecialchars( stripslashes( nggGallery::i18n( $this->description, 'pic_' . $this->pid . '_description' ) ) ) . '" ' . $this->get_thumbcode( $this->name ) . '>' . "\n\t";
+			$this->href .= '<img alt="' . $this->alttext . '" src="' . $this->imageURL . '"/>' . "\n" . '</a>' . "\n";
 
-		return $this->href;
-	}
-
-	function get_href_thumb_link() {
-		// create the a href link with the thumbanil
-		$this->href  = "\n".'<a href="'.$this->imageURL.'" title="'.htmlspecialchars( stripslashes( nggGallery::i18n($this->description, 'pic_' . $this->pid . '_description') ) ).'" '.$this->get_thumbcode($this->name).'>'."\n\t";
-		$this->href .= '<img alt="'.$this->alttext.'" src="'.$this->thumbURL.'"/>'."\n".'</a>'."\n";
-
-		return $this->href;
-	}
-	
-	/**
-	 * This function creates a cache for all singlepics to reduce the CPU load
-	 * 
-	 * @param int $width
-	 * @param int $height
-	 * @param string $mode could be watermark | web20 | crop
-	 * @return the url for the image or false if failed 
-	 */
-	function cached_singlepic_file($width = '', $height = '', $mode = '' ) {
-
-		$ngg_options = get_option('ngg_options');
-		
-		include_once( nggGallery::graphic_library() );
-		
-		// cache filename should be unique
-		$cachename   	= $this->pid . '_' . $mode . '_'. $width . 'x' . $height . '_' . $this->filename;
-		$cachefolder 	= WINABSPATH .$ngg_options['gallerypath'] . 'cache/';
-		$cached_url  	= site_url() . '/' . $ngg_options['gallerypath'] . 'cache/' . $cachename;
-		$cached_file	= $cachefolder . $cachename;
-		
-		// check first for the file
-		if ( file_exists($cached_file) )
-			return $cached_url;
-		
-		// create folder if needed
-		if ( !file_exists($cachefolder) )
-			if ( !wp_mkdir_p($cachefolder) )
-				return false;
-		
-		$thumb = new ngg_Thumbnail($this->imagePath, TRUE);
-		// echo $thumb->errmsg;
-		
-		if (!$thumb->error) {
-            if ($mode == 'crop') {
-        		// calculates the new dimentions for a downsampled image
-                list ( $ratio_w, $ratio_h ) = wp_constrain_dimensions($thumb->currentDimensions['width'], $thumb->currentDimensions['height'], $width, $height);
-                // check ratio to decide which side should be resized
-                ( $ratio_h <  $height || $ratio_w ==  $width ) ? $thumb->resize(0, $height) : $thumb->resize($width, 0);
-                // get the best start postion to crop from the middle    
-                $ypos = ($thumb->currentDimensions['height'] - $height) / 2;
-        		$thumb->crop(0, $ypos, $width, $height);	               
-            } else
-                $thumb->resize($width , $height);
-			
-			if ($mode == 'watermark') {
-				if ($ngg_options['wmType'] == 'image') {
-					$thumb->watermarkImgPath = $ngg_options['wmPath'];
-					$thumb->watermarkImage($ngg_options['wmPos'], $ngg_options['wmXpos'], $ngg_options['wmYpos']); 
-				}
-				if ($ngg_options['wmType'] == 'text') {
-					$thumb->watermarkText = $ngg_options['wmText'];
-					$thumb->watermarkCreateText($ngg_options['wmFont'], $ngg_options['wmColor'], $ngg_options['wmSize'], $ngg_options['wmOpaque']);
-					$thumb->watermarkImage($ngg_options['wmPos'], $ngg_options['wmXpos'], $ngg_options['wmYpos']);  
-				}
-			}
-			
-			if ($mode == 'web20') {
-				$thumb->createReflection(40,40,50,false,'#a4a4a4');
-			}
-			
-			// save the new cache picture
-			$thumb->save($cached_file,$ngg_options['imgQuality']);
+			return $this->href;
 		}
-		$thumb->destruct();
-		
-		// check again for the file
-		if (file_exists($cached_file))
-			return $cached_url;
-		
-		return false;
-	}
-	
-	/**
-	 * Get the tags associated to this image
-	 */
-	function get_tags() {
-		if ( !isset($this->tags) )
-			$this->tags = wp_get_object_terms($this->pid, 'ngg_tag', 'fields=all');
 
-		return $this->tags;
-	}
-	
-	/**
-	 * Get the permalink to the image
-	 * TODO Get a permalink to a page presenting the image
-	 */
-	function get_permalink() {
-		if ($this->permalink == '')
-			$this->permalink = $this->imageURL;
+		function get_href_thumb_link() {
+			// create the a href link with the thumbanil
+			$this->href = "\n" . '<a href="' . $this->imageURL . '" title="' . htmlspecialchars( stripslashes( nggGallery::i18n( $this->description, 'pic_' . $this->pid . '_description' ) ) ) . '" ' . $this->get_thumbcode( $this->name ) . '>' . "\n\t";
+			$this->href .= '<img alt="' . $this->alttext . '" src="' . $this->thumbURL . '"/>' . "\n" . '</a>' . "\n";
 
-		return $this->permalink; 
-	}
-    
-    function __destruct() {
+			return $this->href;
+		}
 
-    }
-}
+		/**
+		 * This function creates a cache for all singlepics to reduce the CPU load
+		 * 
+		 * @param int $width
+		 * @param int $height
+		 * @param string $mode could be watermark | web20 | crop
+		 * @return string|bool url for the image or false if failed 
+		 */
+		function cached_singlepic_file( $width = '', $height = '', $mode = '' ) {
+
+			$ngg_options = get_option( 'ngg_options' );
+
+			include_once ( nggGallery::graphic_library() );
+
+			// cache filename should be unique
+			$cachename = $this->pid . '_' . $mode . '_' . $width . 'x' . $height . '_' . $this->filename;
+			$cachefolder = WINABSPATH . $ngg_options['gallerypath'] . 'cache/';
+			$cached_url = site_url() . '/' . $ngg_options['gallerypath'] . 'cache/' . $cachename;
+			$cached_file = $cachefolder . $cachename;
+
+			// check first for the file
+			if ( file_exists( $cached_file ) )
+				return $cached_url;
+
+			// create folder if needed
+			if ( ! file_exists( $cachefolder ) )
+				if ( ! wp_mkdir_p( $cachefolder ) )
+					return false;
+
+			$thumb = new ngg_Thumbnail( $this->imagePath, TRUE );
+			// echo $thumb->errmsg;
+
+			if ( ! $thumb->error ) {
+				if ( $mode == 'crop' ) {
+					// calculates the new dimentions for a downsampled image
+					list( $ratio_w, $ratio_h ) = wp_constrain_dimensions( $thumb->currentDimensions['width'], $thumb->currentDimensions['height'], $width, $height );
+					// check ratio to decide which side should be resized
+					( $ratio_h < $height || $ratio_w == $width ) ? $thumb->resize( 0, $height ) : $thumb->resize( $width, 0 );
+					// get the best start postion to crop from the middle    
+					$ypos = ( $thumb->currentDimensions['height'] - $height ) / 2;
+					$thumb->crop( 0, $ypos, $width, $height );
+				} else
+					$thumb->resize( $width, $height );
+
+				if ( $mode == 'watermark' ) {
+					if ( $ngg_options['wmType'] == 'image' ) {
+						$thumb->watermarkImgPath = $ngg_options['wmPath'];
+						$thumb->watermarkImage( $ngg_options['wmPos'], $ngg_options['wmXpos'], $ngg_options['wmYpos'] );
+					}
+					if ( $ngg_options['wmType'] == 'text' ) {
+						$thumb->watermarkText = $ngg_options['wmText'];
+						$thumb->watermarkCreateText( $ngg_options['wmFont'], $ngg_options['wmColor'], $ngg_options['wmSize'], $ngg_options['wmOpaque'] );
+						$thumb->watermarkImage( $ngg_options['wmPos'], $ngg_options['wmXpos'], $ngg_options['wmYpos'] );
+					}
+				}
+
+				if ( $mode == 'web20' ) {
+					$thumb->createReflection( 40, 40, 50, false, '#a4a4a4' );
+				}
+
+				// save the new cache picture
+				$thumb->save( $cached_file, $ngg_options['imgQuality'] );
+			}
+			$thumb->destruct();
+
+			// check again for the file
+			if ( file_exists( $cached_file ) )
+				return $cached_url;
+
+			return false;
+		}
+
+		/**
+		 * Get the tags associated to this image
+		 */
+		function get_tags() {
+			if ( ! isset ( $this->tags ) )
+				$this->tags = wp_get_object_terms( $this->pid, 'ngg_tag', 'fields=all' );
+
+			return $this->tags;
+		}
+
+		/**
+		 * Get the permalink to the image
+		 * TODO Get a permalink to a page presenting the image
+		 */
+		function get_permalink() {
+			if ( $this->permalink == '' )
+				$this->permalink = $this->imageURL;
+
+			return $this->permalink;
+		}
+
+		function __destruct() {
+
+		}
+	}
 endif;
 ?>

--- a/lib/imagemagick.inc.php
+++ b/lib/imagemagick.inc.php
@@ -1,357 +1,357 @@
 <?php
 /**
-* imagemagick.inc.php
-*
-* @author 		Frederic De Ranter
-* @copyright	Copyright 2008
-* @version 		0.4 (PHP4)
-* @based 		on thumbnail.inc.php by Ian Selby (gen-x-design.com)
-* @since		NextGEN V1.0.0
-*
-*/
+ * imagemagick.inc.php
+ *
+ * @author 		Frederic De Ranter
+ * @copyright	Copyright 2008
+ * @version 		0.4 (PHP4)
+ * @based 		on thumbnail.inc.php by Ian Selby (gen-x-design.com)
+ * @since		NextGEN V1.0.0
+ *
+ */
 /**
-* PHP class for dynamically resizing, cropping, and rotating images for thumbnail purposes and either displaying them on-the-fly or saving them.
-* with ImageMagick
-*/
+ * PHP class for dynamically resizing, cropping, and rotating images for thumbnail purposes and either displaying them on-the-fly or saving them.
+ * with ImageMagick
+ */
 
 class ngg_Thumbnail {
-/**
-* Error message to display, if any
-* @var string
-*/
-var $errmsg;
-/**
-* Whether or not there is an error
-* @var boolean
-*/
-var $error;
-/**
-* File name and path of the image file
-* @var string
-*/
-var $fileName;
-/**
-* Image meta data if any is available (jpeg/tiff) via the exif library
-* @var array
-*/
-var $imageMeta;
-/**
-* Current dimensions of working image
-* @var array
-*/
-var $currentDimensions;
-/**
-* New dimensions of working image
-* @var array
-*/
-var $newDimensions;
-/**
-* Percentage to resize image b
-* @var int
-* @access private
-*/
-var $percent;
-/**
-* Maximum width of image during resize
-* @var int
-* @access private
-*/
-var $maxWidth;
-/**
-* Maximum height of image during resize
-* @var int
-* @access private
-*/
-var $maxHeight;
-/**
-* Image for Watermark
-* @var string
-*/
-var $watermarkImgPath;
-/**
-* Text for Watermark
-* @var string
-*/
-var $watermarkText;
-/**
-* Path to ImageMagick convert
-* @var string
-*/
-var $imageMagickDir;
-/**
-* String to execute ImageMagick convert.
-* @var string
-*/
-var $imageMagickExec;
-/**
-* String to execute ImageMagick composite.
-* @var string
-*/
-var $imageMagickComp;
-/**
-* String to execute ImageMagick (before the filename).
-* @var string
-*/
-var $imageMagickBefore;
+	/**
+	 * Error message to display, if any
+	 * @var string
+	 */
+	var $errmsg;
+	/**
+	 * Whether or not there is an error
+	 * @var boolean
+	 */
+	var $error;
+	/**
+	 * File name and path of the image file
+	 * @var string
+	 */
+	var $fileName;
+	/**
+	 * Image meta data if any is available (jpeg/tiff) via the exif library
+	 * @var array
+	 */
+	var $imageMeta;
+	/**
+	 * Current dimensions of working image
+	 * @var array
+	 */
+	var $currentDimensions;
+	/**
+	 * New dimensions of working image
+	 * @var array
+	 */
+	var $newDimensions;
+	/**
+	 * Percentage to resize image b
+	 * @var int
+	 * @access private
+	 */
+	var $percent;
+	/**
+	 * Maximum width of image during resize
+	 * @var int
+	 * @access private
+	 */
+	var $maxWidth;
+	/**
+	 * Maximum height of image during resize
+	 * @var int
+	 * @access private
+	 */
+	var $maxHeight;
+	/**
+	 * Image for Watermark
+	 * @var string
+	 */
+	var $watermarkImgPath;
+	/**
+	 * Text for Watermark
+	 * @var string
+	 */
+	var $watermarkText;
+	/**
+	 * Path to ImageMagick convert
+	 * @var string
+	 */
+	var $imageMagickDir;
+	/**
+	 * String to execute ImageMagick convert.
+	 * @var string
+	 */
+	var $imageMagickExec;
+	/**
+	 * String to execute ImageMagick composite.
+	 * @var string
+	 */
+	var $imageMagickComp;
+	/**
+	 * String to execute ImageMagick (before the filename).
+	 * @var string
+	 */
+	var $imageMagickBefore;
 
-  /*
-   * in: filename, error
-   * out: nothing 
-   * init of class: init of variables, detect needed memory (gd), image format (gd), detect image size (GetImageSize is general PHP, not GD), Image Meta?
-   */
+	/*
+	 * in: filename, error
+	 * out: nothing 
+	 * init of class: init of variables, detect needed memory (gd), image format (gd), detect image size (GetImageSize is general PHP, not GD), Image Meta?
+	 */
 
-	function ngg_Thumbnail($fileName, $no_ErrorImage = false) {
-		
+	function __construct( $fileName, $no_ErrorImage = false ) {
+
 		//initialize variables
-      	$this->errmsg				= '';
-      	$this->error				= false;
-      	$this->currentDimensions	= array();
-      	$this->newDimensions		= array();
-      	$this->fileName				= $fileName;
-      	$this->imageMeta			= array();
-      	$this->percent				= 100;
-      	$this->maxWidth				= 0;
-      	$this->maxHeight			= 0;
-      	$this->watermarkImgPath		= '';
-      	$this->watermarkText		= '';
-		$this->imageMagickExec		= '';
-      	$this->imageMagickComp		= '';
-      	$this->imageMagickBefore	= '';
+		$this->errmsg = '';
+		$this->error = false;
+		$this->currentDimensions = array();
+		$this->newDimensions = array();
+		$this->fileName = $fileName;
+		$this->imageMeta = array();
+		$this->percent = 100;
+		$this->maxWidth = 0;
+		$this->maxHeight = 0;
+		$this->watermarkImgPath = '';
+		$this->watermarkText = '';
+		$this->imageMagickExec = '';
+		$this->imageMagickComp = '';
+		$this->imageMagickBefore = '';
 
 		//make sure ImageMagick is installed
 		$this->checkVersion();
-      
+
 		//check to see if file exists
-		if(!file_exists($this->fileName)) {
+		if ( ! file_exists( $this->fileName ) ) {
 			$this->errmsg = 'File not found';
 			$this->error = true;
 		}
 		//check to see if file is readable
-		elseif(!is_readable($this->fileName)) {
+		elseif ( ! is_readable( $this->fileName ) ) {
 			$this->errmsg = 'File is not readable';
 			$this->error = true;
 		}
 
-		if($this->error == false) { 
-	    	$size = GetImageSize($this->fileName);
-      		$this->currentDimensions = array('width'=>$size[0],'height'=>$size[1]);
-	  	}
-	    
-		if($this->error == true) {
+		if ( $this->error == false ) {
+			$size = GetImageSize( $this->fileName );
+			$this->currentDimensions = array( 'width' => $size[0], 'height' => $size[1] );
+		}
+
+		if ( $this->error == true ) {
 			// for SinglePic send the error message out
-	    	if(!$no_ErrorImage) 
-	    		echo $this->errmsg;
-	    	return;
-	    }
+			if ( ! $no_ErrorImage )
+				echo $this->errmsg;
+			return;
+		}
 	}
 
 	function checkVersion() {
-		
+
 		// very often exec()or passthru() is disabled. No chance for Imagick
-		if ( ini_get('disable_functions') ) {
-			$not_allowed = ini_get('disable_functions');
-			if ( stristr($not_allowed, 'exec') || stristr($not_allowed, 'passthru') ) {
+		if ( ini_get( 'disable_functions' ) ) {
+			$not_allowed = ini_get( 'disable_functions' );
+			if ( stristr( $not_allowed, 'exec' ) || stristr( $not_allowed, 'passthru' ) ) {
 				$this->errmsg = 'exec() or passthru() is not allowed. Could not execute Imagick';
 				$this->error = true;
 				return false;
 			}
 		}
-		
+
 		// get the path to imageMagick
-		$ngg_options = get_option('ngg_options');
-		$this->imageMagickDir = trim( $ngg_options['imageMagickDir']);
+		$ngg_options = get_option( 'ngg_options' );
+		$this->imageMagickDir = trim( $ngg_options['imageMagickDir'] );
 		$this->imageMagickDir = str_replace( "\\", "/", $this->imageMagickDir );
 
 		// Try to get the ImageMagick version		
-		$magickv = $this->execute('convert', '-version');
-		
-		if ( empty($magickv) ) {
+		$magickv = $this->execute( 'convert', '-version' );
+
+		if ( empty ( $magickv ) ) {
 			$this->errmsg = 'Could not execute ImageMagick. Check path ';
 			$this->error = true;
 			return false;
 		}
-		
+
 		// We need as least version 6 or higher	
-		$helper = preg_match('/Version: ImageMagick ([0-9])/', $magickv[0], $magickversion);
-		if ( !$magickversion[0] > '5' ) {
+		$helper = preg_match( '/Version: ImageMagick ([0-9])/', $magickv[0], $magickversion );
+		if ( ! $magickversion[0] > '5' ) {
 			$this->errmsg = 'Require ImageMagick Version 6 or higher';
 			$this->error = true;
 			return false;
 		}
 
-      	return true;
+		return true;
 	}
-	
+
 
 	/**
-     * Execute ImageMagick/GraphicsMagick commands
-     *
-     * @param string $cmd an ImageMagick command (eg. "convert")
-     * @param string $args the arguments which should be passed
-     * @param bool �passthru(optional) output the result to the webserver instead
-     * @return void | if passthru return the image
-     */
-	function execute( $cmd, $args, $passthru = false) {
-		
+	 * Execute ImageMagick/GraphicsMagick commands
+	 *
+	 * @param string $cmd an ImageMagick command (eg. "convert")
+	 * @param string $args the arguments which should be passed
+	 * @param bool �passthru(optional) output the result to the webserver instead
+	 * @return void | if passthru return the image
+	 */
+	function execute( $cmd, $args, $passthru = false ) {
+
 		// in error case we do not continue
-		if($this->error == true)
+		if ( $this->error == true )
 			return;
 
 		//if path is not empty
-		if ($this->imageMagickDir != '') {
-		// the path must have a slash at the end
-			if ( $this->imageMagickDir{strlen($this->imageMagickDir)-1} != '/')
-		    	$this->imageMagickDir .= '/';
+		if ( $this->imageMagickDir != '' ) {
+			// the path must have a slash at the end
+			if ( $this->imageMagickDir { strlen( $this->imageMagickDir ) - 1} != '/' )
+				$this->imageMagickDir .= '/';
 		}
-	
+
 		//$args = escapeshellarg($args);
 		//var_dump( escapeshellcmd ( "{$this->imageMagickDir}/{$cmd} {$args}" ) ); return;
 		//$this->errmsg = escapeshellcmd( "{$this->imageMagickDir}{$cmd} {$args}" );
-		
-		if ( !$passthru ) {
+
+		if ( ! $passthru ) {
 			exec( "{$this->imageMagickDir}{$cmd} {$args}", $result );
 			//var_dump( "{$this->imageMagickDir}/{$cmd} {$args}" );
 			return $result;
-			
+
 		}
 		//var_dump( escapeshellcmd ( "{$this->imageMagickDir}/{$cmd} {$args}" ) ); return;
 
 		// for single pic we need the direct output
-		header('Content-type: image/jpeg');
+		header( 'Content-type: image/jpeg' );
 		$this->errmsg = "{$this->imageMagickDir}{$cmd} {$args}";
 		passthru( "{$this->imageMagickDir}{$cmd} {$args}" );
 	}
 
 
-    /**
-     * Must be called to free up allocated memory after all manipulations are done
-     */
-    function destruct() {
-     	//not needed for ImageMagick
+	/**
+	 * Must be called to free up allocated memory after all manipulations are done
+	 */
+	function destruct() {
+		//not needed for ImageMagick
 		return;
-    }
-    
-    /**
-     * Returns the current width of the image
-     * @return int
-     */
-    function getCurrentWidth() {
-        return $this->currentDimensions['width'];
-    }
+	}
 
-    /**
-     * Returns the current height of the image
-     * @return int
-     */
-    function getCurrentHeight() {
-        return $this->currentDimensions['height'];
-    }
+	/**
+	 * Returns the current width of the image
+	 * @return int
+	 */
+	function getCurrentWidth() {
+		return $this->currentDimensions['width'];
+	}
 
-    /**
-     * Calculates new image width
-     * @param int $width
-     * @param int $height
-     * @return array
-     */
-    function calcWidth($width, $height) {
-        $newWp = (100 * $this->maxWidth) / $width;
-        $newHeight = ($height * $newWp) / 100;
-        return array('newWidth'=>intval($this->maxWidth), 'newHeight'=>intval($newHeight));
-    }
+	/**
+	 * Returns the current height of the image
+	 * @return int
+	 */
+	function getCurrentHeight() {
+		return $this->currentDimensions['height'];
+	}
 
-    /**
-     * Calculates new image height
-     * @param int $width
-     * @param int $height
-     * @return array
-     */
-    function calcHeight($width, $height) {
-        $newHp = (100 * $this->maxHeight) / $height;
-        $newWidth = ($width * $newHp) / 100;
-        return array('newWidth'=>intval($newWidth), 'newHeight'=>intval($this->maxHeight));
-    }
+	/**
+	 * Calculates new image width
+	 * @param int $width
+	 * @param int $height
+	 * @return array
+	 */
+	function calcWidth( $width, $height ) {
+		$newWp = ( 100 * $this->maxWidth ) / $width;
+		$newHeight = ( $height * $newWp ) / 100;
+		return array( 'newWidth' => intval( $this->maxWidth ), 'newHeight' => intval( $newHeight ) );
+	}
 
-    /**
-     * Calculates new image size based on percentage
-     * @param int $width
-     * @param int $height
-     * @return array
-     */
-    function calcPercent($width, $height) {
-        $newWidth = ($width * $this->percent) / 100;
-        $newHeight = ($height * $this->percent) / 100;
-        return array('newWidth'=>intval($newWidth), 'newHeight'=>intval($newHeight));
-    }
+	/**
+	 * Calculates new image height
+	 * @param int $width
+	 * @param int $height
+	 * @return array
+	 */
+	function calcHeight( $width, $height ) {
+		$newHp = ( 100 * $this->maxHeight ) / $height;
+		$newWidth = ( $width * $newHp ) / 100;
+		return array( 'newWidth' => intval( $newWidth ), 'newHeight' => intval( $this->maxHeight ) );
+	}
 
-    /**
-     * Calculates new image size based on width and height, while constraining to maxWidth and maxHeight
-     * @param int $width
-     * @param int $height
-     */
-    function calcImageSize($width,$height) {
-        $newSize = array('newWidth'=>$width,'newHeight'=>$height);
+	/**
+	 * Calculates new image size based on percentage
+	 * @param int $width
+	 * @param int $height
+	 * @return array
+	 */
+	function calcPercent( $width, $height ) {
+		$newWidth = ( $width * $this->percent ) / 100;
+		$newHeight = ( $height * $this->percent ) / 100;
+		return array( 'newWidth' => intval( $newWidth ), 'newHeight' => intval( $newHeight ) );
+	}
 
-        if($this->maxWidth > 0) {
+	/**
+	 * Calculates new image size based on width and height, while constraining to maxWidth and maxHeight
+	 * @param int $width
+	 * @param int $height
+	 */
+	function calcImageSize( $width, $height ) {
+		$newSize = array( 'newWidth' => $width, 'newHeight' => $height );
 
-            $newSize = $this->calcWidth($width,$height);
+		if ( $this->maxWidth > 0 ) {
 
-            if($this->maxHeight > 0 && $newSize['newHeight'] > $this->maxHeight) {
-                $newSize = $this->calcHeight($newSize['newWidth'],$newSize['newHeight']);
-            }
+			$newSize = $this->calcWidth( $width, $height );
 
-            //$this->newDimensions = $newSize;
-        }
+			if ( $this->maxHeight > 0 && $newSize['newHeight'] > $this->maxHeight ) {
+				$newSize = $this->calcHeight( $newSize['newWidth'], $newSize['newHeight'] );
+			}
 
-        if($this->maxHeight > 0) {
-            $newSize = $this->calcHeight($width,$height);
+			//$this->newDimensions = $newSize;
+		}
 
-            if($this->maxWidth > 0 && $newSize['newWidth'] > $this->maxWidth) {
-                $newSize = $this->calcWidth($newSize['newWidth'],$newSize['newHeight']);
-            }
+		if ( $this->maxHeight > 0 ) {
+			$newSize = $this->calcHeight( $width, $height );
 
-            //$this->newDimensions = $newSize;
-        }
+			if ( $this->maxWidth > 0 && $newSize['newWidth'] > $this->maxWidth ) {
+				$newSize = $this->calcWidth( $newSize['newWidth'], $newSize['newHeight'] );
+			}
 
-        $this->newDimensions = $newSize;
-    }
+			//$this->newDimensions = $newSize;
+		}
 
-    /**
-     * Calculates new image size based percentage
-     * @param int $width
-     * @param int $height
-     */
-    function calcImageSizePercent($width,$height) {
-        if($this->percent > 0) {
-            $this->newDimensions = $this->calcPercent($width,$height);
-        }
-    }
+		$this->newDimensions = $newSize;
+	}
 
-    /**
-     * Resizes image to maxWidth x maxHeight
-     *
-     * @param int $maxWidth
-     * @param int $maxHeight
-     */
-	  
-	function resize($maxWidth = 0, $maxHeight = 0, $resampleMode = 3) {
+	/**
+	 * Calculates new image size based percentage
+	 * @param int $width
+	 * @param int $height
+	 */
+	function calcImageSizePercent( $width, $height ) {
+		if ( $this->percent > 0 ) {
+			$this->newDimensions = $this->calcPercent( $width, $height );
+		}
+	}
+
+	/**
+	 * Resizes image to maxWidth x maxHeight
+	 *
+	 * @param int $maxWidth
+	 * @param int $maxHeight
+	 */
+
+	function resize( $maxWidth = 0, $maxHeight = 0, $resampleMode = 3 ) {
 		$this->maxWidth = $maxWidth;
-    	$this->maxHeight = $maxHeight;
+		$this->maxHeight = $maxHeight;
 
-    	$this->calcImageSize($this->currentDimensions['width'],$this->currentDimensions['height']);
+		$this->calcImageSize( $this->currentDimensions['width'], $this->currentDimensions['height'] );
 
 		//string to resize the picture to $this->newDimensions['newWidth'],$this->newDimensions['newHeight']
 		//should result in: -thumbnail $this->newDimensions['newWidth']x$this->newDimensions['newHeight']
-		if($maxWidth=='0')
-			$this->imageMagickExec .= " -resize x".$maxHeight;
-		elseif($maxHeight=='0')
-			$this->imageMagickExec .= " -resize ".$maxWidth."x";
-		elseif($maxHeight!='0' && $maxWidth!='0')
-			$this->imageMagickExec .= " -resize ".$maxWidth."x".$maxHeight;
-			
+		if ( $maxWidth == '0' )
+			$this->imageMagickExec .= " -resize x" . $maxHeight;
+		elseif ( $maxHeight == '0' )
+			$this->imageMagickExec .= " -resize " . $maxWidth . "x";
+		elseif ( $maxHeight != '0' && $maxWidth != '0' )
+			$this->imageMagickExec .= " -resize " . $maxWidth . "x" . $maxHeight;
+
 		// next calculations should be done with the 'new' dimensions
 		$this->currentDimensions['width'] = $this->newDimensions['newWidth'];
 		$this->currentDimensions['height'] = $this->newDimensions['newHeight'];
-		
+
 	}
 
 	/**
@@ -361,47 +361,49 @@ var $imageMagickBefore;
 	 * @param bool $vert flip the image in vertical mode
 	 */
 	function flipImage( $horz = false, $vert = false ) {
-		
+
 		//TODO: need to be added
 
 	}
-	
-	/**
-     * Rotates image either 90 degrees clockwise or counter-clockwise
-     *
-     * @param string $direction
-     */
-	function rotateImage($dir = 'CW') {
-		
-		$angle = ($dir == 'CW') ? 90 : -90;
 
-  		$this->imageMagickExec .= " -rotate $angle ";
-		
+	/**
+	 * Rotates image either 90 degrees clockwise or counter-clockwise
+	 *
+	 * @param string $direction
+	 */
+	function rotateImage( $dir = 'CW' ) {
+
+		$angle = ( $dir == 'CW' ) ? 90 : -90;
+
+		$this->imageMagickExec .= " -rotate $angle ";
+
 		$newWidth = $this->currentDimensions['height'];
-	   	$newHeight = $this->currentDimensions['width'];
+		$newHeight = $this->currentDimensions['width'];
 		$this->currentDimensions['width'] = $newWidth;
 		$this->currentDimensions['height'] = $newHeight;
 	}
 
-   /**
+	/**
 	 * Crops the image from calculated center in a square of $cropSize pixels
 	 *
 	 * @param int $cropSize
 	 */
-	function cropFromCenter($cropSize, $resampleMode = 3) {
-	   if($cropSize > $this->currentDimensions['width']) $cropSize = $this->currentDimensions['width'];
-	   if($cropSize > $this->currentDimensions['height']) $cropSize = $this->currentDimensions['height'];
+	function cropFromCenter( $cropSize, $resampleMode = 3 ) {
+		if ( $cropSize > $this->currentDimensions['width'] )
+			$cropSize = $this->currentDimensions['width'];
+		if ( $cropSize > $this->currentDimensions['height'] )
+			$cropSize = $this->currentDimensions['height'];
 
-	   //$cropX = intval(($this->currentDimensions['width'] - $cropSize) / 2);
-	   //$cropY = intval(($this->currentDimensions['height'] - $cropSize) / 2);
+		//$cropX = intval(($this->currentDimensions['width'] - $cropSize) / 2);
+		//$cropY = intval(($this->currentDimensions['height'] - $cropSize) / 2);
 
 		//string to crop the picture to $cropSize,$cropSize (from center)
 		//result: -gravity Center -crop $cropSizex$cropSize+0+0
 		$this->imageMagickExec .= ' -gravity Center -crop ' . $cropSize . 'x' . $cropSize . '+0+0';
-		
+
 		// next calculations should be done with the 'new' dimensions
 		$this->currentDimensions['width'] = $cropSize;
-		$this->currentDimensions['height'] = $cropSize;		
+		$this->currentDimensions['height'] = $cropSize;
 	}
 
 	/**
@@ -412,19 +414,25 @@ var $imageMagickBefore;
 	 * @param int $width
 	 * @param int $height
 	 */
-	function crop($startX,$startY,$width,$height) {
-	    //make sure the cropped area is not greater than the size of the image
-	   if($width > $this->currentDimensions['width']) $width = $this->currentDimensions['width'];
-	   if($height > $this->currentDimensions['height']) $height = $this->currentDimensions['height'];
-	    //make sure not starting outside the image
-	   if(($startX + $width) > $this->currentDimensions['width']) $startX = ($this->currentDimensions['width'] - $width);
-	   if(($startY + $height) > $this->currentDimensions['height']) $startY = ($this->currentDimensions['height'] - $height);
-	   if($startX < 0) $startX = 0;
-	   if($startY < 0) $startY = 0;
+	function crop( $startX, $startY, $width, $height ) {
+		//make sure the cropped area is not greater than the size of the image
+		if ( $width > $this->currentDimensions['width'] )
+			$width = $this->currentDimensions['width'];
+		if ( $height > $this->currentDimensions['height'] )
+			$height = $this->currentDimensions['height'];
+		//make sure not starting outside the image
+		if ( ( $startX + $width ) > $this->currentDimensions['width'] )
+			$startX = ( $this->currentDimensions['width'] - $width );
+		if ( ( $startY + $height ) > $this->currentDimensions['height'] )
+			$startY = ( $this->currentDimensions['height'] - $height );
+		if ( $startX < 0 )
+			$startX = 0;
+		if ( $startY < 0 )
+			$startY = 0;
 
 		//string to crop the picture to $width,$height (from $startX,$startY)
 		//result: -crop $widthx$height+$startX+$startY
-		$this->imageMagickExec .= ' -crop ' . $width . 'x' . $height . '+' . $startX .'+' . $startY;
+		$this->imageMagickExec .= ' -crop ' . $width . 'x' . $height . '+' . $startX . '+' . $startY;
 
 		$this->currentDimensions['width'] = $width;
 		$this->currentDimensions['height'] = $height;
@@ -439,118 +447,136 @@ var $imageMagickBefore;
 	 * @param bool $border
 	 * @param string $borderColor
 	 */
-	function createReflection($percent, $reflection, $white, $border = true, $borderColor = '#a4a4a4') {
+	function createReflection( $percent, $reflection, $white, $border = true, $borderColor = '#a4a4a4' ) {
 
-	    $width = $this->currentDimensions['width'];
-	    $height = $this->currentDimensions['height'];
-	
-	    $reflectionHeight = intval($height * ($reflection / 100));
-	    $newHeight = $height + $reflectionHeight;
-	        //$reflectedPart = $height * ((100-$percent) / 100);
-	    $reflectedsize = intval($height * ((100 - (100 - $percent) + $reflection) / 100)); 
-			
-		$this->imageMagickBefore = "-size $width" . "x" ."$newHeight xc:white ";
-			
-		if($border == true) {
-			$this->imageMagickBefore .= " \( ";	 
+		$width = $this->currentDimensions['width'];
+		$height = $this->currentDimensions['height'];
+
+		$reflectionHeight = intval( $height * ( $reflection / 100 ) );
+		$newHeight = $height + $reflectionHeight;
+		//$reflectedPart = $height * ((100-$percent) / 100);
+		$reflectedsize = intval( $height * ( ( 100 - ( 100 - $percent ) + $reflection ) / 100 ) );
+
+		$this->imageMagickBefore = "-size $width" . "x" . "$newHeight xc:white ";
+
+		if ( $border == true ) {
+			$this->imageMagickBefore .= " \( ";
 			$this->imageMagickExec = " -bordercolor '$borderColor' -border 1 \) ";
 		}
 
 		$this->imageMagickExec .= " -geometry +0+0 -composite ";
-		$gradientWhite = 100-$white;
-		$this->imageMagickExec .= " \( '$this->fileName' -flip -resize $width"."x"."$reflectedsize\! \( -size $width"."x"."$reflectionHeight gradient: -fill black -colorize $gradientWhite \) +matte -compose copy_opacity -composite \) -geometry +0+$height -composite ";
+		$gradientWhite = 100 - $white;
+		$this->imageMagickExec .= " \( '$this->fileName' -flip -resize $width" . "x" . "$reflectedsize\! \( -size $width" . "x" . "$reflectionHeight gradient: -fill black -colorize $gradientWhite \) +matte -compose copy_opacity -composite \) -geometry +0+$height -composite ";
 
 		$this->currentDimensions['width'] = $width;
 		$this->currentDimensions['height'] = $newHeight;
 	}
-	
+
 	/**
- 	 * @param string $color
+	 * @param string $color
 	 * @param string $wmFont
 	 * @param int $wmSize
- 	 * @param int $wmOpaque
-     */
-	function watermarkCreateText($wmFont, $color = '000000', $wmSize = 10, $wmOpaque = 90 ){
+	 * @param int $wmOpaque
+	 */
+	function watermarkCreateText( $wmFont, $color = '000000', $wmSize = 10, $wmOpaque = 90 ) {
 		//create a watermark.png image with the requested text.
-		
+
 		// set font path
 		$wmFontPath = NGGALLERY_ABSPATH . 'fonts/' . $wmFont;
-		if ( !is_readable($wmFontPath) )
-			return;	
-			
+		if ( ! is_readable( $wmFontPath ) )
+			return;
+
 		/*
-		$exec = "convert -size 800x500 xc:grey30 -font $wmFontPath -pointsize $wmSize -gravity center -draw \"fill '#$color$wmOpaque'  text 0,0  '$this->watermarkText'\" stamp_fgnd.png"; 
-		$make_magick = system($exec);
-		$exec = "convert -size 800x500 xc:black -font $wmFontPath -pointsize $wmSize -gravity center -draw \"fill white  text  1,1  '$this->watermarkText'  text  0,0  '$this->watermarkText' fill black  text -1,-1 '$this->watermarkText'\" +matte stamp_mask.png";
-		$make_magick = system($exec);
-		$exec = "composite -compose CopyOpacity  stamp_mask.png  stamp_fgnd.png  watermark.png";*/
+			  $exec = "convert -size 800x500 xc:grey30 -font $wmFontPath -pointsize $wmSize -gravity center -draw \"fill '#$color$wmOpaque'  text 0,0  '$this->watermarkText'\" stamp_fgnd.png"; 
+			  $make_magick = system($exec);
+			  $exec = "convert -size 800x500 xc:black -font $wmFontPath -pointsize $wmSize -gravity center -draw \"fill white  text  1,1  '$this->watermarkText'  text  0,0  '$this->watermarkText' fill black  text -1,-1 '$this->watermarkText'\" +matte stamp_mask.png";
+			  $make_magick = system($exec);
+			  $exec = "composite -compose CopyOpacity  stamp_mask.png  stamp_fgnd.png  watermark.png";*/
 
 		//convert the opacity between FF or 00; 100->0 and 0->FF (256)
-		$opacity = dechex( round( (100-$wmOpaque) * 256/100 ) );
-		if ($opacity == "0") {$opacity = "00";} 
-		
+		$opacity = dechex( round( ( 100 - $wmOpaque ) * 256 / 100 ) );
+		if ( $opacity == "0" ) {
+			$opacity = "00";
+		}
+
 		$cmd = "-size 800x500 xc:none -fill '{$color}{$opacity}' -font {$wmFontPath} -pointsize {$wmSize} -gravity center -annotate 0 '{$this->watermarkText}' watermark_text.png";
-		$this->execute('convert', $cmd);
-		
-		$cmd = "-trim +repage watermark_text.png";		 
-		$this->execute('mogrify', $cmd);
-	
+		$this->execute( 'convert', $cmd );
+
+		$cmd = "-trim +repage watermark_text.png";
+		$this->execute( 'mogrify', $cmd );
+
 		$this->watermarkImgPath = NGGALLERY_ABSPATH . 'watermark_text.png';
 
-		return;		
+		return;
 	}
-    
-    /**
-     *
- 	 * @param string $relPOS
+
+	/**
+	 *
+	 * @param string $relPOS
 	 * @param int $xPOS
- 	 * @param int $yPOS
-     */
-    function watermarkImage( $relPOS = 'botRight', $xPOS = 0, $yPOS = 0) {
+	 * @param int $yPOS
+	 */
+	function watermarkImage( $relPOS = 'botRight', $xPOS = 0, $yPOS = 0 ) {
 
 		// if it's not a valid file die... 
 		/*if ( !is_readable($this->watermarkImgPath))
-		{
-			echo $this->watermarkImgPath;
-			return;
-		}	*/
+			  {
+				  echo $this->watermarkImgPath;
+				  return;
+			  }	*/
 
-		$size = GetImageSize($this->watermarkImgPath);
-    	$watermarkDimensions = array('width'=>$size[0],'height'=>$size[1]);
-		
-		$sourcefile_width=$this->currentDimensions['width'];
-		$sourcefile_height=$this->currentDimensions['height'];
-		
-		$watermarkfile_width=$watermarkDimensions['width'];
-		$watermarkfile_height=$watermarkDimensions['height'];
+		$size = GetImageSize( $this->watermarkImgPath );
+		$watermarkDimensions = array( 'width' => $size[0], 'height' => $size[1] );
 
-		switch( substr($relPOS, 0, 3) ){
-			case 'top': $dest_y = 0 + $yPOS; break;
-			case 'mid': $dest_y = ($sourcefile_height / 2) - ($watermarkfile_height / 2); break;
-			case 'bot': $dest_y = $sourcefile_height - $watermarkfile_height - $yPOS; break;
-			default   : $dest_y = 0; break;
+		$sourcefile_width = $this->currentDimensions['width'];
+		$sourcefile_height = $this->currentDimensions['height'];
+
+		$watermarkfile_width = $watermarkDimensions['width'];
+		$watermarkfile_height = $watermarkDimensions['height'];
+
+		switch ( substr( $relPOS, 0, 3 ) ) {
+			case 'top':
+				$dest_y = 0 + $yPOS;
+				break;
+			case 'mid':
+				$dest_y = ( $sourcefile_height / 2 ) - ( $watermarkfile_height / 2 );
+				break;
+			case 'bot':
+				$dest_y = $sourcefile_height - $watermarkfile_height - $yPOS;
+				break;
+			default:
+				$dest_y = 0;
+				break;
 		}
-		switch( substr($relPOS, 3) ){
-			case 'Left'	:	$dest_x = 0 + $xPOS; break;
-			case 'Center':	$dest_x = ($sourcefile_width / 2) - ($watermarkfile_width / 2); break;
-			case 'Right':	$dest_x = $sourcefile_width - $watermarkfile_width - $xPOS; break;
-			default : 		$dest_x = 0; break;
+		switch ( substr( $relPOS, 3 ) ) {
+			case 'Left':
+				$dest_x = 0 + $xPOS;
+				break;
+			case 'Center':
+				$dest_x = ( $sourcefile_width / 2 ) - ( $watermarkfile_width / 2 );
+				break;
+			case 'Right':
+				$dest_x = $sourcefile_width - $watermarkfile_width - $xPOS;
+				break;
+			default:
+				$dest_x = 0;
+				break;
 		}
-		if ($dest_y<0) {
-			$dest_y = $dest_y; 
-		} else { 
+		if ( $dest_y < 0 ) {
+			$dest_y = $dest_y;
+		} else {
 			$dest_y = '+' . $dest_y;
 		}
-		if ($dest_x<0) {
-			$dest_x = $dest_x; 
-		} else { 
+		if ( $dest_x < 0 ) {
+			$dest_x = $dest_x;
+		} else {
 			$dest_x = '+' . $dest_x;
 		}
-		
-		$this->imageMagickComp .=  "'$this->watermarkImgPath' -geometry $dest_x$dest_y  -composite";
+
+		$this->imageMagickComp .= "'$this->watermarkImgPath' -geometry $dest_x$dest_y  -composite";
 		//" -dissolve 80% -geometry +$dest_x+$dest_y $this->watermarkImgPath";
 	}
-    
+
 	/**
 	 * Saves image as $name (can include file path), with quality of # percent if file is a jpeg
 	 *
@@ -559,38 +585,38 @@ var $imageMagickBefore;
 	 * @return bool errorstate
 	 */
 	function save( $name, $quality = 85 ) {
-	    $this->show($quality,$name);
-	    if ($this->error == true) {
-	    	//$this->errmsg = 'Create Image failed. Check safe mode settings';
-	    	return false;
-	    }
-        
-        if( function_exists('do_action') )
-	       do_action('ngg_ajax_image_save', $name);
+		$this->show( $quality, $name );
+		if ( $this->error == true ) {
+			//$this->errmsg = 'Create Image failed. Check safe mode settings';
+			return false;
+		}
 
-	    return true;
+		if ( function_exists( 'do_action' ) )
+			do_action( 'ngg_ajax_image_save', $name );
+
+		return true;
 	}
-	    
+
 	/**
 	 * Outputs the image to the screen, or saves to $name if supplied.  Quality of JPEG images can be controlled with the $quality variable
 	 *
 	 * @param int $quality
 	 * @param string $name
 	 */
-	function show( $quality = 85, $name = '') {
+	function show( $quality = 85, $name = '' ) {
 		//save the image if we get a filename
-		if( $name != '' ) {
+		if ( $name != '' ) {
 			$args = "{$this->imageMagickBefore} ";
-			$args .= escapeshellarg("$this->fileName");
+			$args .= escapeshellarg( "$this->fileName" );
 			$args .= " $this->imageMagickExec $this->imageMagickComp -quality '$quality' ";
-			$args .= escapeshellarg("$name");
+			$args .= escapeshellarg( "$name" );
 			//$args = "{$this->imageMagickBefore} '$this->fileName' $this->imageMagickExec $this->imageMagickComp -quality $quality '$name'";
-			$this->execute('convert', $args);
+			$this->execute( 'convert', $args );
 			//$this->error = true;			
-	  } else {
-	  	//return a raw image stream
-			$args = "{$this->imageMagickBefore} '$this->fileName' $this->imageMagickExec $this->imageMagickComp -quality $quality JPG:-"; 
-			$this->execute('convert', $args, true);
+		} else {
+			//return a raw image stream
+			$args = "{$this->imageMagickBefore} '$this->fileName' $this->imageMagickExec $this->imageMagickComp -quality $quality JPG:-";
+			$this->execute( 'convert', $args, true );
 			$this->error = true;
 		}
 	}

--- a/lib/locale.php
+++ b/lib/locale.php
@@ -1,144 +1,144 @@
 <?php
-if ( !class_exists('ngg_locale') ) :
-/**
- * Install locale files from WordPress.org plugin repository
- * 
- * @version 1.0.0
- * @author Alex Rabe
- * 
- * @package NextGEN Gallery
- * @since 1.5.0
- */
-
-class ngg_locale {
-
+if ( ! class_exists( 'ngg_locale' ) ) :
 	/**
-     * Current locale
-     *
-     * @var string
-     */
-    var $locale = '';
-
-	/**
-     * Plugin domain name
-     *
-     * @var string
-     */
-    var $domain = 'nggallery';
-
-	/**
-     * URL to the translation files
-     *
-     * @var string
-     */
-    var $remote_locale_url = 'http://nextgen-gallery.googlecode.com/files/';
-
-	/**
-     * Plugin path to the langauage files 
-     *
-     * @var string
-     */
-    var $plugin_locale_path = 'lang';
-
-	/**
-     * Server path to the locale file on the server
-     *
-     * @var string
-     */
-    var $mo_file = '';
-
-	/**
-     * URL to the locale file from the remote server
-     *
-     * @var string
-     */
-    var $mo_url = '';
-    
-	/**
-     * Repsonse code for request
-     *
-     * @var array
-     */
-    var $repsonse = '';
-
-    /**
-     * Init the Database Abstraction layer for NextGEN Gallery
-     * 
-     */ 
-    function __construct() {
-    	$this->plugin_locale_path = NGGALLERY_ABSPATH . 'lang/';
-    	$this->locale = get_locale();
-
-    	$this->mo_file = trailingslashit($this->plugin_locale_path) . $this->domain . '-' . $this->locale . '.mo';
-		$this->mo_url  = trailingslashit($this->remote_locale_url) . $this->domain . '-' . $this->locale . '.mo';
-    }
-    
-	/**
-	 * This functions checks if a translation is at wp.org available
-	 * Please note, if a language file is already loaded it exits as well
-	 *
-	 * @return string result of check ( default | installed | not_exist | available )
+	 * Install locale files from WordPress.org plugin repository
+	 * 
+	 * @version 1.0.0
+	 * @author Alex Rabe
+	 * 
+	 * @package NextGEN Gallery
+	 * @since 1.5.0
 	 */
-    function check() {
-    	
-    	// we do not need to check for translation if you use english
-    	if ( ($this->locale == 'en_US') )
-    		return 'default';
-		
-		$this->response = wp_remote_get($this->mo_url, array('timeout' => 300));
-    		
-    	// if a language file exist, do not load it again
-		if ( is_readable( $this->mo_file ) ) 
-			return 'installed';
 
-		// if no translation file exists exit the check
-		if ( is_wp_error($this->response) || $this->response['response']['code'] != '200' )
-			return 'not_exist';
-		
-		return 'available';		
-    }
+	class ngg_locale {
 
-	/**
-	 * Downloads a locale to the plugin folder using the WordPress HTTP Class.
-	 *
-	 * @author taken from WP core 
-	 * @return mixed WP_Error on failure, true on success.
-	 */
-	function download_locale() {
-		
-		$url = $this->mo_url;
+		/**
+		 * Current locale
+		 *
+		 * @var string
+		 */
+		private string $locale = '';
 
-		if ( ! $url )
-			return new WP_Error('http_no_url', __('Invalid URL Provided.'));
-	
-		$filename = $this->mo_file;
-		if ( ! $filename )
-			return new WP_Error('http_no_file', __('Could not create Temporary file.'));
-	
-		$handle = @fopen($filename, 'wb');
-		if ( ! $handle )
-			return new WP_Error('http_no_file', __('Could not create Temporary file.'));
-	
-		$response = wp_remote_get($url, array('timeout' => 300));
+		/**
+		 * Plugin domain name
+		 *
+		 * @var string
+		 */
+		private string $domain = 'nggallery';
 
-		if ( is_wp_error($response) ) {
-			fclose($handle);
-			unlink($filename);
-			return $response;
+		/**
+		 * URL to the translation files
+		 *
+		 * @var string
+		 */
+		private string $remote_locale_url = 'http://nextgen-gallery.googlecode.com/files/';
+
+		/**
+		 * Plugin path to the langauage files 
+		 *
+		 * @var string
+		 */
+		private string $plugin_locale_path = 'lang';
+
+		/**
+		 * Server path to the locale file on the server
+		 *
+		 * @var string
+		 */
+		private string $mo_file = '';
+
+		/**
+		 * URL to the locale file from the remote server
+		 *
+		 * @var string
+		 */
+		private string $mo_url = '';
+
+		/**
+		 * Repsonse code for request
+		 *
+		 * @var array|WP_Error
+		 */
+		private $repsonse = '';
+
+		/**
+		 * Init the Database Abstraction layer for NextGEN Gallery
+		 * 
+		 */
+		function __construct() {
+			$this->plugin_locale_path = NGGALLERY_ABSPATH . 'lang/';
+			$this->locale = get_locale();
+
+			$this->mo_file = trailingslashit( $this->plugin_locale_path ) . $this->domain . '-' . $this->locale . '.mo';
+			$this->mo_url = trailingslashit( $this->remote_locale_url ) . $this->domain . '-' . $this->locale . '.mo';
 		}
-	
-		if ( $response['response']['code'] != '200' ){
-			fclose($handle);
-			unlink($filename);
-			return new WP_Error('http_404', trim($response['response']['message']));
+
+		/**
+		 * This functions checks if a translation is at wp.org available
+		 * Please note, if a language file is already loaded it exits as well
+		 *
+		 * @return string result of check ( default | installed | not_exist | available )
+		 */
+		function check() {
+
+			// we do not need to check for translation if you use english
+			if ( ( $this->locale == 'en_US' ) )
+				return 'default';
+
+			$this->response = wp_remote_get( $this->mo_url, array( 'timeout' => 300 ) );
+
+			// if a language file exist, do not load it again
+			if ( is_readable( $this->mo_file ) )
+				return 'installed';
+
+			// if no translation file exists exit the check
+			if ( is_wp_error( $this->response ) || $this->response['response']['code'] != '200' )
+				return 'not_exist';
+
+			return 'available';
 		}
-	
-		fwrite($handle, $response['body']);
-		fclose($handle);
-	
-		return true;
+
+		/**
+		 * Downloads a locale to the plugin folder using the WordPress HTTP Class.
+		 *
+		 * @author taken from WP core 
+		 * @return mixed WP_Error on failure, true on success.
+		 */
+		function download_locale() {
+
+			$url = $this->mo_url;
+
+			if ( ! $url )
+				return new WP_Error( 'http_no_url', __( 'Invalid URL Provided.' ) );
+
+			$filename = $this->mo_file;
+			if ( ! $filename )
+				return new WP_Error( 'http_no_file', __( 'Could not create Temporary file.' ) );
+
+			$handle = @fopen( $filename, 'wb' );
+			if ( ! $handle )
+				return new WP_Error( 'http_no_file', __( 'Could not create Temporary file.' ) );
+
+			$response = wp_remote_get( $url, array( 'timeout' => 300 ) );
+
+			if ( is_wp_error( $response ) ) {
+				fclose( $handle );
+				unlink( $filename );
+				return $response;
+			}
+
+			if ( $response['response']['code'] != '200' ) {
+				fclose( $handle );
+				unlink( $filename );
+				return new WP_Error( 'http_404', trim( $response['response']['message'] ) );
+			}
+
+			fwrite( $handle, $response['body'] );
+			fclose( $handle );
+
+			return true;
+		}
+
 	}
-
-}
 endif;
 ?>

--- a/lib/media-rss.php
+++ b/lib/media-rss.php
@@ -1,75 +1,75 @@
 <?php
 /**
-* Class to produce Media RSS nodes
-* 
-* @author 		Vincent Prat
-* @copyright 	Copyright 2008-2011
-*/
+ * Class to produce Media RSS nodes
+ * 
+ * @author 		Vincent Prat
+ * @copyright 	Copyright 2008-2011
+ */
 class nggMediaRss {
-	
+
 	/**
 	 * Function called by the wp_head action to output the RSS link for medias
 	 */
 	static function add_mrss_alternate_link() {
-		echo "<link id='MediaRSS' rel='alternate' type='application/rss+xml' title='NextGEN Gallery RSS Feed' href='" . nggMediaRss::get_mrss_url() . "' />\n";		
+		echo "<link id='MediaRSS' rel='alternate' type='application/rss+xml' title='NextGEN Gallery RSS Feed' href='" . nggMediaRss::get_mrss_url() . "' />\n";
 	}
-	
+
 	/**
 	 * Add the javascript required to enable PicLens/CoolIris support 
 	 */
 	static function add_piclens_javascript() {
-        if (is_ssl())
-            wp_enqueue_script( 'piclens', 'https://lite.piclens.com/current/piclens_optimized.js', array(), false, true);
+		if ( is_ssl() )
+			wp_enqueue_script( 'piclens', 'https://lite.piclens.com/current/piclens_optimized.js', array(), false, true );
 		else
-            wp_enqueue_script( 'piclens', 'http://lite.piclens.com/current/piclens_optimized.js', array(), false, true);
+			wp_enqueue_script( 'piclens', 'http://lite.piclens.com/current/piclens_optimized.js', array(), false, true );
 	}
-	
+
 	/**
 	 * Get the URL of the general media RSS
 	 */
 	static function get_mrss_url() {
 		return NGGALLERY_URLPATH . 'xml/media-rss.php';
 	}
-	
+
 	/**
 	 * Get the URL of a gallery media RSS
 	 */
-	static function get_gallery_mrss_url($gid, $prev_next = false) {
-		return nggMediaRss::get_mrss_url() . '?' . ('gid=' . $gid . ($prev_next ? '&prev_next=true' : '') . '&mode=gallery');
+	static function get_gallery_mrss_url( $gid, $prev_next = false ) {
+		return nggMediaRss::get_mrss_url() . '?' . ( 'gid=' . $gid . ( $prev_next ? '&prev_next=true' : '' ) . '&mode=gallery' );
 	}
-	
+
 	/**
 	 * Get the URL of an album media RSS
 	 */
-	static function get_album_mrss_url($aid) {
-		return nggMediaRss::get_mrss_url() . '?' . ('aid=' . $aid . '&mode=album');
+	static function get_album_mrss_url( $aid ) {
+		return nggMediaRss::get_mrss_url() . '?' . ( 'aid=' . $aid . '&mode=album' );
 	}
-	
+
 	/**
 	 * Get the URL of the media RSS for last pictures
 	 */
-	static function get_last_pictures_mrss_url($page = 0, $show = 30) {
-		return nggMediaRss::get_mrss_url() . '?' . ('show=' . $show . '&page=' . $page . '&mode=last_pictures');
+	static function get_last_pictures_mrss_url( $page = 0, $show = 30 ) {
+		return nggMediaRss::get_mrss_url() . '?' . ( 'show=' . $show . '&page=' . $page . '&mode=last_pictures' );
 	}
-	
+
 	/**
 	 * Get the XML <rss> node corresponding to the last pictures registered
 	 *
-	 * @param page The current page (defaults to 0)
-	 * @param show The number of pictures to include in one field (default 30) 
+	 * @param int The current page (defaults to 0)
+	 * @param int The number of pictures to include in one field (default 30) 
 	 */
-	static function get_last_pictures_mrss($page = 0, $show = 30) {
-		$images = nggdb::find_last_images($page, $show);
-		
-		$title = stripslashes(get_option('blogname'));
-		$description = stripslashes(get_option('blogdescription'));
+	static function get_last_pictures_mrss( $page = 0, $show = 30 ) {
+		$images = nggdb::find_last_images( $page, $show );
+
+		$title = stripslashes( get_option( 'blogname' ) );
+		$description = stripslashes( get_option( 'blogdescription' ) );
 		$link = site_url();
-		$prev_link = ($page > 0) ? nggMediaRss::get_last_pictures_mrss_url($page-1, $show) : '';
-		$next_link = count($images)!=0 ? nggMediaRss::get_last_pictures_mrss_url($page+1, $show) : '';
-		
-		return nggMediaRss::get_mrss_root_node($title, $description, $link, $prev_link, $next_link, $images);
+		$prev_link = ( $page > 0 ) ? nggMediaRss::get_last_pictures_mrss_url( $page - 1, $show ) : '';
+		$next_link = count( $images ) != 0 ? nggMediaRss::get_last_pictures_mrss_url( $page + 1, $show ) : '';
+
+		return nggMediaRss::get_mrss_root_node( $title, $description, $link, $prev_link, $next_link, $images );
 	}
-	
+
 	/**
 	 * Get the XML <rss> node corresponding to a gallery
 	 *
@@ -77,173 +77,173 @@ class nggMediaRss {
 	 * @param $prev_gallery (object) The previous gallery to link in RSS (null if none)
 	 * @param $next_gallery (object) The next gallery to link in RSS (null if none)
 	 */
-	static function get_gallery_mrss($gallery, $prev_gallery = null, $next_gallery = null) {
+	static function get_gallery_mrss( $gallery, $prev_gallery = null, $next_gallery = null ) {
 		global $nggdb;
 
-		$ngg_options = nggGallery::get_option('ngg_options');
+		$ngg_options = nggGallery::get_option( 'ngg_options' );
 		//Set sort order value, if not used (upgrade issue)
-		$ngg_options['galSort'] = ($ngg_options['galSort']) ? $ngg_options['galSort'] : 'pid';
-		$ngg_options['galSortDir'] = ($ngg_options['galSortDir'] == 'DESC') ? 'DESC' : 'ASC';
-	
-		$title = stripslashes(nggGallery::i18n($gallery->title));
-		$description = stripslashes(nggGallery::i18n($gallery->galdesc));
-		$link = nggMediaRss::get_permalink($gallery->pageid);
-		$prev_link = ( $prev_gallery != null) ? nggMediaRss::get_gallery_mrss_url($prev_gallery->gid, true) : '';
-		$next_link = ( $next_gallery != null) ? nggMediaRss::get_gallery_mrss_url($next_gallery->gid, true) : '';
-		//20140106:shouldn't call it statically when is not...
-        //$images = nggdb::get_gallery($gallery->gid, $ngg_options['galSort'], $ngg_options['galSortDir']);
-		$images = $nggdb->get_gallery($gallery->gid, $ngg_options['galSort'], $ngg_options['galSortDir']);
+		$ngg_options['galSort'] = ( $ngg_options['galSort'] ) ? $ngg_options['galSort'] : 'pid';
+		$ngg_options['galSortDir'] = ( $ngg_options['galSortDir'] == 'DESC' ) ? 'DESC' : 'ASC';
 
-		return nggMediaRss::get_mrss_root_node($title, $description, $link, $prev_link, $next_link, $images);
+		$title = stripslashes( nggGallery::i18n( $gallery->title ) );
+		$description = stripslashes( nggGallery::i18n( $gallery->galdesc ) );
+		$link = nggMediaRss::get_permalink( $gallery->pageid );
+		$prev_link = ( $prev_gallery != null ) ? nggMediaRss::get_gallery_mrss_url( $prev_gallery->gid, true ) : '';
+		$next_link = ( $next_gallery != null ) ? nggMediaRss::get_gallery_mrss_url( $next_gallery->gid, true ) : '';
+		//20140106:shouldn't call it statically when is not...
+		//$images = nggdb::get_gallery($gallery->gid, $ngg_options['galSort'], $ngg_options['galSortDir']);
+		$images = $nggdb->get_gallery( $gallery->gid, $ngg_options['galSort'], $ngg_options['galSortDir'] );
+
+		return nggMediaRss::get_mrss_root_node( $title, $description, $link, $prev_link, $next_link, $images );
 	}
-	
+
 	/**
 	 * Get the XML <rss> node corresponding to an album
 	 *
 	 * @param $album The album to include in RSS
 	 */
-	static function get_album_mrss($album) {
+	static function get_album_mrss( $album ) {
 
-		$title = stripslashes(nggGallery::i18n($album->name));
+		$title = stripslashes( nggGallery::i18n( $album->name ) );
 		$description = '';
-		$link = nggMediaRss::get_permalink(0);
+		$link = nggMediaRss::get_permalink( 0 );
 		$prev_link = '';
 		$next_link = '';
-		$images = nggdb::find_images_in_album($album->id);
-		
-		return nggMediaRss::get_mrss_root_node($title, $description, $link, $prev_link, $next_link, $images);
+		$images = nggdb::find_images_in_album( $album->id );
+
+		return nggMediaRss::get_mrss_root_node( $title, $description, $link, $prev_link, $next_link, $images );
 	}
-	
+
 	/**
 	 * Get the XML <rss> node
 	 */
-	static function get_mrss_root_node($title, $description, $link, $prev_link, $next_link, $images) {
-		
-		if ($prev_link != '' || $next_link != '')
-			$out = "<rss version='2.0' xmlns:media='http://search.yahoo.com/mrss/' xmlns:atom='http://www.w3.org/2005/Atom'>\n" ;
+	static function get_mrss_root_node( $title, $description, $link, $prev_link, $next_link, $images ) {
+
+		if ( $prev_link != '' || $next_link != '' )
+			$out = "<rss version='2.0' xmlns:media='http://search.yahoo.com/mrss/' xmlns:atom='http://www.w3.org/2005/Atom'>\n";
 		else
 			$out = "<rss version='2.0' xmlns:media='http://search.yahoo.com/mrss/'>\n";
-		
+
 		$out .= "\t<channel>\n";
-		
+
 		$out .= nggMediaRss::get_generator_mrss_node();
-		$out .= nggMediaRss::get_title_mrss_node($title);
-		$out .= nggMediaRss::get_description_mrss_node($description);
-		$out .= nggMediaRss::get_link_mrss_node($link);
-		
-        if ($prev_link != '' || $next_link != '')
-        	$out .= nggMediaRss::get_self_node(nggMediaRss::get_mrss_url());	
-		if ($prev_link!='') {
-			$out .= nggMediaRss::get_previous_link_mrss_node($prev_link);
+		$out .= nggMediaRss::get_title_mrss_node( $title );
+		$out .= nggMediaRss::get_description_mrss_node( $description );
+		$out .= nggMediaRss::get_link_mrss_node( $link );
+
+		if ( $prev_link != '' || $next_link != '' )
+			$out .= nggMediaRss::get_self_node( nggMediaRss::get_mrss_url() );
+		if ( $prev_link != '' ) {
+			$out .= nggMediaRss::get_previous_link_mrss_node( $prev_link );
 		}
-		if ($next_link!='') { 
-			$out .= nggMediaRss::get_next_link_mrss_node($next_link);
-		} 
-		
-		foreach ($images as $image) {
-			$out .= nggMediaRss::get_image_mrss_node($image);
+		if ( $next_link != '' ) {
+			$out .= nggMediaRss::get_next_link_mrss_node( $next_link );
 		}
-		
+
+		foreach ( $images as $image ) {
+			$out .= nggMediaRss::get_image_mrss_node( $image );
+		}
+
 		$out .= "\t</channel>\n";
 		$out .= "</rss>\n";
-		
+
 		return $out;
-	}	
-	
+	}
+
 	/**
 	 * Get the XML <generator> node
 	 */
-	static function get_generator_mrss_node($indent = "\t\t") {
+	static function get_generator_mrss_node( $indent = "\t\t" ) {
 		return $indent . "<generator><![CDATA[NextGEN Gallery [http://nextgen-gallery.com]]]></generator>\n";
-	}	
-	
+	}
+
 	/**
 	 * Get the XML <title> node
 	 */
-	static function get_title_mrss_node($title, $indent = "\t\t") {
+	static function get_title_mrss_node( $title, $indent = "\t\t" ) {
 		return $indent . "<title>" . $title . "</title>\n";
-	}	
-	
+	}
+
 	/**
 	 * Get the XML <description> node
 	 */
-	static function get_description_mrss_node($description, $indent = "\t\t") {
+	static function get_description_mrss_node( $description, $indent = "\t\t" ) {
 		return $indent . "<description>" . $description . "</description>\n";
-	}	
-	
+	}
+
 	/**
 	 * Get the XML <link> node
 	 */
-	static function get_link_mrss_node($link, $indent = "\t\t") {
-		return $indent . "<link><![CDATA[" . htmlspecialchars($link) . "]]></link>\n";
-	}	
+	static function get_link_mrss_node( $link, $indent = "\t\t" ) {
+		return $indent . "<link><![CDATA[" . htmlspecialchars( $link ) . "]]></link>\n";
+	}
 
 	/**
 	 * Get the XML <atom:link self> node
 	 */
-	static function get_self_node($link, $indent = "\t\t") {
-		return $indent . "<atom:link rel='self' href='" . htmlspecialchars($link) . "' type='application/rss+xml' />\n";
+	static function get_self_node( $link, $indent = "\t\t" ) {
+		return $indent . "<atom:link rel='self' href='" . htmlspecialchars( $link ) . "' type='application/rss+xml' />\n";
 	}
-	
+
 	/**
 	 * Get the XML <atom:link previous> node
 	 */
-	static function get_previous_link_mrss_node($link, $indent = "\t\t") {
-		return $indent . "<atom:link rel='previous' href='" . htmlspecialchars($link) . "' />\n";
-	}	
-	
+	static function get_previous_link_mrss_node( $link, $indent = "\t\t" ) {
+		return $indent . "<atom:link rel='previous' href='" . htmlspecialchars( $link ) . "' />\n";
+	}
+
 	/**
 	 * Get the XML <atom:link next> node
 	 */
-	static function get_next_link_mrss_node($link, $indent = "\t\t") {
-		return $indent . "<atom:link rel='next' href='" . htmlspecialchars($link) . "' />\n";
-	}	
-	
+	static function get_next_link_mrss_node( $link, $indent = "\t\t" ) {
+		return $indent . "<atom:link rel='next' href='" . htmlspecialchars( $link ) . "' />\n";
+	}
+
 	/**
 	 * Get the XML <item> node corresponding to one single image
 	 *
 	 * @param $image The image object
 	 */
-	static function get_image_mrss_node($image, $indent = "\t\t" ) {
-		$ngg_options = nggGallery::get_option('ngg_options');
-		
+	static function get_image_mrss_node( $image, $indent = "\t\t" ) {
+		$ngg_options = nggGallery::get_option( 'ngg_options' );
+
 		$tags = $image->get_tags();
 		$tag_names = '';
-		foreach ($tags as $tag) {
-			$tag_names .= ($tag_names=='' ? $tag->name : ', ' . $tag->name);
+		foreach ( $tags as $tag ) {
+			$tag_names .= ( $tag_names == '' ? $tag->name : ', ' . $tag->name );
 		}
-		
-		$title = html_entity_decode(stripslashes($image->alttext));
-		$desc = html_entity_decode(stripslashes($image->description));
-		
+
+		$title = html_entity_decode( stripslashes( $image->alttext ) );
+		$desc = html_entity_decode( stripslashes( $image->description ) );
+
 		$thumbwidth = $ngg_options['thumbwidth'];
-		$thumbheight = ($ngg_options['thumbfix'] ? $ngg_options['thumbheight'] : $thumbwidth); 	
-		
-		$out  = $indent . "<item>\n";
-		$out .= $indent . "\t<title><![CDATA[" . nggGallery::i18n($title, 'pic_' . $image->pid . '_alttext') . "]]></title>\n";
-		$out .= $indent . "\t<description><![CDATA[" . nggGallery::i18n($desc, 'pic_' . $image->pid . '_description') . "]]></description>\n";
+		$thumbheight = ( $ngg_options['thumbfix'] ? $ngg_options['thumbheight'] : $thumbwidth );
+
+		$out = $indent . "<item>\n";
+		$out .= $indent . "\t<title><![CDATA[" . nggGallery::i18n( $title, 'pic_' . $image->pid . '_alttext' ) . "]]></title>\n";
+		$out .= $indent . "\t<description><![CDATA[" . nggGallery::i18n( $desc, 'pic_' . $image->pid . '_description' ) . "]]></description>\n";
 		$out .= $indent . "\t<link><![CDATA[" . $image->get_permalink() . "]]></link>\n";
-        $out .= $indent . "\t<guid>image-id:" . $image->pid . "</guid>\n";
-		$out .= $indent . "\t<media:content url='" . esc_url($image->imageURL) . "' medium='image' />\n";
-		$out .= $indent . "\t<media:title><![CDATA[" . nggGallery::i18n($title, 'pic_' . $image->pid . '_alttext') . "]]></media:title>\n";
-		$out .= $indent . "\t<media:description><![CDATA[" . nggGallery::i18n($desc, 'pic_' . $image->pid . '_description') . "]]></media:description>\n";
-		$out .= $indent . "\t<media:thumbnail url='" . esc_url($image->thumbURL) . "' width='" . $thumbwidth . "' height='" . $thumbheight . "' />\n";
-		$out .= $indent . "\t<media:keywords><![CDATA[" . nggGallery::i18n($tag_names) . "]]></media:keywords>\n";
-		$out .= $indent . "\t<media:copyright><![CDATA[Copyright (c) " . get_option("blogname") . " (" . site_url() . ")]]></media:copyright>\n";
+		$out .= $indent . "\t<guid>image-id:" . $image->pid . "</guid>\n";
+		$out .= $indent . "\t<media:content url='" . esc_url( $image->imageURL ) . "' medium='image' />\n";
+		$out .= $indent . "\t<media:title><![CDATA[" . nggGallery::i18n( $title, 'pic_' . $image->pid . '_alttext' ) . "]]></media:title>\n";
+		$out .= $indent . "\t<media:description><![CDATA[" . nggGallery::i18n( $desc, 'pic_' . $image->pid . '_description' ) . "]]></media:description>\n";
+		$out .= $indent . "\t<media:thumbnail url='" . esc_url( $image->thumbURL ) . "' width='" . $thumbwidth . "' height='" . $thumbheight . "' />\n";
+		$out .= $indent . "\t<media:keywords><![CDATA[" . nggGallery::i18n( $tag_names ) . "]]></media:keywords>\n";
+		$out .= $indent . "\t<media:copyright><![CDATA[Copyright (c) " . get_option( "blogname" ) . " (" . site_url() . ")]]></media:copyright>\n";
 		$out .= $indent . "</item>\n";
 
 		return $out;
 	}
 
-	static function get_permalink($page_id) {
-		if ($page_id == 0)	
-			$permalink = site_url();		 
-		else 
-			$permalink = get_permalink($page_id);
-				 
-		return $permalink;		 
-	}	
-		
+	static function get_permalink( $page_id ) {
+		if ( $page_id == 0 )
+			$permalink = site_url();
+		else
+			$permalink = get_permalink( $page_id );
+
+		return $permalink;
+	}
+
 }
 
 ?>

--- a/lib/meta.php
+++ b/lib/meta.php
@@ -9,566 +9,588 @@
  *
  */
 
-class nggMeta{
+class nggMeta {
 
 	/**** Image Data ****/
-    var $image			=	'';		// The image object
-    var $size			=	false;	// The image size
-	var $exif_data 		= 	false;	// EXIF data array
-	var $iptc_data 		= 	false;	// IPTC data array
-	var $xmp_data  		= 	false;	// XMP data array
+	public nggImage $image;		// The image object
+	/**
+	 * @var array|bool
+	 */
+	private $size = false;	// The image size
+	/**
+	 * @var array|bool
+	 */
+	private $exif_data = false;	// EXIF data array
+	/**
+	 * @var array|bool
+	 */
+	private $iptc_data = false;	// IPTC data array
+	/**
+	 * @var array|bool
+	 */
+	private $xmp_data = false;	// XMP data array
+	/**
+	 * @var array|bool
+	 */
 	/**** Filtered Data ****/
-	var $exif_array 	= 	false;	// EXIF data array
-	var $iptc_array 	= 	false;	// IPTC data array
-	var $xmp_array  	= 	false;	// XMP data array
-
-    var $sanitize       =   false;  // sanitize meta data on request
-
-    /**
-     * Parses the nggMeta data only if needed
-     * @param int $image path to a image
-     * @param bool $onlyEXIF parse only exif if needed
-     * @return
-     */
-    function __construct($pic_id, $onlyEXIF = false) {
-
-        //get the path and other data about the image
-        $this->image = nggdb::find_image( $pic_id );
-
-        $this->image = apply_filters( 'ngg_find_image_meta', $this->image  );
-
-        if ( !file_exists( $this->image->imagePath ) )
-            return false;
-
-        $this->size = @getimagesize ( $this->image->imagePath , $metadata );
-
-        if ($this->size && is_array($metadata)) {
-
-            // get exif - data
-            if ( is_callable('exif_read_data'))
-                $this->exif_data = @exif_read_data($this->image->imagePath , 0, true );
-
-            // stop here if we didn't need other meta data
-            if ($onlyEXIF)
-                return true;
-
-            // get the iptc data - should be in APP13
-            if ( is_callable('iptcparse') && isset($metadata['APP13']) )
-                $this->iptc_data = @iptcparse($metadata['APP13']);
-
-            // get the xmp data in a XML format
-            if ( is_callable('xml_parser_create'))
-                $this->xmp_data = $this->extract_XMP($this->image->imagePath );
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * return the saved meta data from the database
-     *
-     * @since 1.4.0
-     * @param string $object (optional)
-     * @return array|mixed return either the complete array or the single object
-     */
-    function get_saved_meta($object = false) {
-
-        $meta = $this->image->meta_data;
-
-        //check if we already import the meta data to the database
-        if (!is_array($meta) || ($meta['saved'] != true))
-            return false;
-
-        // return one element if requested
-        if ($object)
-            return $meta[$object];
-
-        //removed saved parameter we don't need that to show
-        unset($meta['saved']);
-
-        // and remove empty tags or arrays
-        foreach ($meta as $key => $value) {
-            if ( empty($value) OR is_array($value))
-                unset($meta[$key]);
-        }
-
-        // on request sanitize the output
-        if ( $this->sanitize == true )
-            array_walk( $meta , function (&$value) { $value = esc_html($value); });
-
-        return $meta;
-    }
-
-    /**
-     * nggMeta::get_EXIF()
-     * See also http://trac.wordpress.org/changeset/6313
-     *
-     * @return structured EXIF data
-     */
-    function get_EXIF($object = false) {
-
-        if ( !$this->exif_data )
-            return false;
-
-        if (!is_array($this->exif_array)){
-
-            $meta= array();
-
-            if ( isset($this->exif_data['EXIF']) ) {
-                $exif = $this->exif_data['EXIF'];
-
-                if (!empty($exif['FNumber']))
-                    $meta['aperture'] = 'F ' . round( $this->exif_frac2dec( $exif['FNumber'] ), 2 );
-                if (!empty($exif['Model']))
-                    $meta['camera'] = trim( $exif['Model'] );
-                if (!empty($exif['DateTimeDigitized']))
-                    $meta['created_timestamp'] = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $this->exif_date2ts($exif['DateTimeDigitized']));
-                else if (!empty($exif['DateTimeOriginal']))
-                    $meta['created_timestamp'] = date_i18n(get_option('date_format') . ' ' . get_option('time_format'), $this->exif_date2ts($exif['DateTimeOriginal']));
-                if (!empty($exif['FocalLength']))
-                    $meta['focal_length'] = $this->exif_frac2dec( $exif['FocalLength'] ) . __(' mm','nggallery');
-                if (!empty($exif['ISOSpeedRatings']))
-                    $meta['iso'] = $exif['ISOSpeedRatings'];
-                if (!empty($exif['ExposureTime'])) {
-                    $meta['shutter_speed']  = $this->exif_frac2dec ($exif['ExposureTime']);
-                    $meta['shutter_speed']  =($meta['shutter_speed'] > 0.0 and $meta['shutter_speed'] < 1.0) ? ( '1/' . round( 1 / $meta['shutter_speed'], -1) ) : ($meta['shutter_speed']);
-                    $meta['shutter_speed'] .=  __(' sec','nggallery');
-                }
-                //Bit 0 indicates the flash firing status
-                if (!empty($exif['Flash']))
-                    $meta['flash'] =  ( $exif['Flash'] & 1 ) ? __('Fired', 'nggallery') : __('Not fired',' nggallery');
-            }
-
-            // additional information
-            if ( isset($this->exif_data['IFD0']) ) {
-                $exif = $this->exif_data['IFD0'];
-
-                if (!empty($exif['Model']))
-                    $meta['camera'] = $exif['Model'];
-                if (!empty($exif['Make']))
-                    $meta['make'] = $exif['Make'];
-                if (!empty($exif['ImageDescription']))
-                    $meta['title'] = utf8_encode($exif['ImageDescription']);
-                if (!empty($exif['Orientation']))
-                    $meta['Orientation'] = $exif['Orientation'];
-            }
-
-            // this is done by Windows
-            if ( isset($this->exif_data['WINXP']) ) {
-                $exif = $this->exif_data['WINXP'];
-
-                if (!empty($exif['Title']) && empty($meta['title']))
-                    $meta['title'] = utf8_encode($exif['Title']);
-                if (!empty($exif['Author']))
-                    $meta['author'] = utf8_encode($exif['Author']);
-                if (!empty($exif['Keywords']))
-                    $meta['tags'] = utf8_encode($exif['Keywords']);
-                if (!empty($exif['Subject']))
-                    $meta['subject'] = utf8_encode($exif['Subject']);
-                if (!empty($exif['Comments']))
-                    $meta['caption'] = utf8_encode($exif['Comments']);
-            }
-
-            $this->exif_array = $meta;
-        }
-
-        // return one element if requested
-        if ( $object == true ) {
-            $value = isset($this->exif_array[$object]) ? $this->exif_array[$object] : false;
-            return $value;
-        }
-
-        // on request sanitize the output
-        if ( $this->sanitize == true )
-            array_walk( $this->exif_array , function (&$value) { $value = esc_html($value); });
-
-        return $this->exif_array;
-
-    }
-
-    // convert a fraction string to a decimal
-    function exif_frac2dec($str) {
-        @list( $n, $d ) = explode( '/', $str );
-        if ( !empty($d) )
-            return $n / $d;
-        return $str;
-    }
-
-    // convert the exif date format to a unix timestamp
-    function exif_date2ts($str) {
-        // seriously, who formats a date like 'YYYY:MM:DD hh:mm:ss'?
-        @list( $date, $time ) = explode( ' ', trim($str) );
-        @list( $y, $m, $d ) = explode( ':', $date );
-
-        return strtotime( "{$y}-{$m}-{$d} {$time}" );
-    }
-
-    /**
-     * nggMeta::readIPTC() - IPTC Data Information for EXIF Display
-     *
-     * @param mixed $output_tag
-     * @return IPTC-tags
-     */
-    function get_IPTC($object = false) {
-
-        if (!$this->iptc_data)
-            return false;
-
-        if (!is_array($this->iptc_array)){
-
-            // --------- Set up Array Functions --------- //
-            $iptcTags = array (
-                "2#005" => 'title',
-                "2#007" => 'status',
-                "2#012" => 'subject',
-                "2#015" => 'category',
-                "2#025" => 'keywords',
-                "2#055" => 'created_date',
-                "2#060" => 'created_time',
-                "2#080" => 'author',
-                "2#085" => 'position',
-                "2#090" => 'city',
-                "2#092" => 'location',
-                "2#095" => 'state',
-                "2#100" => 'country_code',
-                "2#101" => 'country',
-                "2#105" => 'headline',
-                "2#110" => 'credit',
-                "2#115" => 'source',
-                "2#116" => 'copyright',
-                "2#118" => 'contact',
-                "2#120" => 'caption'
-            );
-
-            $meta = array();
-            foreach ($iptcTags as $key => $value) {
-                if (isset ( $this->iptc_data[$key] ) )
-                    $meta[$value] = trim(utf8_encode(implode(", ", $this->iptc_data[$key])));
-
-            }
-            $this->iptc_array = $meta;
-        }
-
-        // return one element if requested
-        if ($object)
-            return (isset($this->iptc_array[$object])) ? $this->iptc_array[$object] : NULL;
-
-        // on request sanitize the output
-        if ( $this->sanitize == true )
-            array_walk( $this->iptc_array , function (&$value) { $value = esc_html($value); });
-
-        return $this->iptc_array;
-    }
-
-    /**
-     * nggMeta::extract_XMP()
-     * get XMP DATA
-     * code by Pekka Saarinen http://photography-on-the.net
-     *
-     * @param mixed $filename
-     * @return XML data
-     */
-    function extract_XMP( $filename ) {
-
-        //TODO:Require a lot of memory, could be better
-        ob_start();
-        @readfile($filename);
-        $source = ob_get_contents();
-        ob_end_clean();
-
-        $start = strpos( $source, "<x:xmpmeta"   );
-        $end   = strpos( $source, "</x:xmpmeta>" );
-        if ((!$start === false) && (!$end === false)) {
-            $lenght = $end - $start;
-            $xmp_data = substr($source, $start, $lenght+12 );
-            unset($source);
-            return $xmp_data;
-        }
-
-        unset($source);
-        return false;
-    }
-
-    /**
-     * nggMeta::get_XMP()
-     *
-     * @package Taken from http://php.net/manual/en/function.xml-parse-into-struct.php
-     * @author Alf Marius Foss Olsen & Alex Rabe
-     * @return XML Array or object
-     *
-     */
-    function get_XMP($object = false) {
-
-        if(!$this->xmp_data)
-            return false;
-
-        if (!is_array($this->xmp_array)){
-
-            $parser = xml_parser_create();
-            xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0); // Dont mess with my cAsE sEtTings
-            xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1); // Dont bother with empty info
-            xml_parse_into_struct($parser, $this->xmp_data, $values);
-            xml_parser_free($parser);
-
-            $xmlarray			= array();	// The XML array
-            $this->xmp_array  	= array();	// The returned array
-            $stack        		= array();	// tmp array used for stacking
-            $list_array   		= array();	// tmp array for list elements
-            $list_element 		= false;	// rdf:li indicator
-
-            foreach($values as $val) {
-
-                if($val['type'] == "open") {
-                    array_push($stack, $val['tag']);
-
-                } elseif($val['type'] == "close") {
-                    // reset the compared stack
-                    if ($list_element == false)
-                        array_pop($stack);
-                    // reset the rdf:li indicator & array
-                    $list_element = false;
-                    $list_array   = array();
-
-                } elseif($val['type'] == "complete") {
-                    if ($val['tag'] == "rdf:li") {
-                        // first go one element back
-                        if ($list_element == false)
-                            array_pop($stack);
-                        $list_element = true;
-                        // do not parse empty tags
-                        if ( empty($val['value']) ) continue;
-                        // save it in our temp array
-                        $list_array[] = $val['value'];
-                        // in the case it's a list element we seralize it
-                        $value = implode(",", $list_array);
-                        $this->setArrayValue($xmlarray, $stack, $value);
-                    } else {
-                        array_push($stack, $val['tag']);
-                        // do not parse empty tags
-                        if ( !empty($val['value']) )
-                            $this->setArrayValue($xmlarray, $stack, $val['value']);
-                        array_pop($stack);
-                    }
-                }
-
-            } // foreach
-
-            // don't parse a empty array
-            if( empty($xmlarray) || empty($xmlarray['x:xmpmeta']) )
-                return false;
-
-            // cut off the useless tags
-            $xmlarray = $xmlarray['x:xmpmeta']['rdf:RDF']['rdf:Description'];
-
-            // --------- Some values from the XMP format--------- //
-            $xmpTags = array (
-                'xap:CreateDate' 			=> 'created_timestamp',
-                'xap:ModifyDate'  			=> 'last_modfied',
-                'xap:CreatorTool' 			=> 'tool',
-                'dc:format' 				=> 'format',
-                'dc:title'					=> 'title',
-                'dc:creator' 				=> 'author',
-                'dc:subject' 				=> 'keywords',
-                'dc:description' 			=> 'caption',
-                'photoshop:AuthorsPosition' => 'position',
-                'photoshop:City'			=> 'city',
-                'photoshop:Country' 		=> 'country'
-            );
-
-            foreach ($xmpTags as $key => $value) {
-                // if the kex exist
-                if ( isset($xmlarray[$key]) ) {
-                    switch ($key) {
-                        case 'xap:CreateDate':
-                        case 'xap:ModifyDate':
-                            $this->xmp_array[$value] = date_i18n(get_option('date_format').' '.get_option('time_format'), strtotime($xmlarray[$key]));
-                            break;
-                        default :
-                            $this->xmp_array[$value] = $xmlarray[$key];
-                    }
-                }
-            }
-
-        }
-
-        // return one element if requested
-        if ($object != false )
-            return isset($this->xmp_array[$object]) ? $this->xmp_array[$object] : false;
-
-        // on request sanitize the output
-        if ( $this->sanitize == true )
-            array_walk( $this->xmp_array , function (&$value) { $value = esc_html($value); });
-
-        return $this->xmp_array;
-    }
-
-    function setArrayValue(&$array, $stack, $value) {
-        if ($stack) {
-            $key = array_shift($stack);
-            $this->setArrayValue($array[$key], $stack, $value);
-            return $array;
-        } else {
-            $array = $value;
-        }
-    }
-
-    /**
-     * nggMeta::get_META() - return a meta value form the available list
-     *
-     * @param string $object
-     * @return mixed $value
-     */
-    function get_META($object = false) {
-
-        // defined order first look into database, then XMP, IPTC and EXIF.
-        if ($value = $this->get_saved_meta($object))
-            return $value;
-        if ($value = $this->get_XMP($object))
-            return $value;
-        if ($value = $this->get_IPTC($object))
-            return $value;
-        if ($value = $this->get_EXIF($object))
-            return $value;
-
-        // nothing found ?
-        return false;
-    }
-
-    /**
-     * nggMeta::i8n_name() -  localize the tag name
-     *
-     * @param mixed $key
-     * @return translated $key
-     */
-    function i8n_name($key) {
-
-        $tagnames = array(
-            'aperture' 			=> __('Aperture','nggallery'),
-            'credit' 			=> __('Credit','nggallery'),
-            'camera' 			=> __('Camera','nggallery'),
-            'caption' 			=> __('Caption','nggallery'),
-            'created_timestamp' => __('Date/Time','nggallery'),
-            'copyright' 		=> __('Copyright','nggallery'),
-            'focal_length' 		=> __('Focal length','nggallery'),
-            'iso' 				=> __('ISO','nggallery'),
-            'shutter_speed' 	=> __('Shutter speed','nggallery'),
-            'title' 			=> __('Title','nggallery'),
-            'author' 			=> __('Author','nggallery'),
-            'tags' 				=> __('Tags','nggallery'),
-            'subject' 			=> __('Subject','nggallery'),
-            'make' 				=> __('Make','nggallery'),
-            'status' 			=> __('Edit Status','nggallery'),
-            'category'			=> __('Category','nggallery'),
-            'keywords' 			=> __('Keywords','nggallery'),
-            'created_date' 		=> __('Date Created','nggallery'),
-            'created_time'		=> __('Time Created','nggallery'),
-            'position'			=> __('Author Position','nggallery'),
-            'city'				=> __('City','nggallery'),
-            'location'			=> __('Location','nggallery'),
-            'state' 			=> __('Province/State','nggallery'),
-            'country_code'		=> __('Country code','nggallery'),
-            'country'			=> __('Country','nggallery'),
-            'headline' 			=> __('Headline','nggallery'),
-            'credit'			=> __('Credit','nggallery'),
-            'source'			=> __('Source','nggallery'),
-            'copyright'			=> __('Copyright Notice','nggallery'),
-            'contact'			=> __('Contact','nggallery'),
-            'last_modfied'		=> __('Last modified','nggallery'),
-            'tool'				=> __('Program tool','nggallery'),
-            'format'			=> __('Format','nggallery'),
-            'width'				=> __('Image Width','nggallery'),
-            'height'			=> __('Image Height','nggallery'),
-            'flash'				=> __('Flash','nggallery')
-        );
-
-        if ( isset($tagnames[$key]) )
-            $key = $tagnames[$key];
-
-        return($key);
-
-    }
-
-    /**
-     * Return the Timestamp from the image , if possible it's read from exif data
-     *
-     * @return
-     */
-    function get_date_time() {
-
-        $date_time = time();
-
-        // get exif - data
-        if ( isset( $this->exif_data['EXIF']) ) {
-
-            // try to read the date / time from the exif
-            foreach (array('DateTimeDigitized', 'DateTimeOriginal', 'FileDateTime') as $key) {
-                if (isset($this->exif_data['EXIF'][$key])) {
-                    $date_time = strtotime($this->exif_data['EXIF'][$key]);
-                    break;
-                }
-            }
-        } else {
-            // if no other date available, get the filetime
-            $date_time = @filectime($this->image->imagePath );
-        }
-
-        // Return the MySQL format
-        $date_time = date( 'Y-m-d H:i:s', $date_time );
-
-        return $date_time;
-    }
-
-    /**
-     * This function return the most common metadata, via a filter we can add more
-     * Reason : GD manipulation removes that options
-     *
-     * @since V1.4.0
-     * @return array|boolean
-     */
-    function get_common_meta() {
-        global $wpdb;
-
-        $meta = array(
-            'aperture' => 0,
-            'credit' => '',
-            'camera' => '',
-            'caption' => '',
-            'created_timestamp' => 0,
-            'copyright' => '',
-            'focal_length' => 0,
-            'iso' => 0,
-            'shutter_speed' => 0,
-            'flash' => 0,
-            'title' => '',
-            'keywords' => ''
-        );
-
-        $meta = apply_filters( 'ngg_read_image_metadata', $meta  );
-
-        // meta should be still an array
-        if ( !is_array($meta) )
-            return false;
-
-        foreach ($meta as $key => $value) {
-            $meta[$key] = $this->get_META($key);
-        }
-
-        //let's add now the size of the image
-        $meta['width']  = $this->size[0];
-        $meta['height'] = $this->size[1];
-
-        return $meta;
-    }
-
-    /**
-     * If needed sanitize each value before output
-     *
-     * @return void
-     */
-    function sanitize () {
-        $this->sanitize = true;
-    }
+	private $exif_array = false;	// EXIF data array
+	/**
+	 * @var array|bool
+	 */
+	private $iptc_array = false;	// IPTC data array
+	/**
+	 * @var array|bool
+	 */
+	private $xmp_array = false;	// XMP data array
+	private bool $sanitize = false;  // sanitize meta data on request
+
+	/**
+	 * Parses the nggMeta data only if needed
+	 * @param int $image path to a image
+	 * @param bool $onlyEXIF parse only exif if needed
+	 */
+	function __construct( $pic_id, $onlyEXIF = false ) {
+
+		//get the path and other data about the image
+		$this->image = nggdb::find_image( $pic_id );
+
+		$this->image = apply_filters( 'ngg_find_image_meta', $this->image );
+
+		if ( file_exists( $this->image->imagePath ) ) {
+
+			$this->size = @getimagesize( $this->image->imagePath, $metadata );
+
+			if ( $this->size && is_array( $metadata ) ) {
+
+				// get exif - data
+				if ( is_callable( 'exif_read_data' ) )
+					$this->exif_data = @exif_read_data( $this->image->imagePath, 0, true );
+
+				// stop here if we didn't need other meta data
+				if ( ! $onlyEXIF ) {
+					// get the iptc data - should be in APP13
+					if ( is_callable( 'iptcparse' ) && isset( $metadata['APP13'] ) )
+						$this->iptc_data = @iptcparse( $metadata['APP13'] );
+
+					// get the xmp data in a XML format
+					if ( is_callable( 'xml_parser_create' ) )
+						$this->xmp_data = $this->extract_XMP( $this->image->imagePath );
+				}
+			}
+		}
+	}
+
+	/**
+	 * return the saved meta data from the database
+	 *
+	 * @since 1.4.0
+	 * @param string $object (optional)
+	 * @return array|mixed return either the complete array or the single object
+	 */
+	function get_saved_meta( $object = false ) {
+
+		$meta = $this->image->meta_data;
+
+		//check if we already import the meta data to the database
+		if ( ! is_array( $meta ) || ( $meta['saved'] != true ) )
+			return false;
+
+		// return one element if requested
+		if ( $object )
+			return $meta[ $object ];
+
+		//removed saved parameter we don't need that to show
+		unset( $meta['saved'] );
+
+		// and remove empty tags or arrays
+		foreach ( $meta as $key => $value ) {
+			if ( empty( $value ) or is_array( $value ) )
+				unset( $meta[ $key ] );
+		}
+
+		// on request sanitize the output
+		if ( $this->sanitize == true )
+			array_walk( $meta, function (&$value) {
+				$value = esc_html( $value );
+			} );
+
+		return $meta;
+	}
+
+	/**
+	 * nggMeta::get_EXIF()
+	 * See also http://trac.wordpress.org/changeset/6313
+	 *
+	 * @return bool|array EXIF data
+	 */
+	function get_EXIF( $object = false ) {
+
+		if ( ! $this->exif_data )
+			return false;
+
+		if ( ! is_array( $this->exif_array ) ) {
+
+			$meta = array();
+
+			if ( isset( $this->exif_data['EXIF'] ) ) {
+				$exif = $this->exif_data['EXIF'];
+
+				if ( ! empty( $exif['FNumber'] ) )
+					$meta['aperture'] = 'F ' . round( $this->exif_frac2dec( $exif['FNumber'] ), 2 );
+				if ( ! empty( $exif['Model'] ) )
+					$meta['camera'] = trim( $exif['Model'] );
+				if ( ! empty( $exif['DateTimeDigitized'] ) )
+					$meta['created_timestamp'] = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $this->exif_date2ts( $exif['DateTimeDigitized'] ) );
+				else if ( ! empty( $exif['DateTimeOriginal'] ) )
+					$meta['created_timestamp'] = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $this->exif_date2ts( $exif['DateTimeOriginal'] ) );
+				if ( ! empty( $exif['FocalLength'] ) )
+					$meta['focal_length'] = $this->exif_frac2dec( $exif['FocalLength'] ) . __( ' mm', 'nggallery' );
+				if ( ! empty( $exif['ISOSpeedRatings'] ) )
+					$meta['iso'] = $exif['ISOSpeedRatings'];
+				if ( ! empty( $exif['ExposureTime'] ) ) {
+					$meta['shutter_speed'] = $this->exif_frac2dec( $exif['ExposureTime'] );
+					$meta['shutter_speed'] = ( $meta['shutter_speed'] > 0.0 and $meta['shutter_speed'] < 1.0 ) ? ( '1/' . round( 1 / $meta['shutter_speed'], -1 ) ) : ( $meta['shutter_speed'] );
+					$meta['shutter_speed'] .= __( ' sec', 'nggallery' );
+				}
+				//Bit 0 indicates the flash firing status
+				if ( ! empty( $exif['Flash'] ) )
+					$meta['flash'] = ( $exif['Flash'] & 1 ) ? __( 'Fired', 'nggallery' ) : __( 'Not fired', ' nggallery' );
+			}
+
+			// additional information
+			if ( isset( $this->exif_data['IFD0'] ) ) {
+				$exif = $this->exif_data['IFD0'];
+
+				if ( ! empty( $exif['Model'] ) )
+					$meta['camera'] = $exif['Model'];
+				if ( ! empty( $exif['Make'] ) )
+					$meta['make'] = $exif['Make'];
+				if ( ! empty( $exif['ImageDescription'] ) )
+					$meta['title'] = mb_convert_encoding( $exif['ImageDescription'], 'UTF-8' );
+				if ( ! empty( $exif['Orientation'] ) )
+					$meta['Orientation'] = $exif['Orientation'];
+			}
+
+			// this is done by Windows
+			if ( isset( $this->exif_data['WINXP'] ) ) {
+				$exif = $this->exif_data['WINXP'];
+
+				if ( ! empty( $exif['Title'] ) && empty( $meta['title'] ) )
+					$meta['title'] = mb_convert_encoding( $exif['Title'], 'UTF-8' );
+				if ( ! empty( $exif['Author'] ) )
+					$meta['author'] = mb_convert_encoding( $exif['Author'], 'UTF-8' );
+				if ( ! empty( $exif['Keywords'] ) )
+					$meta['tags'] = mb_convert_encoding( $exif['Keywords'], 'UTF-8' );
+				if ( ! empty( $exif['Subject'] ) )
+					$meta['subject'] = mb_convert_encoding( $exif['Subject'], 'UTF-8' );
+				if ( ! empty( $exif['Comments'] ) )
+					$meta['caption'] = mb_convert_encoding( $exif['Comments'], 'UTF-8' );
+			}
+
+			$this->exif_array = $meta;
+		}
+
+		// return one element if requested
+		if ( $object == true ) {
+			$value = isset( $this->exif_array[ $object ] ) ? $this->exif_array[ $object ] : false;
+			return $value;
+		}
+
+		// on request sanitize the output
+		if ( $this->sanitize == true )
+			array_walk( $this->exif_array, function (&$value) {
+				$value = esc_html( $value );
+			} );
+
+		return $this->exif_array;
+
+	}
+
+	// convert a fraction string to a decimal
+	function exif_frac2dec( $str ) {
+		@list( $n, $d ) = explode( '/', $str );
+		if ( ! empty( $d ) )
+			return $n / $d;
+		return $str;
+	}
+
+	// convert the exif date format to a unix timestamp
+	function exif_date2ts( $str ) {
+		// seriously, who formats a date like 'YYYY:MM:DD hh:mm:ss'?
+		@list( $date, $time ) = explode( ' ', trim( $str ) );
+		@list( $y, $m, $d ) = explode( ':', $date );
+
+		return strtotime( "{$y}-{$m}-{$d} {$time}" );
+	}
+
+	/**
+	 * nggMeta::readIPTC() - IPTC Data Information for EXIF Display
+	 *
+	 * @param mixed $output_tag
+	 * @return string[]|bool IPTC-tags
+	 */
+	function get_IPTC( $object = false ) {
+
+		if ( ! $this->iptc_data )
+			return false;
+
+		if ( ! is_array( $this->iptc_array ) ) {
+
+			// --------- Set up Array Functions --------- //
+			$iptcTags = array(
+				"2#005" => 'title',
+				"2#007" => 'status',
+				"2#012" => 'subject',
+				"2#015" => 'category',
+				"2#025" => 'keywords',
+				"2#055" => 'created_date',
+				"2#060" => 'created_time',
+				"2#080" => 'author',
+				"2#085" => 'position',
+				"2#090" => 'city',
+				"2#092" => 'location',
+				"2#095" => 'state',
+				"2#100" => 'country_code',
+				"2#101" => 'country',
+				"2#105" => 'headline',
+				"2#110" => 'credit',
+				"2#115" => 'source',
+				"2#116" => 'copyright',
+				"2#118" => 'contact',
+				"2#120" => 'caption'
+			);
+
+			$meta = array();
+			foreach ( $iptcTags as $key => $value ) {
+				if ( isset( $this->iptc_data[ $key ] ) )
+					$meta[ $value ] = trim( mb_convert_encoding( implode( ", ", $this->iptc_data[ $key ] ), 'UTF-8' ) );
+
+			}
+			$this->iptc_array = $meta;
+		}
+
+		// return one element if requested
+		if ( $object )
+			return ( isset( $this->iptc_array[ $object ] ) ) ? $this->iptc_array[ $object ] : NULL;
+
+		// on request sanitize the output
+		if ( $this->sanitize == true )
+			array_walk( $this->iptc_array, function (&$value) {
+				$value = esc_html( $value );
+			} );
+
+		return $this->iptc_array;
+	}
+
+	/**
+	 * nggMeta::extract_XMP()
+	 * get XMP DATA
+	 * code by Pekka Saarinen http://photography-on-the.net
+	 *
+	 * @param mixed $filename
+	 * @return string|bool XML data
+	 */
+	function extract_XMP( $filename ) {
+
+		//TODO:Require a lot of memory, could be better
+		ob_start();
+		@readfile( $filename );
+		$source = ob_get_contents();
+		ob_end_clean();
+
+		$start = strpos( $source, "<x:xmpmeta" );
+		$end = strpos( $source, "</x:xmpmeta>" );
+		if ( ( ! $start === false ) && ( ! $end === false ) ) {
+			$lenght = $end - $start;
+			$xmp_data = substr( $source, $start, $lenght + 12 );
+			unset( $source );
+			return $xmp_data;
+		}
+
+		unset( $source );
+		return false;
+	}
+
+	/**
+	 * nggMeta::get_XMP()
+	 *
+	 * @package Taken from http://php.net/manual/en/function.xml-parse-into-struct.php
+	 * @author Alf Marius Foss Olsen & Alex Rabe
+	 * @return string[]|bool XML Array or object
+	 *
+	 */
+	function get_XMP( $object = false ) {
+
+		if ( ! $this->xmp_data )
+			return false;
+
+		if ( ! is_array( $this->xmp_array ) ) {
+
+			$parser = xml_parser_create();
+			xml_parser_set_option( $parser, XML_OPTION_CASE_FOLDING, 0 ); // Dont mess with my cAsE sEtTings
+			xml_parser_set_option( $parser, XML_OPTION_SKIP_WHITE, 1 ); // Dont bother with empty info
+			xml_parse_into_struct( $parser, $this->xmp_data, $values );
+			xml_parser_free( $parser );
+
+			$xmlarray = array();	// The XML array
+			$this->xmp_array = array();	// The returned array
+			$stack = array();	// tmp array used for stacking
+			$list_array = array();	// tmp array for list elements
+			$list_element = false;	// rdf:li indicator
+
+			foreach ( $values as $val ) {
+
+				if ( $val['type'] == "open" ) {
+					array_push( $stack, $val['tag'] );
+
+				} elseif ( $val['type'] == "close" ) {
+					// reset the compared stack
+					if ( $list_element == false )
+						array_pop( $stack );
+					// reset the rdf:li indicator & array
+					$list_element = false;
+					$list_array = array();
+
+				} elseif ( $val['type'] == "complete" ) {
+					if ( $val['tag'] == "rdf:li" ) {
+						// first go one element back
+						if ( $list_element == false )
+							array_pop( $stack );
+						$list_element = true;
+						// do not parse empty tags
+						if ( empty( $val['value'] ) )
+							continue;
+						// save it in our temp array
+						$list_array[] = $val['value'];
+						// in the case it's a list element we seralize it
+						$value = implode( ",", $list_array );
+						$this->setArrayValue( $xmlarray, $stack, $value );
+					} else {
+						array_push( $stack, $val['tag'] );
+						// do not parse empty tags
+						if ( ! empty( $val['value'] ) )
+							$this->setArrayValue( $xmlarray, $stack, $val['value'] );
+						array_pop( $stack );
+					}
+				}
+
+			} // foreach
+
+			// don't parse a empty array
+			if ( empty( $xmlarray ) || empty( $xmlarray['x:xmpmeta'] ) )
+				return false;
+
+			// cut off the useless tags
+			$xmlarray = $xmlarray['x:xmpmeta']['rdf:RDF']['rdf:Description'];
+
+			// --------- Some values from the XMP format--------- //
+			$xmpTags = array(
+				'xap:CreateDate' => 'created_timestamp',
+				'xap:ModifyDate' => 'last_modfied',
+				'xap:CreatorTool' => 'tool',
+				'dc:format' => 'format',
+				'dc:title' => 'title',
+				'dc:creator' => 'author',
+				'dc:subject' => 'keywords',
+				'dc:description' => 'caption',
+				'photoshop:AuthorsPosition' => 'position',
+				'photoshop:City' => 'city',
+				'photoshop:Country' => 'country'
+			);
+
+			foreach ( $xmpTags as $key => $value ) {
+				// if the kex exist
+				if ( isset( $xmlarray[ $key ] ) ) {
+					switch ( $key ) {
+						case 'xap:CreateDate':
+						case 'xap:ModifyDate':
+							$this->xmp_array[ $value ] = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $xmlarray[ $key ] ) );
+							break;
+						default:
+							$this->xmp_array[ $value ] = $xmlarray[ $key ];
+					}
+				}
+			}
+
+		}
+
+		// return one element if requested
+		if ( $object != false )
+			return isset( $this->xmp_array[ $object ] ) ? $this->xmp_array[ $object ] : false;
+
+		// on request sanitize the output
+		if ( $this->sanitize == true )
+			array_walk( $this->xmp_array, function (&$value) {
+				$value = esc_html( $value );
+			} );
+
+		return $this->xmp_array;
+	}
+
+	function setArrayValue( &$array, $stack, $value ) {
+		if ( $stack ) {
+			$key = array_shift( $stack );
+			$this->setArrayValue( $array[ $key ], $stack, $value );
+			return $array;
+		} else {
+			$array = $value;
+		}
+	}
+
+	/**
+	 * nggMeta::get_META() - return a meta value form the available list
+	 *
+	 * @param string $object
+	 * @return mixed $value
+	 */
+	function get_META( $object = false ) {
+
+		// defined order first look into database, then XMP, IPTC and EXIF.
+		if ( $value = $this->get_saved_meta( $object ) )
+			return $value;
+		if ( $value = $this->get_XMP( $object ) )
+			return $value;
+		if ( $value = $this->get_IPTC( $object ) )
+			return $value;
+		if ( $value = $this->get_EXIF( $object ) )
+			return $value;
+
+		// nothing found ?
+		return false;
+	}
+
+	/**
+	 * nggMeta::i8n_name() -  localize the tag name
+	 *
+	 * @param mixed $key
+	 * @return string translated $key
+	 */
+	function i8n_name( $key ) {
+
+		$tagnames = array(
+			'aperture' => __( 'Aperture', 'nggallery' ),
+			'credit' => __( 'Credit', 'nggallery' ),
+			'camera' => __( 'Camera', 'nggallery' ),
+			'caption' => __( 'Caption', 'nggallery' ),
+			'created_timestamp' => __( 'Date/Time', 'nggallery' ),
+			'copyright' => __( 'Copyright', 'nggallery' ),
+			'focal_length' => __( 'Focal length', 'nggallery' ),
+			'iso' => __( 'ISO', 'nggallery' ),
+			'shutter_speed' => __( 'Shutter speed', 'nggallery' ),
+			'title' => __( 'Title', 'nggallery' ),
+			'author' => __( 'Author', 'nggallery' ),
+			'tags' => __( 'Tags', 'nggallery' ),
+			'subject' => __( 'Subject', 'nggallery' ),
+			'make' => __( 'Make', 'nggallery' ),
+			'status' => __( 'Edit Status', 'nggallery' ),
+			'category' => __( 'Category', 'nggallery' ),
+			'keywords' => __( 'Keywords', 'nggallery' ),
+			'created_date' => __( 'Date Created', 'nggallery' ),
+			'created_time' => __( 'Time Created', 'nggallery' ),
+			'position' => __( 'Author Position', 'nggallery' ),
+			'city' => __( 'City', 'nggallery' ),
+			'location' => __( 'Location', 'nggallery' ),
+			'state' => __( 'Province/State', 'nggallery' ),
+			'country_code' => __( 'Country code', 'nggallery' ),
+			'country' => __( 'Country', 'nggallery' ),
+			'headline' => __( 'Headline', 'nggallery' ),
+			'source' => __( 'Source', 'nggallery' ),
+			'copyright' => __( 'Copyright Notice', 'nggallery' ),
+			'contact' => __( 'Contact', 'nggallery' ),
+			'last_modfied' => __( 'Last modified', 'nggallery' ),
+			'tool' => __( 'Program tool', 'nggallery' ),
+			'format' => __( 'Format', 'nggallery' ),
+			'width' => __( 'Image Width', 'nggallery' ),
+			'height' => __( 'Image Height', 'nggallery' ),
+			'flash' => __( 'Flash', 'nggallery' )
+		);
+
+		if ( isset( $tagnames[ $key ] ) )
+			$key = $tagnames[ $key ];
+
+		return ( $key );
+
+	}
+
+	/**
+	 * Return the Timestamp from the image , if possible it's read from exif data
+	 *
+	 * @return
+	 */
+	function get_date_time() {
+
+		$date_time = time();
+
+		// get exif - data
+		if ( isset( $this->exif_data['EXIF'] ) ) {
+
+			// try to read the date / time from the exif
+			foreach ( array( 'DateTimeDigitized', 'DateTimeOriginal', 'FileDateTime' ) as $key ) {
+				if ( isset( $this->exif_data['EXIF'][ $key ] ) ) {
+					$date_time = strtotime( $this->exif_data['EXIF'][ $key ] );
+					break;
+				}
+			}
+		} else {
+			// if no other date available, get the filetime
+			$date_time = @filectime( $this->image->imagePath );
+		}
+
+		// Return the MySQL format
+		$date_time = date( 'Y-m-d H:i:s', $date_time );
+
+		return $date_time;
+	}
+
+	/**
+	 * This function return the most common metadata, via a filter we can add more
+	 * Reason : GD manipulation removes that options
+	 *
+	 * @since V1.4.0
+	 * @return array|boolean
+	 */
+	function get_common_meta() {
+		global $wpdb;
+
+		$meta = array(
+			'aperture' => 0,
+			'credit' => '',
+			'camera' => '',
+			'caption' => '',
+			'created_timestamp' => 0,
+			'copyright' => '',
+			'focal_length' => 0,
+			'iso' => 0,
+			'shutter_speed' => 0,
+			'flash' => 0,
+			'title' => '',
+			'keywords' => ''
+		);
+
+		$meta = apply_filters( 'ngg_read_image_metadata', $meta );
+
+		// meta should be still an array
+		if ( ! is_array( $meta ) )
+			return false;
+
+		foreach ( $meta as $key => $value ) {
+			$meta[ $key ] = $this->get_META( $key );
+		}
+
+		//let's add now the size of the image
+		$meta['width'] = $this->size[0];
+		$meta['height'] = $this->size[1];
+
+		return $meta;
+	}
+
+	/**
+	 * If needed sanitize each value before output
+	 *
+	 * @return void
+	 */
+	function sanitize() {
+		$this->sanitize = true;
+	}
 
 }

--- a/lib/multisite.php
+++ b/lib/multisite.php
@@ -1,12 +1,12 @@
 <?php
 /**
-* Main PHP Class for Multisite setup
-* 
-* @author Alex Rabe 
-* 
-* 
-*/
-class nggWPMU{
+ * Main PHP Class for Multisite setup
+ * 
+ * @author Alex Rabe 
+ * 
+ * 
+ */
+class nggWPMU {
 
 	/**
 	 * Check the Quota under WPMU. Only needed for this case
@@ -15,30 +15,30 @@ class nggWPMU{
 	 * @return bool $result
 	 */
 	static function check_quota() {
-        	if ( get_site_option( 'upload_space_check_disabled' ) )
-        		return false;
-
-			if ( (is_multisite()) && nggWPMU::wpmu_enable_function('wpmuQuotaCheck'))
-				if( $error = upload_is_user_over_quota( false ) ) {
-					nggGallery::show_error( __( 'Sorry, you have used your space allocation. Please delete some files to upload more files.','nggallery' ) );
-					return true;
-				}
+		if ( get_site_option( 'upload_space_check_disabled' ) )
 			return false;
-	}
-    
 
-    /**
-     * Check for site wide options
-     * 
-     * @param string $value
-     * @return value
-     */
-    function wpmu_enable_function($value) {
-    	if (is_multisite()) {
-    		$ngg_options = get_site_option('ngg_options');
-    		return $ngg_options[$value];
-    	}
-    	// if this is not WPMU, enable it !
-    	return true;
-    }    
+		if ( ( is_multisite() ) && nggWPMU::wpmu_enable_function( 'wpmuQuotaCheck' ) )
+			if ( $error = upload_is_user_over_quota( false ) ) {
+				nggGallery::show_error( __( 'Sorry, you have used your space allocation. Please delete some files to upload more files.', 'nggallery' ) );
+				return true;
+			}
+		return false;
+	}
+
+
+	/**
+	 * Check for site wide options
+	 * 
+	 * @param string $value
+	 * @return bool|string value
+	 */
+	static function wpmu_enable_function( $value ) {
+		if ( is_multisite() ) {
+			$ngg_options = get_site_option( 'ngg_options' );
+			return $ngg_options[ $value ];
+		}
+		// if this is not WPMU, enable it !
+		return true;
+	}
 }

--- a/lib/ngg-db.php
+++ b/lib/ngg-db.php
@@ -1,1169 +1,1178 @@
 <?php
-if ( !class_exists('nggdb') ) :
-/**
- * NextGEN Gallery Database Class
- *
- * @author Alex Rabe, Vincent Prat
- *
- * @since 1.0.0
- */
-class nggdb {
+if ( ! class_exists( 'nggdb' ) ) :
+	/**
+	 * NextGEN Gallery Database Class
+	 *
+	 * @author Alex Rabe, Vincent Prat
+	 *
+	 * @since 1.0.0
+	 */
+	class nggdb {
+
+		/**
+		 * Holds the list of all galleries
+		 *
+		 * @since 1.1.0
+		 * @access public
+		 * @var object|array
+		 */
+		var $galleries = false;
+
+		/**
+		 * Holds the list of all images
+		 *
+		 * @since 1.3.0
+		 * @access public
+		 * @var object|array
+		 */
+		var $images = false;
+
+		/**
+		 * Holds the list of all albums
+		 *
+		 * @since 1.3.0
+		 * @access public
+		 * @var object|array
+		 */
+		var $albums = false;
+
+		/**
+		 * The array for the pagination
+		 *
+		 * @since 1.1.0
+		 * @access public
+		 * @var array
+		 */
+		var $paged = false;
+
+		/**
+		 * Init the Database Abstraction layer for NextGEN Gallery
+		 *
+		 */
+		function __construct() {
+			global $wpdb;
+
+			$this->galleries = array();
+			$this->images = array();
+			$this->albums = array();
+			$this->paged = array();
+
+			register_shutdown_function( array(&$this, '__destruct' ) );
 
-    /**
-     * Holds the list of all galleries
-     *
-     * @since 1.1.0
-     * @access public
-     * @var object|array
-     */
-    var $galleries = false;
-
-    /**
-     * Holds the list of all images
-     *
-     * @since 1.3.0
-     * @access public
-     * @var object|array
-     */
-    var $images = false;
-
-    /**
-     * Holds the list of all albums
-     *
-     * @since 1.3.0
-     * @access public
-     * @var object|array
-     */
-    var $albums = false;
-
-    /**
-     * The array for the pagination
-     *
-     * @since 1.1.0
-     * @access public
-     * @var array
-     */
-    var $paged = false;
-
-    /**
-     * Init the Database Abstraction layer for NextGEN Gallery
-     *
-     */
-    function __construct() {
-        global $wpdb;
-
-        $this->galleries = array();
-        $this->images    = array();
-        $this->albums    = array();
-        $this->paged     = array();
-
-        register_shutdown_function(array(&$this, '__destruct'));
-
-    }
-
-    /**
-     * PHP5 style destructor and will run when database object is destroyed.
-     *
-     * @return bool Always true
-     */
-    function __destruct() {
-        return true;
-    }
-
-    /**
-     * Get all the album and unserialize the content
-     *
-     * @since 1.3.0
-     * @param string $order_by
-     * @param string $order_dir
-     * @param int $limit number of albums, 0 shows all albums
-     * @param int $start the start index for paged albums
-     * @return array $album
-     */
-    function find_all_album( $order_by = 'id', $order_dir = 'ASC', $limit = 0, $start = 0) {
-        global $wpdb;
-
-        $order_dir = ( $order_dir == 'DESC') ? 'DESC' : 'ASC';
-        $limit_by  = ( $limit > 0 ) ? 'LIMIT ' . intval($start) . ',' . intval($limit) : '';
-        $this->albums = $wpdb->get_results("SELECT * FROM $wpdb->nggalbum ORDER BY {$order_by} {$order_dir} {$limit_by}" , OBJECT_K );
-
-        if ( !$this->albums )
-            return array();
-
-        foreach ($this->albums as $key => $value) {
-            $this->albums[$key]->galleries = empty ($this->albums[$key]->sortorder) ? array() : (array) unserialize($this->albums[$key]->sortorder)  ;
-            $this->albums[$key]->name = stripslashes( $this->albums[$key]->name );
-            $this->albums[$key]->albumdesc = stripslashes( $this->albums[$key]->albumdesc );
-            wp_cache_add($key, $this->albums[$key], 'ngg_album');
-        }
-
-        return $this->albums;
-    }
-
-    static function count_galleries() {
-
-        global $wpdb;
-
-        return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->nggallery" );
-    }
-
-    /**
-     * @param $id int The gallery ID.
-     *
-     * @return null|string
-     */
-    static function count_images_in_gallery( $id ) {
-
-        global $wpdb;
-
-        return $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->nggpictures WHERE galleryid = %d", $id ) );
-    }
-
-    /**
-     * Get all the galleries
-     *
-     * @param string $order_by
-     * @param string $order_dir
-     * @param bool $counter (optional) Select true  when you need to count the images
-     * @param int $limit number of paged galleries, 0 shows all galleries
-     * @param int $start the start index for paged galleries
-     * @param bool $exclude
-     * @return array $galleries
-     */
-    function find_all_galleries($order_by = 'gid', $order_dir = 'ASC', $counter = false, $limit = 0, $start = 0, $exclude = true) {
-        global $wpdb;
-
-        // Check for the exclude setting
-        $exclude_clause = ($exclude) ? ' AND exclude<>1 ' : '';
-        $order_dir = ( $order_dir == 'DESC') ? 'DESC' : 'ASC';
-        $limit_by  = ( $limit > 0 ) ? 'LIMIT ' . intval($start) . ',' . intval($limit) : '';
-        $this->galleries = $wpdb->get_results( "SELECT SQL_CALC_FOUND_ROWS * FROM $wpdb->nggallery ORDER BY {$order_by} {$order_dir} {$limit_by}", OBJECT_K );
-
-        // Count the number of galleries and calculate the pagination
-        if ($limit > 0) {
-            $this->paged['total_objects'] = intval ( $wpdb->get_var( "SELECT FOUND_ROWS()" ) );
-            $this->paged['objects_per_page'] = max ( count( $this->galleries ), $limit );
-            $this->paged['max_objects_per_page'] = ( $limit > 0 ) ? ceil( $this->paged['total_objects'] / intval($limit)) : 1;
-        }
-
-        if ( !$this->galleries )
-            return array();
-
-        // get the galleries information
-        foreach ($this->galleries as $key => $value) {
-            $galleriesID[] = $key;
-            // init the counter values
-            $this->galleries[$key]->counter = 0;
-            $this->galleries[$key]->title = stripslashes($this->galleries[$key]->title);
-            $this->galleries[$key]->galdesc  = stripslashes($this->galleries[$key]->galdesc);
-			$this->galleries[$key]->abspath = WINABSPATH . $this->galleries[$key]->path;
-            wp_cache_add($key, $this->galleries[$key], 'ngg_gallery');
-        }
-
-        // if we didn't need to count the images then stop here
-        if ( !$counter )
-            return $this->galleries;
-
-        // get the counter values
-        $picturesCounter = $wpdb->get_results('SELECT galleryid, COUNT(*) as counter FROM '.$wpdb->nggpictures.' WHERE galleryid IN (\''.implode('\',\'', $galleriesID).'\') ' . $exclude_clause . ' GROUP BY galleryid', OBJECT_K);
-
-        if ( !$picturesCounter )
-            return $this->galleries;
-
-        // add the counter to the gallery objekt
-        foreach ($picturesCounter as $key => $value) {
-            $this->galleries[$value->galleryid]->counter = $value->counter;
-            wp_cache_set($value->galleryid, $this->galleries[$value->galleryid], 'ngg_gallery');
-        }
-
-        return $this->galleries;
-    }
-
-    /**
-     * Get a gallery given its ID
-     *
-     * @param int|string $id or $slug
-     * @return A nggGallery object (null if not found)
-     */
-    static function find_gallery( $id ) {
-        global $wpdb;
-
-        if( is_numeric($id) ) {
-
-            if ( $gallery = wp_cache_get($id, 'ngg_gallery') )
-                return $gallery;
-
-            $gallery = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggallery WHERE gid = %d", $id ) );
-
-        } else
-            $gallery = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggallery WHERE slug = %s", $id ) );
-
-        // Build the object from the query result
-        if ($gallery) {
-            // it was a bad idea to use a object, stripslashes_deep() could not used here, learn from it
-            $gallery->title = stripslashes($gallery->title);
-            $gallery->galdesc  = stripslashes($gallery->galdesc);
-
-            $gallery->abspath = WINABSPATH . $gallery->path;
-            //TODO:Possible failure , $id could be a number or name
-            wp_cache_add($id, $gallery, 'ngg_gallery');
-
-            return $gallery;
-        } else
-            return false;
-    }
-
-    /**
-     * This function return all information about the gallery and the images inside
-     *
-     * @param int|string $id or $name
-     * @param string $order_by
-     * @param string $order_dir (ASC |DESC)
-     * @param bool $exclude
-     * @param int $limit number of paged galleries, 0 shows all galleries
-     * @param int $start the start index for paged galleries
-     * @param bool $json remove the key for associative array in json request
-     * @return An array containing the nggImage objects representing the images in the gallery.
-     */
-    function get_gallery($id, $order_by = 'sortorder', $order_dir = 'ASC', $exclude = true, $limit = 0, $start = 0, $json = false) {
-
-        global $wpdb;
-
-        // init the gallery as empty array
-        $gallery = array();
-        $i = 0;
-
-        // Check for the exclude setting
-        $exclude_clause = ($exclude) ? ' AND tt.exclude<>1 ' : '';
-
-        // Say no to any other value
-        $order_dir		= ( $order_dir == 'DESC') ? 'DESC' : 'ASC';
-        $order_by		= ( empty($order_by) ) ? 'sortorder' : $order_by;
-		$order_clause	= "ABS(tt.{$order_by}) {$order_dir}, tt.{$order_by} {$order_dir}";
-//		$order_clause	= "LENGTH(tt.{$order_by}) {$order_dir}, tt.{$order_by} {$order_dir}";
-
-        // Should we limit this query ?
-        $limit_by  = ( $limit > 0 ) ? 'LIMIT ' . intval($start) . ',' . intval($limit) : '';
-
-        // Query database
-        if( is_numeric($id) )
-            $result = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.gid = %d {$exclude_clause} ORDER BY {$order_clause} {$limit_by}", $id ), OBJECT_K );
-        else
-            $result = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.slug = %s {$exclude_clause} ORDER BY {$order_clause} {$limit_by}", $id ), OBJECT_K );
-
-        // Count the number of images and calculate the pagination
-        if ($limit > 0) {
-            $this->paged['total_objects'] = intval ( $wpdb->get_var( "SELECT FOUND_ROWS()" ) );
-            $this->paged['objects_per_page'] = max ( count( $result ), $limit );
-            $this->paged['max_objects_per_page'] = ( $limit > 0 ) ? ceil( $this->paged['total_objects'] / intval($limit)) : 1;
-        }
-
-        // Build the object
-        if ($result) {
-
-            // Now added all image data
-            foreach ($result as $key => $value) {
-                // due to a browser bug we need to remove the key for associative array for json request
-                // (see http://code.google.com/p/chromium/issues/detail?id=883)
-                if ($json) $key = $i++;
-                $gallery[$key] = new nggImage( $value ); // keep in mind each request require 8-16 kb memory usage
-
-            }
-        }
-
-        // Could not add to cache, the structure is different to find_gallery() cache_add, need rework
-        //wp_cache_add($id, $gallery, 'ngg_gallery');
-
-        return $gallery;
-    }
-
-    /**
-     * This function return all information about the gallery and the images inside
-     *
-     * @param int|string $id or $name
-     * @param string $orderby
-     * @param string $order (ASC |DESC)
-     * @param bool $exclude
-     * @return array An array containing the nggImage objects representing the images in the gallery.
-     */
-    static function get_ids_from_gallery($id, $order_by = 'sortorder', $order_dir = 'ASC', $exclude = true) {
-
-        global $wpdb;
-
-        // Check for the exclude setting
-        $exclude_clause = ($exclude) ? ' AND tt.exclude<>1 ' : '';
-
-        // Say no to any other value
-        $order_dir = ( $order_dir == 'DESC') ? 'DESC' : 'ASC';
-        $order_by  = ( empty($order_by) ) ? 'sortorder' : $order_by;
-
-        // Query database
-        if( is_numeric($id) )
-            $result = $wpdb->get_col( $wpdb->prepare( "SELECT tt.pid FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.gid = %d $exclude_clause ORDER BY tt.{$order_by} $order_dir", $id ) );
-        else
-            $result = $wpdb->get_col( $wpdb->prepare( "SELECT tt.pid FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.slug = %s $exclude_clause ORDER BY tt.{$order_by} $order_dir", $id ) );
-
-        return $result;
-    }
-
-    /**
-     * Delete a gallery AND all the pictures associated to this gallery!
-     *
-     * @id The gallery ID
-     */
-    static function delete_gallery( $id ) {
-        global $wpdb, $nggdb;
-
-        $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggpictures WHERE galleryid = %d", $id) );
-        $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggallery WHERE gid = %d", $id) );
-
-        wp_cache_delete($id, 'ngg_gallery');
-
-        //TODO:Remove all tag relationship
-
-		//Update the galleries to remove the deleted ID's
-		$albums = $nggdb->find_all_album();
-
-		foreach ($albums as $album) {
-			$albumid = $album->id;
-			$galleries = $album->galleries;
-			$deleted = array_search($id, $galleries);
-
-			unset($galleries[$deleted]);
-
-			$new_galleries = serialize($galleries);
-
-			nggdb::update_album($albumid, false, false, false, $new_galleries);
 		}
 
-        return true;
-    }
+		/**
+		 * PHP5 style destructor and will run when database object is destroyed.
+		 *
+		 * @return bool Always true
+		 */
+		function __destruct() {
+			return true;
+		}
 
-    /**
-     * Get an album given its ID
-     *
-     * @id The album ID or name
-     * @return A nggGallery object (false if not found)
-     */
-    static function find_album( $id ) {
-        global $wpdb;
+		/**
+		 * Get all the album and unserialize the content
+		 *
+		 * @since 1.3.0
+		 * @param string $order_by
+		 * @param string $order_dir
+		 * @param int $limit number of albums, 0 shows all albums
+		 * @param int $start the start index for paged albums
+		 * @return array $album
+		 */
+		function find_all_album( $order_by = 'id', $order_dir = 'ASC', $limit = 0, $start = 0 ) {
+			global $wpdb;
 
-        // Query database
-        if ( is_numeric($id) && $id != 0 ) {
-            if ( $album = wp_cache_get($id, 'ngg_album') )
-                return $album;
+			$order_dir = ( $order_dir == 'DESC' ) ? 'DESC' : 'ASC';
+			$limit_by = ( $limit > 0 ) ? 'LIMIT ' . intval( $start ) . ',' . intval( $limit ) : '';
+			$this->albums = $wpdb->get_results( "SELECT * FROM $wpdb->nggalbum ORDER BY {$order_by} {$order_dir} {$limit_by}", OBJECT_K );
 
-            $album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggalbum WHERE id = %d", $id) );
-        } elseif ( $id == 'all' || (is_numeric($id) && $id == 0) ) {
-            // init the object and fill it
-            $album = new stdClass();
-            $album->id = 'all';
-            $album->name = __('Album overview','nggallery');
-            $album->albumdesc  = __('Album overview','nggallery');
-            $album->previewpic = 0;
-            $album->sortorder  =  serialize( $wpdb->get_col("SELECT gid FROM $wpdb->nggallery") );
-        } else {
-            $album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggalbum WHERE slug = %s", $id) );
-        }
+			if ( ! $this->albums )
+				return array();
 
-        // Unserialize the galleries inside the album
-        if ( $album ) {
-            if ( !empty( $album->sortorder ) )
-                $album->gallery_ids = unserialize( $album->sortorder );
+			foreach ( $this->albums as $key => $value ) {
+				$this->albums[ $key ]->galleries = empty( $this->albums[ $key ]->sortorder ) ? array() : (array) unserialize( $this->albums[ $key ]->sortorder );
+				$this->albums[ $key ]->name = stripslashes( $this->albums[ $key ]->name );
+				$this->albums[ $key ]->albumdesc = stripslashes( $this->albums[ $key ]->albumdesc );
+				wp_cache_add( $key, $this->albums[ $key ], 'ngg_album' );
+			}
 
-            // it was a bad idea to use a object, stripslashes_deep() could not used here, learn from it
-            $album->albumdesc  = stripslashes($album->albumdesc);
-            $album->name       = stripslashes($album->name);
+			return $this->albums;
+		}
 
-            wp_cache_add($album->id, $album, 'ngg_album');
-            return $album;
-        }
+		static function count_galleries() {
 
-        return false;
-    }
+			global $wpdb;
 
-    /**
-     * Delete an album
-     *
-     * @id The album ID
-     */
-    static function delete_album( $id ) {
-        global $wpdb;
+			return $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->nggallery" );
+		}
 
-        $result = $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggalbum WHERE id = %d", $id) );
-        wp_cache_delete($id, 'ngg_album');
+		/**
+		 * @param $id int The gallery ID.
+		 *
+		 * @return null|string
+		 */
+		static function count_images_in_gallery( $id ) {
 
-        return $result;
-    }
+			global $wpdb;
 
-    /**
-     * Insert an image in the database
-     *
-     * @return the ID of the inserted image
-     */
-    static function insert_image($gid, $filename, $alttext, $desc, $exclude) {
-        global $wpdb;
+			return $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->nggpictures WHERE galleryid = %d", $id ) );
+		}
 
-        $result = $wpdb->query(
-              "INSERT INTO $wpdb->nggpictures (galleryid, filename, description, alttext, exclude) VALUES "
-            . "('$gid', '$filename', '$desc', '$alttext', '$exclude');");
-        $pid = (int) $wpdb->insert_id;
-        wp_cache_delete($gid, 'ngg_gallery');
+		/**
+		 * Get all the galleries
+		 *
+		 * @param string $order_by
+		 * @param string $order_dir
+		 * @param bool $counter (optional) Select true  when you need to count the images
+		 * @param int $limit number of paged galleries, 0 shows all galleries
+		 * @param int $start the start index for paged galleries
+		 * @param bool $exclude
+		 * @return array $galleries
+		 */
+		function find_all_galleries( $order_by = 'gid', $order_dir = 'ASC', $counter = false, $limit = 0, $start = 0, $exclude = true ) {
+			global $wpdb;
 
-        return $pid;
-    }
+			// Check for the exclude setting
+			$exclude_clause = ( $exclude ) ? ' AND exclude<>1 ' : '';
+			$order_dir = ( $order_dir == 'DESC' ) ? 'DESC' : 'ASC';
+			$limit_by = ( $limit > 0 ) ? 'LIMIT ' . intval( $start ) . ',' . intval( $limit ) : '';
+			$this->galleries = $wpdb->get_results( "SELECT SQL_CALC_FOUND_ROWS * FROM $wpdb->nggallery ORDER BY {$order_by} {$order_dir} {$limit_by}", OBJECT_K );
 
-    /**
-     * nggdb::update_image() - Update an image in the database
-     *
-     * @param int $pid   id of the image
-     * @param (optional) string|int $galleryid
-     * @param (optional) string $filename
-     * @param (optional) string $description
-     * @param (optional) string $alttext
-     * @param (optional) int $exclude (0 or 1)
-     * @param (optional) int $sortorder
-     * @return bool result of update query
-     */
-    static function update_image($pid, $galleryid = false, $filename = false, $description = false, $alttext = false, $exclude = false, $sortorder = false) {
+			// Count the number of galleries and calculate the pagination
+			if ( $limit > 0 ) {
+				$this->paged['total_objects'] = intval( $wpdb->get_var( "SELECT FOUND_ROWS()" ) );
+				$this->paged['objects_per_page'] = max( count( $this->galleries ), $limit );
+				$this->paged['max_objects_per_page'] = ( $limit > 0 ) ? ceil( $this->paged['total_objects'] / intval( $limit ) ) : 1;
+			}
 
-        global $wpdb;
+			if ( ! $this->galleries )
+				return array();
 
-        $sql = array();
-        $pid = (int) $pid;
+			// get the galleries information
+			foreach ( $this->galleries as $key => $value ) {
+				$galleriesID[] = $key;
+				// init the counter values
+				$this->galleries[ $key ]->counter = 0;
+				$this->galleries[ $key ]->title = stripslashes( $this->galleries[ $key ]->title );
+				$this->galleries[ $key ]->galdesc = stripslashes( $this->galleries[ $key ]->galdesc );
+				$this->galleries[ $key ]->abspath = WINABSPATH . $this->galleries[ $key ]->path;
+				wp_cache_add( $key, $this->galleries[ $key ], 'ngg_gallery' );
+			}
 
-        // slug must be unique, we use the alttext for that
-        $slug = nggdb::get_unique_slug( sanitize_title( $alttext ), 'image' );
+			// if we didn't need to count the images then stop here
+			if ( ! $counter )
+				return $this->galleries;
 
-        $update = array(
-            'image_slug'  => $slug,
-            'galleryid'   => $galleryid,
-            'filename'    => $filename,
-            'description' => $description,
-            'alttext'     => $alttext,
-            'exclude'     => $exclude,
-            'sortorder'   => $sortorder);
+			// get the counter values
+			$picturesCounter = $wpdb->get_results( 'SELECT galleryid, COUNT(*) as counter FROM ' . $wpdb->nggpictures . ' WHERE galleryid IN (\'' . implode( '\',\'', $galleriesID ) . '\') ' . $exclude_clause . ' GROUP BY galleryid', OBJECT_K );
 
-        // create the sql parameter "name = value"
-        foreach ($update as $key => $value)
-            if ($value !== false)
-                $sql[] = $key . " = '" . $value . "'";
+			if ( ! $picturesCounter )
+				return $this->galleries;
 
-        // create the final string
-        $sql = implode(', ', $sql);
+			// add the counter to the gallery objekt
+			foreach ( $picturesCounter as $key => $value ) {
+				$this->galleries[ $value->galleryid ]->counter = $value->counter;
+				wp_cache_set( $value->galleryid, $this->galleries[ $value->galleryid ], 'ngg_gallery' );
+			}
 
-        if ( !empty($sql) && $pid != 0)
-            $result = $wpdb->query( "UPDATE $wpdb->nggpictures SET $sql WHERE pid = $pid" );
+			return $this->galleries;
+		}
 
-        wp_cache_delete($pid, 'ngg_image');
+		/**
+		 * Get a gallery given its ID
+		 *
+		 * @param int|string $id or $slug
+		 * @return nggImage|null nggGallery object (null if not found)
+		 */
+		static function find_gallery( $id ) {
+			global $wpdb;
 
-        return $result;
-    }
+			if ( is_numeric( $id ) ) {
 
-     /**
-     * nggdb::update_gallery() - Update an gallery in the database
-     *
-     * @since V1.7.0
-     * @param int $id   id of the gallery
-     * @param (optional) string $title or name of the gallery
-     * @param (optional) string $path
-     * @param (optional) string $description
-     * @param (optional) int $pageid
-     * @param (optional) int $previewpic
-     * @param (optional) int $author
-     * @return bool result of update query
-     */
-    static function update_gallery($id, $name = false, $path = false, $title = false, $description = false, $pageid = false, $previewpic = false, $author = false) {
+				if ( $gallery = wp_cache_get( $id, 'ngg_gallery' ) )
+					return $gallery;
 
-        global $wpdb;
+				$gallery = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggallery WHERE gid = %d", $id ) );
 
-        $sql = array();
-        $id = (int) $id;
+			} else {
+				$gallery = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggallery WHERE slug = %s", $id ) );
+			}
 
-        // slug must be unique, we use the title for that
-        $slug = nggdb::get_unique_slug( sanitize_title( $title ), 'gallery' );
+			// Build the object from the query result
+			if ( $gallery ) {
+				// it was a bad idea to use a object, stripslashes_deep() could not used here, learn from it
+				$gallery->title = stripslashes( $gallery->title );
+				$gallery->galdesc = stripslashes( $gallery->galdesc );
 
-        $update = array(
-            'name'       => $name,
-            'slug'       => $slug,
-            'path'       => $path,
-            'title'      => $title,
-            'galdesc'    => $description,
-            'pageid'     => $pageid,
-            'previewpic' => $previewpic,
-            'author'     => $author);
+				$gallery->abspath = WINABSPATH . $gallery->path;
+				//TODO:Possible failure , $id could be a number or name
+				wp_cache_add( $id, $gallery, 'ngg_gallery' );
 
-        // create the sql parameter "name = value"
-        foreach ($update as $key => $value)
-            if ($value !== false)
-                $sql[] = $key . " = '" . $value . "'";
+				return $gallery;
+			} else {
+				return null;
+			}
+		}
 
-        // create the final string
-        $sql = implode(', ', $sql);
+		/**
+		 * This function return all information about the gallery and the images inside
+		 *
+		 * @param int|string $id or $name
+		 * @param string $order_by
+		 * @param string $order_dir (ASC |DESC)
+		 * @param bool $exclude
+		 * @param int $limit number of paged galleries, 0 shows all galleries
+		 * @param int $start the start index for paged galleries
+		 * @param bool $json remove the key for associative array in json request
+		 * @return nggImage[] An array containing the nggImage objects representing the images in the gallery.
+		 */
+		function get_gallery( $id, $order_by = 'sortorder', $order_dir = 'ASC', $exclude = true, $limit = 0, $start = 0, $json = false ) {
 
-        if ( !empty($sql) && $id != 0)
-            $result = $wpdb->query( "UPDATE $wpdb->nggallery SET $sql WHERE gid = $id" );
+			global $wpdb;
 
-        wp_cache_delete($id, 'ngg_gallery');
+			// init the gallery as empty array
+			$gallery = array();
+			$i = 0;
 
-        return $result;
-    }
+			// Check for the exclude setting
+			$exclude_clause = ( $exclude ) ? ' AND tt.exclude<>1 ' : '';
 
-     /**
-     * nggdb::update_album() - Update an album in the database
-     *
-     * @since V1.7.0
-     * @param int $ id   id of the album
-     * @param (optional) string $title
-     * @param (optional) int $previewpic
-     * @param (optional) string $description
-     * @param (optional) serialized array $sortorder
-     * @param (optional) int $pageid
-     * @return bool result of update query
-     */
-    static function update_album($id, $name = false, $previewpic = false, $description = false, $sortorder = false, $pageid = false ) {
+			// Say no to any other value
+			$order_dir = ( $order_dir == 'DESC' ) ? 'DESC' : 'ASC';
+			$order_by = ( empty( $order_by ) ) ? 'sortorder' : $order_by;
+			$order_clause = "ABS(tt.{$order_by}) {$order_dir}, tt.{$order_by} {$order_dir}";
+			//		$order_clause	= "LENGTH(tt.{$order_by}) {$order_dir}, tt.{$order_by} {$order_dir}";
 
-        global $wpdb;
+			// Should we limit this query ?
+			$limit_by = ( $limit > 0 ) ? 'LIMIT ' . intval( $start ) . ',' . intval( $limit ) : '';
 
-        $sql = array();
-        $id = (int) $id;
+			// Query database
+			if ( is_numeric( $id ) )
+				$result = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.gid = %d {$exclude_clause} ORDER BY {$order_clause} {$limit_by}", $id ), OBJECT_K );
+			else
+				$result = $wpdb->get_results( $wpdb->prepare( "SELECT SQL_CALC_FOUND_ROWS tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.slug = %s {$exclude_clause} ORDER BY {$order_clause} {$limit_by}", $id ), OBJECT_K );
 
-        // slug must be unique, we use the title for that
-        $slug = nggdb::get_unique_slug( sanitize_title( $name ), 'album' );
+			// Count the number of images and calculate the pagination
+			if ( $limit > 0 ) {
+				$this->paged['total_objects'] = intval( $wpdb->get_var( "SELECT FOUND_ROWS()" ) );
+				$this->paged['objects_per_page'] = max( count( $result ), $limit );
+				$this->paged['max_objects_per_page'] = ( $limit > 0 ) ? ceil( $this->paged['total_objects'] / intval( $limit ) ) : 1;
+			}
 
-        $update = array(
-            'name'       => $name,
-            'slug'       => $slug,
-            'previewpic' => $previewpic,
-            'albumdesc'  => $description,
-            'sortorder'  => $sortorder,
-            'pageid'     => $pageid);
+			// Build the object
+			if ( $result ) {
 
-        // create the sql parameter "name = value"
-        foreach ($update as $key => $value)
-            if ($value !== false)
-                $sql[] = $key . " = '" . $value . "'";
+				// Now added all image data
+				foreach ( $result as $key => $value ) {
+					// due to a browser bug we need to remove the key for associative array for json request
+					// (see http://code.google.com/p/chromium/issues/detail?id=883)
+					if ( $json )
+						$key = $i++;
+					$gallery[ $key ] = new nggImage( $value ); // keep in mind each request require 8-16 kb memory usage
 
-        // create the final string
-        $sql = implode(', ', $sql);
+				}
+			}
 
-        if ( !empty($sql) && $id != 0)
-            $result = $wpdb->query( "UPDATE $wpdb->nggalbum SET $sql WHERE id = $id" );
+			// Could not add to cache, the structure is different to find_gallery() cache_add, need rework
+			//wp_cache_add($id, $gallery, 'ngg_gallery');
 
-        wp_cache_delete($id, 'ngg_album');
+			return $gallery;
+		}
 
-        return $result;
-    }
+		/**
+		 * This function return all information about the gallery and the images inside
+		 *
+		 * @param int|string $id or $name
+		 * @param string $orderby
+		 * @param string $order (ASC |DESC)
+		 * @param bool $exclude
+		 * @return nggImage[] An array containing the nggImage objects representing the images in the gallery.
+		 */
+		static function get_ids_from_gallery( $id, $order_by = 'sortorder', $order_dir = 'ASC', $exclude = true ) {
 
-    /**
-     * Get an image given its ID
-     *
-     * @param  int|string The image ID or Slug
-     * @return nggImage|bool The image, or false if it wasn't found.
-     */
-    static function find_image( $id ) {
-        global $wpdb;
+			global $wpdb;
 
-        if( is_numeric($id) ) {
+			// Check for the exclude setting
+			$exclude_clause = ( $exclude ) ? ' AND tt.exclude<>1 ' : '';
 
-            if ( $image = wp_cache_get($id, 'ngg_image') )
-                return $image;
+			// Say no to any other value
+			$order_dir = ( $order_dir == 'DESC' ) ? 'DESC' : 'ASC';
+			$order_by = ( empty( $order_by ) ) ? 'sortorder' : $order_by;
 
-            $result = $wpdb->get_row( $wpdb->prepare( "SELECT tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.pid = %d ", $id ) );
-        } else
-            $result = $wpdb->get_row( $wpdb->prepare( "SELECT tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.image_slug = %s ", $id ) );
+			// Query database
+			if ( is_numeric( $id ) )
+				$result = $wpdb->get_col( $wpdb->prepare( "SELECT tt.pid FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.gid = %d $exclude_clause ORDER BY tt.{$order_by} $order_dir", $id ) );
+			else
+				$result = $wpdb->get_col( $wpdb->prepare( "SELECT tt.pid FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.slug = %s $exclude_clause ORDER BY tt.{$order_by} $order_dir", $id ) );
 
-        // Build the object from the query result
-        if ($result) {
-            $image = new nggImage($result);
-            return $image;
-        }
+			return $result;
+		}
 
-        return false;
-    }
+		/**
+		 * Delete a gallery AND all the pictures associated to this gallery!
+		 *
+		 * @id The gallery ID
+		 */
+		static function delete_gallery( $id ) {
+			global $wpdb, $nggdb;
 
-    /**
-     * Get images given a list of IDs
-     *
-     * @param $pids array of picture_ids
-     * @return An array of nggImage objects representing the images
-     */
-    static function find_images_in_list( $pids, $exclude = false, $order = 'NOTSET') {
-        global $wpdb;
+			$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggpictures WHERE galleryid = %d", $id ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggallery WHERE gid = %d", $id ) );
 
-        $qry = nggdb::find_images_query( $pids, $exclude, $order); //Build query to get images
-        $images =$wpdb->get_results($qry,OBJECT_K);
+			wp_cache_delete( $id, 'ngg_gallery' );
 
-        $result = array(); // Build the image objects from the query result
-        if ($images) {
-            foreach ($images as $key => $image)
-                $result[$key] = new nggImage( $image );
-        }
-        return $result;
-    }
+			//TODO:Remove all tag relationship
 
-    /**
-     *
-     * Return sql query to get images
-     * 20150110: workarounded case if $pids is a string or numeric value. Makes function more flexible, yet there is no case where
-     * this functions is called using string/numeric...
-     *
-     * @param $pids array of Picture Ids | id value (string or integer) which is converted to array.
-     * @param $exclude Boolean true to exclude images with field exclude set
-     * @param $sort_dir  String order direction. Options: ASC,DESC,RAND and NOTSET where natural sort is used.
-     *
-     */
-    static function find_images_query( $pids, $exclude = false , $sort_dir = 'NOTSET') {
-        global $ngg,$wpdb;
+			//Update the galleries to remove the deleted ID's
+			$albums = $nggdb->find_all_album();
 
-        //Try to convert if there is one element.
-        //TODO: empty or invalid arrays should be avoided. (they will make an invalid query)
-        if (!is_array($pids)) {
-            $pids= array($pids); //create one-element array
-        }
+			foreach ( $albums as $album ) {
+				$albumid = $album->id;
+				$galleries = $album->galleries;
+				$deleted = array_search( $id, $galleries );
 
-        $exclude_clause = ($exclude) ? " AND t.exclude <> 1" : ""; //exclude images if required (notice one  space before, none after)
+				unset( $galleries[ $deleted ] );
 
-        if ($sort_dir =="RAND") {
-            $order_clause = " ORDER BY rand()"; //notice one space before, none after
-        } else {
-            //get Sort field and sort direction to make order by sentence
-            $sort_dir     = ($sort_dir == 'NOTSET') ? $ngg->options['galSortDir'] : $sort_dir;
-            $sort_field   = $ngg->options['galSort'];
-            $order_clause = " ORDER BY t.$sort_field $sort_dir"; //notice one space before,none after
-        }
-        $id_list = "'" . implode("', '", $pids) . "'";
-        //notice NO spaces between $exclude_clause and $order_clause on purpose
-        return "SELECT t.*, tt.* FROM $wpdb->nggpictures AS t INNER JOIN $wpdb->nggallery AS tt ON t.galleryid = tt.gid WHERE t.pid IN ($id_list)$exclude_clause$order_clause";
-    }
+				$new_galleries = serialize( $galleries );
+
+				nggdb::update_album( $albumid, false, false, false, $new_galleries );
+			}
+
+			return true;
+		}
+
+		/**
+		 * Get an album given its ID
+		 *
+		 * @id The album ID or name
+		 * @return nggImage|null A nggGallery object (null if not found)
+		 */
+		static function find_album( $id ) {
+			global $wpdb;
+
+			// Query database
+			if ( is_numeric( $id ) && $id != 0 ) {
+				if ( $album = wp_cache_get( $id, 'ngg_album' ) )
+					return $album;
+
+				$album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggalbum WHERE id = %d", $id ) );
+			} elseif ( $id == 'all' || ( is_numeric( $id ) && $id == 0 ) ) {
+				// init the object and fill it
+				$album = new stdClass();
+				$album->id = 'all';
+				$album->name = __( 'Album overview', 'nggallery' );
+				$album->albumdesc = __( 'Album overview', 'nggallery' );
+				$album->previewpic = 0;
+				$album->sortorder = serialize( $wpdb->get_col( "SELECT gid FROM $wpdb->nggallery" ) );
+			} else {
+				$album = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->nggalbum WHERE slug = %s", $id ) );
+			}
+
+			// Unserialize the galleries inside the album
+			if ( $album ) {
+				if ( ! empty( $album->sortorder ) )
+					$album->gallery_ids = unserialize( $album->sortorder );
+
+				// it was a bad idea to use a object, stripslashes_deep() could not used here, learn from it
+				$album->albumdesc = stripslashes( $album->albumdesc );
+				$album->name = stripslashes( $album->name );
+
+				wp_cache_add( $album->id, $album, 'ngg_album' );
+				return $album;
+			}
+
+			return null;
+		}
+
+		/**
+		 * Delete an album
+		 *
+		 * @id The album ID
+		 */
+		static function delete_album( $id ) {
+			global $wpdb;
+
+			$result = $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggalbum WHERE id = %d", $id ) );
+			wp_cache_delete( $id, 'ngg_album' );
+
+			return $result;
+		}
+
+		/**
+		 * Insert an image in the database
+		 *
+		 * @return int the ID of the inserted image
+		 */
+		static function insert_image( $gid, $filename, $alttext, $desc, $exclude ) {
+			global $wpdb;
+
+			$result = $wpdb->query(
+				"INSERT INTO $wpdb->nggpictures (galleryid, filename, description, alttext, exclude) VALUES "
+				. "('$gid', '$filename', '$desc', '$alttext', '$exclude');" );
+			$pid = (int) $wpdb->insert_id;
+			wp_cache_delete( $gid, 'ngg_gallery' );
+
+			return $pid;
+		}
+
+		/**
+		 * nggdb::update_image() - Update an image in the database
+		 *
+		 * @param int $pid   id of the image
+		 * @param string|int (optional) $galleryid
+		 * @param string (optional) $filename
+		 * @param string (optional) $description
+		 * @param string (optional) $alttext
+		 * @param int (optional) $exclude (0 or 1)
+		 * @param int (optional) $sortorder
+		 * @return bool result of update query
+		 */
+		static function update_image( $pid, $galleryid = false, $filename = false, $description = false, $alttext = false, $exclude = false, $sortorder = false ) {
+
+			global $wpdb;
+
+			$sql = array();
+			$pid = (int) $pid;
+
+			// slug must be unique, we use the alttext for that
+			$slug = nggdb::get_unique_slug( sanitize_title( $alttext ), 'image' );
+
+			$update = array(
+				'image_slug' => $slug,
+				'galleryid' => $galleryid,
+				'filename' => $filename,
+				'description' => $description,
+				'alttext' => $alttext,
+				'exclude' => $exclude,
+				'sortorder' => $sortorder );
+
+			// create the sql parameter "name = value"
+			foreach ( $update as $key => $value )
+				if ( $value !== false )
+					$sql[] = $key . " = '" . $value . "'";
+
+			// create the final string
+			$sql = implode( ', ', $sql );
+
+			if ( ! empty( $sql ) && $pid != 0 )
+				$result = $wpdb->query( "UPDATE $wpdb->nggpictures SET $sql WHERE pid = $pid" );
+
+			wp_cache_delete( $pid, 'ngg_image' );
+
+			return $result;
+		}
+
+		/**
+		 * nggdb::update_gallery() - Update an gallery in the database
+		 *
+		 * @since V1.7.0
+		 * @param int $id   id of the gallery
+		 * @param string (optional) $title or name of the gallery
+		 * @param string (optional) $path
+		 * @param string (optional) $description
+		 * @param int (optional) $pageid
+		 * @param int (optional) $previewpic
+		 * @param int (optional) $author
+		 * @return bool result of update query
+		 */
+		static function update_gallery( $id, $name = false, $path = false, $title = false, $description = false, $pageid = false, $previewpic = false, $author = false ) {
+
+			global $wpdb;
+
+			$sql = array();
+			$id = (int) $id;
+
+			// slug must be unique, we use the title for that
+			$slug = nggdb::get_unique_slug( sanitize_title( $title ), 'gallery' );
+
+			$update = array(
+				'name' => $name,
+				'slug' => $slug,
+				'path' => $path,
+				'title' => $title,
+				'galdesc' => $description,
+				'pageid' => $pageid,
+				'previewpic' => $previewpic,
+				'author' => $author );
+
+			// create the sql parameter "name = value"
+			foreach ( $update as $key => $value )
+				if ( $value !== false )
+					$sql[] = $key . " = '" . $value . "'";
+
+			// create the final string
+			$sql = implode( ', ', $sql );
+
+			if ( ! empty( $sql ) && $id != 0 )
+				$result = $wpdb->query( "UPDATE $wpdb->nggallery SET $sql WHERE gid = $id" );
+
+			wp_cache_delete( $id, 'ngg_gallery' );
+
+			return $result;
+		}
+
+		/**
+		 * nggdb::update_album() - Update an album in the database
+		 *
+		 * @since V1.7.0
+		 * @param int $ id   id of the album
+		 * @param string (optional) $title
+		 * @param int (optional) $previewpic
+		 * @param string (optional) $description
+		 * @param string (optional) array $sortorder
+		 * @param int (optional) $pageid
+		 * @return bool result of update query
+		 */
+		static function update_album( $id, $name = false, $previewpic = false, $description = false, $sortorder = false, $pageid = false ) {
+
+			global $wpdb;
+
+			$sql = array();
+			$id = (int) $id;
+
+			// slug must be unique, we use the title for that
+			$slug = nggdb::get_unique_slug( sanitize_title( $name ), 'album' );
+
+			$update = array(
+				'name' => $name,
+				'slug' => $slug,
+				'previewpic' => $previewpic,
+				'albumdesc' => $description,
+				'sortorder' => $sortorder,
+				'pageid' => $pageid );
+
+			// create the sql parameter "name = value"
+			foreach ( $update as $key => $value )
+				if ( $value !== false )
+					$sql[] = $key . " = '" . $value . "'";
+
+			// create the final string
+			$sql = implode( ', ', $sql );
+
+			if ( ! empty( $sql ) && $id != 0 )
+				$result = $wpdb->query( "UPDATE $wpdb->nggalbum SET $sql WHERE id = $id" );
+
+			wp_cache_delete( $id, 'ngg_album' );
+
+			return $result;
+		}
+
+		/**
+		 * Get an image given its ID
+		 *
+		 * @param  int|string The image ID or Slug
+		 * @return nggImage|bool The image, or false if it wasn't found.
+		 */
+		static function find_image( $id ) {
+			global $wpdb;
+
+			if ( is_numeric( $id ) ) {
+
+				if ( $image = wp_cache_get( $id, 'ngg_image' ) )
+					return $image;
+
+				$result = $wpdb->get_row( $wpdb->prepare( "SELECT tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.pid = %d ", $id ) );
+			} else
+				$result = $wpdb->get_row( $wpdb->prepare( "SELECT tt.*, t.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.image_slug = %s ", $id ) );
+
+			// Build the object from the query result
+			if ( $result ) {
+				$image = new nggImage( $result );
+				return $image;
+			}
+
+			return false;
+		}
+
+		/**
+		 * Get images given a list of IDs
+		 *
+		 * @param $pids array of picture_ids
+		 * @return nggImage[] An array of nggImage objects representing the images
+		 */
+		static function find_images_in_list( $pids, $exclude = false, $order = 'NOTSET' ) {
+			global $wpdb;
+
+			$qry = nggdb::find_images_query( $pids, $exclude, $order ); //Build query to get images
+			$images = $wpdb->get_results( $qry, OBJECT_K );
+
+			$result = array(); // Build the image objects from the query result
+			if ( $images ) {
+				foreach ( $images as $key => $image )
+					$result[ $key ] = new nggImage( $image );
+			}
+			return $result;
+		}
+
+		/**
+		 *
+		 * Return sql query to get images
+		 * 20150110: workarounded case if $pids is a string or numeric value. Makes function more flexible, yet there is no case where
+		 * this functions is called using string/numeric...
+		 *
+		 * @param $pids array of Picture Ids | id value (string or integer) which is converted to array.
+		 * @param $exclude Boolean true to exclude images with field exclude set
+		 * @param $sort_dir  String order direction. Options: ASC,DESC,RAND and NOTSET where natural sort is used.
+		 *
+		 */
+		static function find_images_query( $pids, $exclude = false, $sort_dir = 'NOTSET' ) {
+			global $ngg, $wpdb;
+
+			//Try to convert if there is one element.
+			//TODO: empty or invalid arrays should be avoided. (they will make an invalid query)
+			if ( ! is_array( $pids ) ) {
+				$pids = array( $pids ); //create one-element array
+			}
+
+			$exclude_clause = ( $exclude ) ? " AND t.exclude <> 1" : ""; //exclude images if required (notice one  space before, none after)
+
+			if ( $sort_dir == "RAND" ) {
+				$order_clause = " ORDER BY rand()"; //notice one space before, none after
+			} else {
+				//get Sort field and sort direction to make order by sentence
+				$sort_dir = ( $sort_dir == 'NOTSET' ) ? $ngg->options['galSortDir'] : $sort_dir;
+				$sort_field = $ngg->options['galSort'];
+				$order_clause = " ORDER BY t.$sort_field $sort_dir"; //notice one space before,none after
+			}
+			$id_list = "'" . implode( "', '", $pids ) . "'";
+			//notice NO spaces between $exclude_clause and $order_clause on purpose
+			return "SELECT t.*, tt.* FROM $wpdb->nggpictures AS t INNER JOIN $wpdb->nggallery AS tt ON t.galleryid = tt.gid WHERE t.pid IN ($id_list)$exclude_clause$order_clause";
+		}
 
 
-    /**
-    * Add an image to the database
-    *
-	* @since V1.4.0
-	* @param int $pid   id of the gallery
-    * @param (optional) string|int $galleryid
-    * @param (optional) string $filename
-    * @param (optional) string $description
-    * @param (optional) string $alttext
-    * @param (optional) array $meta data
-    * @param (optional) int $post_id (required for sync with WP media lib)
-    * @param (optional) string $imagedate
-    * @param (optional) int $exclude (0 or 1)
-    * @param (optional) int $sortorder
-    * @return bool result of the ID of the inserted image
-    */
-    static function add_image( $id = false, $filename = false, $description = '', $alttext = '', $meta_data = false, $post_id = 0, $imagedate = '0000-00-00 00:00:00', $exclude = 0, $sortorder = 0  ) {
-        global $wpdb;
+		/**
+		 * Add an image to the database
+		 *
+		 * @since V1.4.0
+		 * @param int $pid   id of the gallery
+		 * @param string|int (optional) $galleryid
+		 * @param string (optional) $filename
+		 * @param string (optional) $description
+		 * @param string (optional) $alttext
+		 * @param array (optional) $meta data
+		 * @param int (optional) $post_id (required for sync with WP media lib)
+		 * @param string (optional) $imagedate
+		 * @param int (optional) $exclude (0 or 1)
+		 * @param int (optional) $sortorder
+		 * @return bool result of the ID of the inserted image
+		 */
+		static function add_image( $id = false, $filename = false, $description = '', $alttext = '', $meta_data = false, $post_id = 0, $imagedate = '0000-00-00 00:00:00', $exclude = 0, $sortorder = 0 ) {
+			global $wpdb;
 
-		if ( is_array($meta_data) )
-			$meta_data = serialize($meta_data);
+			if ( is_array( $meta_data ) )
+				$meta_data = serialize( $meta_data );
 
-        // slug must be unique, we use the alttext for that
-        $slug = nggdb::get_unique_slug( sanitize_title( $alttext ), 'image' );
+			// slug must be unique, we use the alttext for that
+			$slug = nggdb::get_unique_slug( sanitize_title( $alttext ), 'image' );
 
-		// Add the image
-		if ( false === $wpdb->query( $wpdb->prepare("INSERT INTO $wpdb->nggpictures (image_slug, galleryid, filename, description, alttext, meta_data, post_id, imagedate, exclude, sortorder)
+			// Add the image
+			if ( false === $wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->nggpictures (image_slug, galleryid, filename, description, alttext, meta_data, post_id, imagedate, exclude, sortorder)
 													 VALUES (%s, %d, %s, %s, %s, %s, %d, %s, %d, %d)", $slug, $id, $filename, $description, $alttext, $meta_data, $post_id, $imagedate, $exclude, $sortorder ) ) ) {
-			return false;
+				return false;
+			}
+
+			$imageID = (int) $wpdb->insert_id;
+
+			// Remove from cache the galley, needs to be rebuild now
+			wp_cache_delete( $id, 'ngg_gallery' );
+
+			//and give me the new id
+			return $imageID;
 		}
 
-		$imageID = (int) $wpdb->insert_id;
+		/**
+		 * Add an album to the database
+		 *
+		 * @since V1.7.0
+		 * @param string (optional) $title
+		 * @param int (optional) $previewpic
+		 * @param string (optional) $description
+		 * @param  array serialized (optional) $sortorder
+		 * @param int (optional) $pageid
+		 * @return bool result of the ID of the inserted album
+		 */
+		static function add_album( $name = false, $previewpic = 0, $description = '', $sortorder = 0, $pageid = 0 ) {
+			global $wpdb;
 
-		// Remove from cache the galley, needs to be rebuild now
-	    wp_cache_delete( $id, 'ngg_gallery');
+			// name must be unique, we use the title for that
+			$slug = nggdb::get_unique_slug( sanitize_title( $name ), 'album' );
 
-		//and give me the new id
-		return $imageID;
-    }
-
-    /**
-    * Add an album to the database
-    *
-	* @since V1.7.0
-    * @param (optional) string $title
-    * @param (optional) int $previewpic
-    * @param (optional) string $description
-    * @param (optional) serialized array $sortorder
-    * @param (optional) int $pageid
-    * @return bool result of the ID of the inserted album
-    */
-    static function add_album( $name = false, $previewpic = 0, $description = '', $sortorder = 0, $pageid = 0  ) {
-        global $wpdb;
-
-        // name must be unique, we use the title for that
-        $slug = nggdb::get_unique_slug( sanitize_title( $name ), 'album' );
-
-		// Add the album
-		if ( false === $wpdb->query( $wpdb->prepare("INSERT INTO $wpdb->nggalbum (name, slug, previewpic, albumdesc, sortorder, pageid)
+			// Add the album
+			if ( false === $wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->nggalbum (name, slug, previewpic, albumdesc, sortorder, pageid)
 													 VALUES (%s, %s, %d, %s, %s, %d)", $name, $slug, $previewpic, $description, $sortorder, $pageid ) ) ) {
-			return false;
+				return false;
+			}
+
+			$albumID = (int) $wpdb->insert_id;
+
+			//and give me the new id
+			return $albumID;
 		}
 
-		$albumID = (int) $wpdb->insert_id;
+		/**
+		 * Add an gallery to the database
+		 *
+		 * @since V1.7.0
+		 * @param string (optional) $title or name of the gallery
+		 * @param string (optional) $path
+		 * @param string (optional) $description
+		 * @param int (optional) $pageid
+		 * @param int (optional) $previewpic
+		 * @param int (optional) $author
+		 * @return bool|int result of the ID of the inserted gallery
+		 */
+		static function add_gallery( $title = '', $path = '', $description = '', $pageid = 0, $previewpic = 0, $author = 0 ) {
+			global $wpdb;
 
-		//and give me the new id
-		return $albumID;
-    }
+			// slug must be unique, we use the title for that
+			$slug = nggdb::get_unique_slug( sanitize_title( $title ), 'gallery' );
 
-    /**
-    * Add an gallery to the database
-    *
-	* @since V1.7.0
-    * @param (optional) string $title or name of the gallery
-    * @param (optional) string $path
-    * @param (optional) string $description
-    * @param (optional) int $pageid
-    * @param (optional) int $previewpic
-    * @param (optional) int $author
-    * @return bool|int result of the ID of the inserted gallery
-    */
-    static function add_gallery( $title = '', $path = '', $description = '', $pageid = 0, $previewpic = 0, $author = 0  ) {
-        global $wpdb;
-
-        // slug must be unique, we use the title for that
-        $slug = nggdb::get_unique_slug( sanitize_title( $title ), 'gallery' );
-
-        // Note : The field 'name' is deprecated, it's currently kept only for compat reason with older shortcodes, we copy the slug into this field
-		if ( false === $wpdb->query( $wpdb->prepare("INSERT INTO $wpdb->nggallery (name, slug, path, title, galdesc, pageid, previewpic, author)
+			// Note : The field 'name' is deprecated, it's currently kept only for compat reason with older shortcodes, we copy the slug into this field
+			if ( false === $wpdb->query( $wpdb->prepare( "INSERT INTO $wpdb->nggallery (name, slug, path, title, galdesc, pageid, previewpic, author)
 													 VALUES (%s, %s, %s, %s, %s, %d, %d, %d)", $slug, $slug, $path, $title, $description, $pageid, $previewpic, $author ) ) ) {
-			return false;
+				return false;
+			}
+
+			$galleryID = (int) $wpdb->insert_id;
+
+			//and give me the new id
+			return $galleryID;
 		}
 
-		$galleryID = (int) $wpdb->insert_id;
-
-		//and give me the new id
-		return $galleryID;
-    }
-
-    /**
-    * Delete an image entry from the database
-    * @param integer $id is the Image ID
-    */
-    static function delete_image( $id ) {
-        global $wpdb;
-
-        //Example: add_filter( 'ngg_pre_delete_image', '__return_true' ) will prevent to delete an image just addint a filter
-        //Use the filter for specific cases when you desire to control wether delete or not an image based on external conditions
-        if (apply_filters('ngg_pre_delete_image',false,$id)) {
-            return;
-        }
-        // Delete the image
-        $result = $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggpictures WHERE pid = %d", $id) );
-
-        // Delete tag references
-        wp_delete_object_term_relationships( $id, 'ngg_tag');
-
-        // Remove from cache
-        wp_cache_delete( $id, 'ngg_image');
-        do_action('ngg_deleted_image', $id);
-        return $result;
-    }
-
-    /**
-     * Get the last images registered in the database with a maximum number of $limit results
-     *
-     * @param integer $page start offset as page number (0,1,2,3,4...)
-     * @param integer $limit the number of result
-     * @param bool $exclude do not show exluded images
-     * @param int $galleryId Only look for images with this gallery id, or in all galleries if id is 0
-     * @param string $orderby is one of "id" (default, order by pid), "date" (order by exif date), sort (order by user sort order)
-     * @return
-     */
-    static function find_last_images($page = 0, $limit = 30, $exclude = true, $galleryId = 0, $orderby = "id") {
-        global $wpdb;
-
-        // Check for the exclude setting
-        $exclude_clause = ($exclude) ? ' AND exclude<>1 ' : '';
-
-        // a limit of 0 makes no sense
-        $limit = ($limit == 0) ? 30 : $limit;
-        // calculate the offset based on the pagr number
-        $offset = (int) $page * $limit;
-
-        $galleryId = (int) $galleryId;
-        $gallery_clause = ($galleryId === 0) ? '' : ' AND galleryid = ' . $galleryId . ' ';
-
-        // default order by pid
-        $order = 'pid DESC';
-        switch ($orderby) {
-            case 'date':
-                $order = 'imagedate DESC';
-                break;
-            case 'sort':
-                $order = 'sortorder ASC';
-                break;
-        }
-
-        $result = array();
-        $gallery_cache = array();
-
-        // Query database
-        $images = $wpdb->get_results("SELECT * FROM $wpdb->nggpictures WHERE 1=1 $exclude_clause $gallery_clause ORDER BY $order LIMIT $offset, $limit");
-
-        // Build the object from the query result
-        if ($images) {
-            foreach ($images as $key => $image) {
-
-                // cache a gallery , so we didn't need to lookup twice
-                if (!array_key_exists($image->galleryid, $gallery_cache))
-                    $gallery_cache[$image->galleryid] = nggdb::find_gallery($image->galleryid);
-
-                // Join gallery information with picture information
-                foreach ($gallery_cache[$image->galleryid] as $index => $value)
-                    $image->$index = $value;
-
-                // Now get the complete image data
-                $result[$key] = new nggImage( $image );
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * nggdb::get_random_images() - Get an random image from one ore more gally
-     *
-     * @param integer $number of images
-     * @param integer $galleryID optional a Gallery
-     * @return A nggImage object representing the image (null if not found)
-     */
-    static function get_random_images($number = 1, $galleryID = 0) {
-        global $wpdb;
-
-        $number = (int) $number;
-        $galleryID = (int) $galleryID;
-        $images = array();
-
-        // Query database
-        if ($galleryID == 0)
-            $result = $wpdb->get_results("SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.exclude != 1 ORDER by rand() limit $number");
-        else
-            $result = $wpdb->get_results("SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.gid = $galleryID AND tt.exclude != 1 ORDER by rand() limit {$number}");
-
-        // Return the object from the query result
-        if ($result) {
-            foreach ($result as $image) {
-                $images[] = new nggImage( $image );
-            }
-            return $images;
-        }
-
-        return null;
-    }
-
-    /**
-     * Get all the images from a given album
-     *
-     * @param object|int $album The album object or the id
-     * @param string $order_by
-     * @param string $order_dir
-     * @param bool $exclude
-     * @return An array containing the nggImage objects representing the images in the album.
-     */
-    static function find_images_in_album($album, $order_by = 'galleryid', $order_dir = 'ASC', $exclude = true) {
-        global $wpdb;
-
-        if ( !is_object($album) )
-            $album = nggdb::find_album( $album );
-
-        // Get gallery list
-        $gallery_list = implode(',', $album->gallery_ids);
-        // Check for the exclude setting
-        $exclude_clause = ($exclude) ? ' AND tt.exclude<>1 ' : '';
-
-        // Say no to any other value
-        $order_dir = ( $order_dir == 'DESC') ? 'DESC' : 'ASC';
-        $order_by  = ( empty($order_by) ) ? 'galleryid' : $order_by;
-
-        $result = $wpdb->get_results("SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.galleryid IN ($gallery_list) $exclude_clause ORDER BY tt.$order_by $order_dir");
-        // Return the object from the query result
-        if ($result) {
-            foreach ($result as $image) {
-                $images[] = new nggImage( $image );
-            }
-            return $images;
-        }
-
-        return null;
-    }
-
-    /**
-     * search for images and return the result
-     *
-     * @since 1.3.0
-     * @param string $request
-     * @param int $limit number of results, 0 shows all results
-     * @return Array Result of the request
-     */
-    function search_for_images( $request, $limit = 0 ) {
-        global $wpdb;
-
-        // If a search pattern is specified, load the posts that match
-        if ( !empty($request) ) {
-            // added slashes screw with quote grouping when done early, so done later
-            $request = stripslashes($request);
-
-            // split the words it a array if separated by a space or comma
-            preg_match_all('/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $request, $matches);
-            $search_terms = array_map( function ($a) { return trim($a, "\"'\n\r "); }, $matches[0]);
-
-            $n = '%';
-            $searchand = '';
-            $search = '';
-
-            foreach( (array) $search_terms as $term) {
-                $term = addslashes_gpc($term);
-                $search .= "{$searchand}((tt.description LIKE '{$n}{$term}{$n}') OR (tt.alttext LIKE '{$n}{$term}{$n}') OR (tt.filename LIKE '{$n}{$term}{$n}'))";
-                $searchand = ' AND ';
-            }
-
-            $term = esc_sql($request);
-            if (count($search_terms) > 1 && $search_terms[0] != $request )
-                $search .= " OR (tt.description LIKE '{$n}{$term}{$n}') OR (tt.alttext LIKE '{$n}{$term}{$n}') OR (tt.filename LIKE '{$n}{$term}{$n}')";
-
-            if ( !empty($search) )
-                $search = " AND ({$search}) ";
-
-            $limit_by  = ( $limit > 0 ) ? 'LIMIT ' . intval($limit) : '';
-        } else
-            return false;
-
-        // build the final query
-        $query = "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE 1=1 $search ORDER BY tt.pid ASC $limit_by";
-        $result = $wpdb->get_results($query);
-
-        // TODO: Currently we didn't support a proper pagination
-        $this->paged['total_objects'] = $this->paged['objects_per_page'] = intval ( $wpdb->get_var( "SELECT FOUND_ROWS()" ) );
-        $this->paged['max_objects_per_page'] = 1;
-
-        // Return the object from the query result
-        if ($result) {
-            foreach ($result as $image) {
-                $images[] = new nggImage( $image );
-            }
-            return $images;
-        }
-
-        return null;
-    }
-
-    /**
-     * search for galleries and return the result
-     *
-     * @since 1.7.0
-     * @param string $request
-     * @param int $limit number of results, 0 shows all results
-     * @return Array Result of the request
-     */
-    function search_for_galleries( $request, $limit = 0 ) {
-        global $wpdb;
-
-        // If a search pattern is specified, load the posts that match
-        if ( !empty($request) ) {
-            // added slashes screw with quote grouping when done early, so done later
-            $request = stripslashes($request);
-
-            // split the words it a array if separated by a space or comma
-            preg_match_all('/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $request, $matches);
-            $search_terms = array_map( function ($a) { return trim($a, "\"'\n\r "); }, $matches[0]);
-
-            $n = '%';
-            $searchand = '';
-            $search = '';
-
-            foreach( (array) $search_terms as $term) {
-                $term = addslashes_gpc($term);
-                $search .= "{$searchand}((title LIKE '{$n}{$term}{$n}') OR (name LIKE '{$n}{$term}{$n}') )";
-                $searchand = ' AND ';
-            }
-
-            $term = esc_sql($request);
-            if (count($search_terms) > 1 && $search_terms[0] != $request )
-                $search .= " OR (title LIKE '{$n}{$term}{$n}') OR (name LIKE '{$n}{$term}{$n}')";
-
-            if ( !empty($search) )
-                $search = " AND ({$search}) ";
-
-            $limit  = ( $limit > 0 ) ? 'LIMIT ' . intval($limit) : '';
-        } else
-            return false;
-
-        // build the final query
-        $query = "SELECT * FROM $wpdb->nggallery WHERE 1=1 $search ORDER BY title ASC $limit";
-        $result = $wpdb->get_results($query);
-
-        return $result;
-    }
-
-    /**
-     * search for albums and return the result
-     *
-     * @since 1.7.0
-     * @param string $request
-     * @param int $limit number of results, 0 shows all results
-     * @return Array Result of the request
-     */
-    function search_for_albums( $request, $limit = 0 ) {
-        global $wpdb;
-
-        // If a search pattern is specified, load the posts that match
-        if ( !empty($request) ) {
-            // added slashes screw with quote grouping when done early, so done later
-            $request = stripslashes($request);
-
-            // split the words it a array if separated by a space or comma
-            preg_match_all('/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $request, $matches);
-            $search_terms = array_map(function ($a) { return trim($a, "\"'\n\r "); }, $matches[0]);
-
-            $n = '%';
-            $searchand = '';
-            $search = '';
-
-            foreach( (array) $search_terms as $term) {
-                $term = addslashes_gpc($term);
-                $search .= "{$searchand}(name LIKE '{$n}{$term}{$n}')";
-                $searchand = ' AND ';
-            }
-
-            $term = esc_sql($request);
-            if (count($search_terms) > 1 && $search_terms[0] != $request )
-                $search .= " OR (name LIKE '{$n}{$term}{$n}')";
-
-            if ( !empty($search) )
-                $search = " AND ({$search}) ";
-
-            $limit  = ( $limit > 0 ) ? 'LIMIT ' . intval($limit) : '';
-        } else
-            return false;
-
-        // build the final query
-        $query = "SELECT * FROM $wpdb->nggalbum WHERE 1=1 $search ORDER BY name ASC $limit";
-        $result = $wpdb->get_results($query);
-
-        return $result;
-    }
-
-    /**
-     * search for a filename
-     *
-     * @since 1.4.0
-     * @param string $filename
-     * @param int (optional) $galleryID
-     * @return Array Result of the request
-     */
-    function search_for_file( $filename, $galleryID = false ) {
-        global $wpdb;
-
-        // If a search pattern is specified, load the posts that match
-        if ( !empty($filename) ) {
-            // added slashes screw with quote grouping when done early, so done later
-            $term = esc_sql($filename);
-
-           	$where_clause = '';
-            if ( is_numeric($galleryID) ) {
-            	$id = (int) $galleryID;
-            	$where_clause = " AND tt.galleryid = {$id}";
-            }
-        }
-
-        // build the final query
-        $query = "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.filename = '{$term}' {$where_clause} ORDER BY tt.pid ASC ";
-		$result = $wpdb->get_row($query);
-
-        // Return the object from the query result
-        if ($result) {
-        	$image = new nggImage( $result );
-            return $image;
-        }
-
-        return null;
-    }
-
-
-    /**
-     * Update or add meta data for an image
-     *
-     * @since 1.4.0
-     * @param int $id The image ID
-     * @param array $values An array with existing or new values
-     * @return bool result of query
-     */
-    static function update_image_meta( $id, $new_values ) {
-        global $wpdb;
-
-        // Query database for existing values
-        // Use cache object
-        $old_values = $wpdb->get_var( $wpdb->prepare( "SELECT meta_data FROM $wpdb->nggpictures WHERE pid = %d ", $id ) );
-        $old_values = unserialize( $old_values );
-
-        $meta = array_merge( (array)$old_values, (array)$new_values );
-
-        $result = $wpdb->query( $wpdb->prepare("UPDATE $wpdb->nggpictures SET meta_data = %s WHERE pid = %d", serialize($meta), $id) );
-
-        wp_cache_delete($id, 'ngg_image');
-
-        return $result;
-    }
-
-    /**
-     * Computes a unique slug for the gallery,album or image, when given the desired slug.
-     *
-     * @since 1.7.0
-     * @author taken from WP Core includes/post.php
-     * @param string $slug the desired slug (post_name)
-     * @param string $type ('image', 'album' or 'gallery')
-     * @param int (optional) $id of the object, so that it's not checked against itself
-     * @return string unique slug for the object, based on $slug (with a -1, -2, etc. suffix)
-     */
-    static function get_unique_slug( $slug, $type, $id = 0 ) {
-
-    	global $wpdb;
-
-        switch ($type) {
-            case 'image':
-        		$check_sql = "SELECT image_slug FROM $wpdb->nggpictures WHERE image_slug = %s AND NOT pid = %d LIMIT 1";
-            break;
-            case 'album':
-        		$check_sql = "SELECT slug FROM $wpdb->nggalbum WHERE slug = %s AND NOT id = %d LIMIT 1";
-            break;
-            case 'gallery':
-        		$check_sql = "SELECT slug FROM $wpdb->nggallery WHERE slug = %s AND NOT gid = %d LIMIT 1";
-            break;
-            default:
-                return false;
-        }
-
-        //if you didn't give us a name we take the type
-        $slug = empty($slug) ? $type: $slug;
-
-   		// Slugs must be unique across all objects.
-        $slug_check = $wpdb->get_var( $wpdb->prepare( $check_sql, $slug, $id ) );
-
-		if ( $slug_check ) {
-			$suffix = 2;
-			do {
-				$alt_name = substr ($slug, 0, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
-				$slug_check = $wpdb->get_var( $wpdb->prepare($check_sql, $alt_name, $id ) );
-				$suffix++;
-			} while ( $slug_check );
-			$slug = $alt_name;
+		/**
+		 * Delete an image entry from the database
+		 * @param integer $id is the Image ID
+		 */
+		static function delete_image( $id ) {
+			global $wpdb;
+
+			//Example: add_filter( 'ngg_pre_delete_image', '__return_true' ) will prevent to delete an image just addint a filter
+			//Use the filter for specific cases when you desire to control wether delete or not an image based on external conditions
+			if ( apply_filters( 'ngg_pre_delete_image', false, $id ) ) {
+				return;
+			}
+			// Delete the image
+			$result = $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->nggpictures WHERE pid = %d", $id ) );
+
+			// Delete tag references
+			wp_delete_object_term_relationships( $id, 'ngg_tag' );
+
+			// Remove from cache
+			wp_cache_delete( $id, 'ngg_image' );
+			do_action( 'ngg_deleted_image', $id );
+			return $result;
 		}
 
-       	return $slug;
-    }
+		/**
+		 * Get the last images registered in the database with a maximum number of $limit results
+		 *
+		 * @param integer $page start offset as page number (0,1,2,3,4...)
+		 * @param integer $limit the number of result
+		 * @param bool $exclude do not show exluded images
+		 * @param int $galleryId Only look for images with this gallery id, or in all galleries if id is 0
+		 * @param string $orderby is one of "id" (default, order by pid), "date" (order by exif date), sort (order by user sort order)
+		 * @return
+		 */
+		static function find_last_images( $page = 0, $limit = 30, $exclude = true, $galleryId = 0, $orderby = "id" ) {
+			global $wpdb;
 
-}
+			// Check for the exclude setting
+			$exclude_clause = ( $exclude ) ? ' AND exclude<>1 ' : '';
+
+			// a limit of 0 makes no sense
+			$limit = ( $limit == 0 ) ? 30 : $limit;
+			// calculate the offset based on the pagr number
+			$offset = (int) $page * $limit;
+
+			$galleryId = (int) $galleryId;
+			$gallery_clause = ( $galleryId === 0 ) ? '' : ' AND galleryid = ' . $galleryId . ' ';
+
+			// default order by pid
+			$order = 'pid DESC';
+			switch ( $orderby ) {
+				case 'date':
+					$order = 'imagedate DESC';
+					break;
+				case 'sort':
+					$order = 'sortorder ASC';
+					break;
+			}
+
+			$result = array();
+			$gallery_cache = array();
+
+			// Query database
+			$images = $wpdb->get_results( "SELECT * FROM $wpdb->nggpictures WHERE 1=1 $exclude_clause $gallery_clause ORDER BY $order LIMIT $offset, $limit" );
+
+			// Build the object from the query result
+			if ( $images ) {
+				foreach ( $images as $key => $image ) {
+
+					// cache a gallery , so we didn't need to lookup twice
+					if ( ! array_key_exists( $image->galleryid, $gallery_cache ) )
+						$gallery_cache[ $image->galleryid ] = nggdb::find_gallery( $image->galleryid );
+
+					// Join gallery information with picture information
+					foreach ( $gallery_cache[ $image->galleryid ] as $index => $value )
+						$image->$index = $value;
+
+					// Now get the complete image data
+					$result[ $key ] = new nggImage( $image );
+				}
+			}
+
+			return $result;
+		}
+
+		/**
+		 * nggdb::get_random_images() - Get an random image from one ore more gally
+		 *
+		 * @param integer $number of images
+		 * @param integer $galleryID optional a Gallery
+		 * @return nggImage[]|null A nggImage object representing the image (null if not found)
+		 */
+		static function get_random_images( $number = 1, $galleryID = 0 ) {
+			global $wpdb;
+
+			$number = (int) $number;
+			$galleryID = (int) $galleryID;
+			$images = array();
+
+			// Query database
+			if ( $galleryID == 0 )
+				$result = $wpdb->get_results( "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.exclude != 1 ORDER by rand() limit $number" );
+			else
+				$result = $wpdb->get_results( "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE t.gid = $galleryID AND tt.exclude != 1 ORDER by rand() limit {$number}" );
+
+			// Return the object from the query result
+			if ( $result ) {
+				foreach ( $result as $image ) {
+					$images[] = new nggImage( $image );
+				}
+				return $images;
+			}
+
+			return null;
+		}
+
+		/**
+		 * Get all the images from a given album
+		 *
+		 * @param object|int $album The album object or the id
+		 * @param string $order_by
+		 * @param string $order_dir
+		 * @param bool $exclude
+		 * @return nggImage[]|null An array containing the nggImage objects representing the images in the album.
+		 */
+		static function find_images_in_album( $album, $order_by = 'galleryid', $order_dir = 'ASC', $exclude = true ) {
+			global $wpdb;
+
+			if ( ! is_object( $album ) )
+				$album = nggdb::find_album( $album );
+
+			// Get gallery list
+			$gallery_list = implode( ',', $album->gallery_ids );
+			// Check for the exclude setting
+			$exclude_clause = ( $exclude ) ? ' AND tt.exclude<>1 ' : '';
+
+			// Say no to any other value
+			$order_dir = ( $order_dir == 'DESC' ) ? 'DESC' : 'ASC';
+			$order_by = ( empty( $order_by ) ) ? 'galleryid' : $order_by;
+
+			$result = $wpdb->get_results( "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.galleryid IN ($gallery_list) $exclude_clause ORDER BY tt.$order_by $order_dir" );
+			// Return the object from the query result
+			if ( $result ) {
+				foreach ( $result as $image ) {
+					$images[] = new nggImage( $image );
+				}
+				return $images;
+			}
+
+			return null;
+		}
+
+		/**
+		 * search for images and return the result
+		 *
+		 * @since 1.3.0
+		 * @param string $request
+		 * @param int $limit number of results, 0 shows all results
+		 * @return nggImage[]|null Array Result of the request
+		 */
+		function search_for_images( $request, $limit = 0 ) {
+			global $wpdb;
+
+			// If a search pattern is specified, load the posts that match
+			if ( ! empty( $request ) ) {
+				// added slashes screw with quote grouping when done early, so done later
+				$request = stripslashes( $request );
+
+				// split the words it a array if separated by a space or comma
+				preg_match_all( '/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $request, $matches );
+				$search_terms = array_map( function ($a) {
+					return trim( $a, "\"'\n\r " );
+				}, $matches[0] );
+
+				$n = '%';
+				$searchand = '';
+				$search = '';
+
+				foreach ( (array) $search_terms as $term ) {
+					$term = addslashes_gpc( $term );
+					$search .= "{$searchand}((tt.description LIKE '{$n}{$term}{$n}') OR (tt.alttext LIKE '{$n}{$term}{$n}') OR (tt.filename LIKE '{$n}{$term}{$n}'))";
+					$searchand = ' AND ';
+				}
+
+				$term = esc_sql( $request );
+				if ( count( $search_terms ) > 1 && $search_terms[0] != $request )
+					$search .= " OR (tt.description LIKE '{$n}{$term}{$n}') OR (tt.alttext LIKE '{$n}{$term}{$n}') OR (tt.filename LIKE '{$n}{$term}{$n}')";
+
+				if ( ! empty( $search ) )
+					$search = " AND ({$search}) ";
+
+				$limit_by = ( $limit > 0 ) ? 'LIMIT ' . intval( $limit ) : '';
+			} else
+				return null;
+
+			// build the final query
+			$query = "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE 1=1 $search ORDER BY tt.pid ASC $limit_by";
+			$result = $wpdb->get_results( $query );
+
+			// TODO: Currently we didn't support a proper pagination
+			$this->paged['total_objects'] = $this->paged['objects_per_page'] = intval( $wpdb->get_var( "SELECT FOUND_ROWS()" ) );
+			$this->paged['max_objects_per_page'] = 1;
+
+			// Return the object from the query result
+			if ( $result ) {
+				foreach ( $result as $image ) {
+					$images[] = new nggImage( $image );
+				}
+				return $images;
+			}
+
+			return null;
+		}
+
+		/**
+		 * search for galleries and return the result
+		 *
+		 * @since 1.7.0
+		 * @param string $request
+		 * @param int $limit number of results, 0 shows all results
+		 * @return array|null Array Result of the request
+		 */
+		function search_for_galleries( $request, $limit = 0 ) {
+			global $wpdb;
+
+			// If a search pattern is specified, load the posts that match
+			if ( ! empty( $request ) ) {
+				// added slashes screw with quote grouping when done early, so done later
+				$request = stripslashes( $request );
+
+				// split the words it a array if separated by a space or comma
+				preg_match_all( '/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $request, $matches );
+				$search_terms = array_map( function ($a) {
+					return trim( $a, "\"'\n\r " );
+				}, $matches[0] );
+
+				$n = '%';
+				$searchand = '';
+				$search = '';
+
+				foreach ( (array) $search_terms as $term ) {
+					$term = addslashes_gpc( $term );
+					$search .= "{$searchand}((title LIKE '{$n}{$term}{$n}') OR (name LIKE '{$n}{$term}{$n}') )";
+					$searchand = ' AND ';
+				}
+
+				$term = esc_sql( $request );
+				if ( count( $search_terms ) > 1 && $search_terms[0] != $request )
+					$search .= " OR (title LIKE '{$n}{$term}{$n}') OR (name LIKE '{$n}{$term}{$n}')";
+
+				if ( ! empty( $search ) )
+					$search = " AND ({$search}) ";
+
+				$limit = ( $limit > 0 ) ? 'LIMIT ' . intval( $limit ) : '';
+			} else
+				return null;
+
+			// build the final query
+			$query = "SELECT * FROM $wpdb->nggallery WHERE 1=1 $search ORDER BY title ASC $limit";
+			$result = $wpdb->get_results( $query );
+
+			return $result;
+		}
+
+		/**
+		 * search for albums and return the result
+		 *
+		 * @since 1.7.0
+		 * @param string $request
+		 * @param int $limit number of results, 0 shows all results
+		 * @return array|null Array Result of the request
+		 */
+		function search_for_albums( $request, $limit = 0 ) {
+			global $wpdb;
+
+			// If a search pattern is specified, load the posts that match
+			if ( ! empty( $request ) ) {
+				// added slashes screw with quote grouping when done early, so done later
+				$request = stripslashes( $request );
+
+				// split the words it a array if separated by a space or comma
+				preg_match_all( '/".*?("|$)|((?<=[\\s",+])|^)[^\\s",+]+/', $request, $matches );
+				$search_terms = array_map( function ($a) {
+					return trim( $a, "\"'\n\r " );
+				}, $matches[0] );
+
+				$n = '%';
+				$searchand = '';
+				$search = '';
+
+				foreach ( (array) $search_terms as $term ) {
+					$term = addslashes_gpc( $term );
+					$search .= "{$searchand}(name LIKE '{$n}{$term}{$n}')";
+					$searchand = ' AND ';
+				}
+
+				$term = esc_sql( $request );
+				if ( count( $search_terms ) > 1 && $search_terms[0] != $request )
+					$search .= " OR (name LIKE '{$n}{$term}{$n}')";
+
+				if ( ! empty( $search ) )
+					$search = " AND ({$search}) ";
+
+				$limit = ( $limit > 0 ) ? 'LIMIT ' . intval( $limit ) : '';
+			} else
+				return null;
+
+			// build the final query
+			$query = "SELECT * FROM $wpdb->nggalbum WHERE 1=1 $search ORDER BY name ASC $limit";
+			$result = $wpdb->get_results( $query );
+
+			return $result;
+		}
+
+		/**
+		 * search for a filename
+		 *
+		 * @since 1.4.0
+		 * @param string $filename
+		 * @param int (optional) $galleryID
+		 * @return nggImage|null Array Result of the request
+		 */
+		function search_for_file( $filename, $galleryID = false ) {
+			global $wpdb;
+
+			// If a search pattern is specified, load the posts that match
+			if ( ! empty( $filename ) ) {
+				// added slashes screw with quote grouping when done early, so done later
+				$term = esc_sql( $filename );
+
+				$where_clause = '';
+				if ( is_numeric( $galleryID ) ) {
+					$id = (int) $galleryID;
+					$where_clause = " AND tt.galleryid = {$id}";
+				}
+			}
+
+			// build the final query
+			$query = "SELECT t.*, tt.* FROM $wpdb->nggallery AS t INNER JOIN $wpdb->nggpictures AS tt ON t.gid = tt.galleryid WHERE tt.filename = '{$term}' {$where_clause} ORDER BY tt.pid ASC ";
+			$result = $wpdb->get_row( $query );
+
+			// Return the object from the query result
+			if ( $result ) {
+				$image = new nggImage( $result );
+				return $image;
+			}
+
+			return null;
+		}
+
+
+		/**
+		 * Update or add meta data for an image
+		 *
+		 * @since 1.4.0
+		 * @param int $id The image ID
+		 * @param array $values An array with existing or new values
+		 * @return bool result of query
+		 */
+		static function update_image_meta( $id, $new_values ) {
+			global $wpdb;
+
+			// Query database for existing values
+			// Use cache object
+			$old_values = $wpdb->get_var( $wpdb->prepare( "SELECT meta_data FROM $wpdb->nggpictures WHERE pid = %d ", $id ) );
+			$old_values = unserialize( $old_values );
+
+			$meta = array_merge( (array) $old_values, (array) $new_values );
+
+			$result = $wpdb->query( $wpdb->prepare( "UPDATE $wpdb->nggpictures SET meta_data = %s WHERE pid = %d", serialize( $meta ), $id ) );
+
+			wp_cache_delete( $id, 'ngg_image' );
+
+			return $result;
+		}
+
+		/**
+		 * Computes a unique slug for the gallery,album or image, when given the desired slug.
+		 *
+		 * @since 1.7.0
+		 * @author taken from WP Core includes/post.php
+		 * @param string $slug the desired slug (post_name)
+		 * @param string $type ('image', 'album' or 'gallery')
+		 * @param int (optional) $id of the object, so that it's not checked against itself
+		 * @return string unique slug for the object, based on $slug (with a -1, -2, etc. suffix)
+		 */
+		static function get_unique_slug( $slug, $type, $id = 0 ) {
+
+			global $wpdb;
+
+			switch ( $type ) {
+				case 'image':
+					$check_sql = "SELECT image_slug FROM $wpdb->nggpictures WHERE image_slug = %s AND NOT pid = %d LIMIT 1";
+					break;
+				case 'album':
+					$check_sql = "SELECT slug FROM $wpdb->nggalbum WHERE slug = %s AND NOT id = %d LIMIT 1";
+					break;
+				case 'gallery':
+					$check_sql = "SELECT slug FROM $wpdb->nggallery WHERE slug = %s AND NOT gid = %d LIMIT 1";
+					break;
+				default:
+					return false;
+			}
+
+			//if you didn't give us a name we take the type
+			$slug = empty( $slug ) ? $type : $slug;
+
+			// Slugs must be unique across all objects.
+			$slug_check = $wpdb->get_var( $wpdb->prepare( $check_sql, $slug, $id ) );
+
+			if ( $slug_check ) {
+				$suffix = 2;
+				do {
+					$alt_name = substr( $slug, 0, 200 - ( strlen( $suffix ) + 1 ) ) . "-$suffix";
+					$slug_check = $wpdb->get_var( $wpdb->prepare( $check_sql, $alt_name, $id ) );
+					$suffix++;
+				} while ( $slug_check );
+				$slug = $alt_name;
+			}
+
+			return $slug;
+		}
+
+	}
 endif;
 
-if ( ! isset($GLOBALS['nggdb']) ) {
-    /**
-     * Initate the NextGEN Gallery Database Object, for later cache reasons
-     * @global object $nggdb Creates a new nggdb object
-     * @since 1.1.0
-     */
-    unset($GLOBALS['nggdb']);
-    $GLOBALS['nggdb'] = new nggdb() ;
+if ( ! isset( $GLOBALS['nggdb'] ) ) {
+	/**
+	 * Initate the NextGEN Gallery Database Object, for later cache reasons
+	 * @global object $nggdb Creates a new nggdb object
+	 * @since 1.1.0
+	 */
+	unset( $GLOBALS['nggdb'] );
+	$GLOBALS['nggdb'] = new nggdb();
 }
 ?>

--- a/lib/rewrite.php
+++ b/lib/rewrite.php
@@ -1,16 +1,16 @@
 <?php
 
 /**
-* nggRewrite - Rewrite Rules for NextGEN Gallery
-*
-* sorry wp-guys I didn't understand this at all. 
-* I tried it a couple of hours : this is the only pooooor result
-*
-* @package NextGEN Gallery
-* @author Alex Rabe
-*
+ * nggRewrite - Rewrite Rules for NextGEN Gallery
+ *
+ * sorry wp-guys I didn't understand this at all. 
+ * I tried it a couple of hours : this is the only pooooor result
+ *
+ * @package NextGEN Gallery
+ * @author Alex Rabe
+ *
  * 20140518 FZSM Moved initialization to this class. Don't need to spread the code everywhere.
-*/
+ */
 class nggRewrite {
 
 	/**
@@ -19,168 +19,173 @@ class nggRewrite {
 	 * @since 1.8.0
 	 * @var string
 	 */
-	var $slug = 'nggallery';
-    
+	private string $slug = 'nggallery';
+
 	/**
 	 * Contain the main rewrite structure
 	 *
 	 * @since 1.8.3
 	 * @var array
-	 */    
-    var $ngg_rules = '';
-    
+	 */
+	private array $ngg_rules = [];
+
 	/**
-	* Constructor
-	*/
+	 * Contains ngg options
+	 */
+	private array $options = [];
+
+	/**
+	 * Constructor
+	 */
 	function __construct() {
-		
+
 		// read the option setting
-		$this->options = get_option('ngg_options');
-		
+		$this->options = is_array( get_option( 'ngg_options' ) ) ? get_option( 'ngg_options' ) : [];
+
 		// get later from the options
-        $this->slug = $this->options['permalinkSlug'];
+		$this->slug = @$this->options['permalinkSlug'] ? $this->options['permalinkSlug'] : '';
 
 		/*WARNING: Do nothook rewrite rule regentation on the init hook for anything other than dev. */
 		//add_action('init',array(&$this, 'flush'));
-		
-		add_filter('query_vars', array(&$this, 'add_queryvars') );
-		add_filter('wp_title' , array(&$this, 'rewrite_title') );
-		
-        //DD32 recommend : http://groups.google.com/group/wp-hackers/browse_thread/thread/50ac0d07e30765e9
-        //add_filter('rewrite_rules_array', array($this, 'RewriteRules')); 
-        	
-		if ($this->options['usePermalinks'])
-			add_action('generate_rewrite_rules', array(&$this, 'RewriteRules'));
 
-        // setup the main rewrite structure for the plugin
-        $this->ngg_rules = array(
-            '/page-([0-9]+)/' => '&nggpage=[matches]',
-    		'/image/([^/]+)/' => '&pid=[matches]',
-    		'/image/([^/]+)/page-([0-9]+)/' => '&pid=[matches]&nggpage=[matches]',
-    		'/slideshow/' => '&show=slide',
-    		'/images/' => '&show=gallery',
-    		'/tags/([^/]+)/' => '&gallerytag=[matches]',
-    		'/tags/([^/]+)/page-([0-9]+)/' => '&gallerytag=[matches]&nggpage=[matches]',
-    		'/([^/]+)/' => '&album=[matches]',
-    		'/([^/]+)/page-([0-9]+)/' => '&album=[matches]&nggpage=[matches]',
-    		'/([^/]+)/([^/]+)/' => '&album=[matches]&gallery=[matches]',
-    		'/([^/]+)/([^/]+)/slideshow/' => '&album=[matches]&gallery=[matches]&show=slide',
-    		'/([^/]+)/([^/]+)/images/' => '&album=[matches]&gallery=[matches]&show=gallery',
-    		'/([^/]+)/([^/]+)/page-([0-9]+)/' => '&album=[matches]&gallery=[matches]&nggpage=[matches]',
-    		'/([^/]+)/([^/]+)/page-([0-9]+)/slideshow/' => '&album=[matches]&gallery=[matches]&nggpage=[matches]&show=slide',
-    		'/([^/]+)/([^/]+)/page-([0-9]+)/images/' => '&album=[matches]&gallery=[matches]&nggpage=[matches]&show=gallery',
-    		'/([^/]+)/([^/]+)/image/([^/]+)/' => '&album=[matches]&gallery=[matches]&pid=[matches]'        
-        );        		
-		
-		
+		add_filter( 'query_vars', array(&$this, 'add_queryvars' ) );
+		add_filter( 'wp_title', array(&$this, 'rewrite_title' ) );
+
+		//DD32 recommend : http://groups.google.com/group/wp-hackers/browse_thread/thread/50ac0d07e30765e9
+		//add_filter('rewrite_rules_array', array($this, 'RewriteRules')); 
+
+		if ( @$this->options['usePermalinks'] )
+			add_action( 'generate_rewrite_rules', array(&$this, 'RewriteRules' ) );
+
+		// setup the main rewrite structure for the plugin
+		$this->ngg_rules = array(
+			'/page-([0-9]+)/' => '&nggpage=[matches]',
+			'/image/([^/]+)/' => '&pid=[matches]',
+			'/image/([^/]+)/page-([0-9]+)/' => '&pid=[matches]&nggpage=[matches]',
+			'/slideshow/' => '&show=slide',
+			'/images/' => '&show=gallery',
+			'/tags/([^/]+)/' => '&gallerytag=[matches]',
+			'/tags/([^/]+)/page-([0-9]+)/' => '&gallerytag=[matches]&nggpage=[matches]',
+			'/([^/]+)/' => '&album=[matches]',
+			'/([^/]+)/page-([0-9]+)/' => '&album=[matches]&nggpage=[matches]',
+			'/([^/]+)/([^/]+)/' => '&album=[matches]&gallery=[matches]',
+			'/([^/]+)/([^/]+)/slideshow/' => '&album=[matches]&gallery=[matches]&show=slide',
+			'/([^/]+)/([^/]+)/images/' => '&album=[matches]&gallery=[matches]&show=gallery',
+			'/([^/]+)/([^/]+)/page-([0-9]+)/' => '&album=[matches]&gallery=[matches]&nggpage=[matches]',
+			'/([^/]+)/([^/]+)/page-([0-9]+)/slideshow/' => '&album=[matches]&gallery=[matches]&nggpage=[matches]&show=slide',
+			'/([^/]+)/([^/]+)/page-([0-9]+)/images/' => '&album=[matches]&gallery=[matches]&nggpage=[matches]&show=gallery',
+			'/([^/]+)/([^/]+)/image/([^/]+)/' => '&album=[matches]&gallery=[matches]&pid=[matches]'
+		);
+
+
 	} // end of initialization
 
 	/**
-	* Get the permalink to a picture/album/gallery given its ID/name/...
-	*/
+	 * Get the permalink to a picture/album/gallery given its ID/name/...
+	 */
 	function get_permalink( $args ) {
 		global $wp_rewrite, $wp_query;
 
-        // taken from is_frontpage plugin, required for static homepage
-        $show_on_front = get_option('show_on_front');
-        $page_on_front = get_option('page_on_front');
+		// taken from is_frontpage plugin, required for static homepage
+		$show_on_front = get_option( 'show_on_front' );
+		$page_on_front = get_option( 'page_on_front' );
 
 		//TODO: Watch out for ticket http://trac.wordpress.org/ticket/6627
-		if ($wp_rewrite->using_permalinks() && $this->options['usePermalinks'] ) {
+		if ( $wp_rewrite->using_permalinks() && $this->options['usePermalinks'] ) {
 
-            $gID  = get_the_ID();
-            $post = get_post($gID);
+			$gID = get_the_ID();
+			$post = get_post( $gID );
 
 			// If the album is not set before get it from the wp_query ($_GET) 
-            if ( !isset ($args['album'] ) )
-                $album = get_query_var('album');
-			if ( !empty( $album ) )
-				$args ['album'] = $album;
-			
-			$gallery = get_query_var('gallery');
-			if ( !empty( $gallery ) )
-				$args ['gallery'] = $gallery;
-			
-			$gallerytag = get_query_var('gallerytag');
-			if ( !empty( $gallerytag ) )
-				$args ['gallerytag'] = $gallerytag;
-			
+			if ( ! isset ( $args['album'] ) )
+				$album = get_query_var( 'album' );
+			if ( ! empty ( $album ) )
+				$args['album'] = $album;
+
+			$gallery = get_query_var( 'gallery' );
+			if ( ! empty ( $gallery ) )
+				$args['gallery'] = $gallery;
+
+			$gallerytag = get_query_var( 'gallerytag' );
+			if ( ! empty ( $gallerytag ) )
+				$args['gallerytag'] = $gallerytag;
+
 			/** urlconstructor =  post url | slug | tags | [nav] | [show]
-				tags : 	album, gallery 	-> /album-([0-9]+)/gallery-([0-9]+)/
-						pid 			-> /image/([0-9]+)/
-						gallerytag		-> /tags/([^/]+)/
-				nav	 : 	nggpage			-> /page-([0-9]+)/
-				show : 	show=slide		-> /slideshow/
-						show=gallery	-> /images/	
-			**/
+																																										 tags : 	album, gallery 	-> /album-([0-9]+)/gallery-([0-9]+)/
+																																												 pid 			-> /image/([0-9]+)/
+																																												 gallerytag		-> /tags/([^/]+)/
+																																										 nav	 : 	nggpage			-> /page-([0-9]+)/
+																																										 show : 	show=slide		-> /slideshow/
+																																												 show=gallery	-> /images/	
+																																									 **/
 
 			// 1. Post / Page url + main slug
-            $url = trailingslashit ( get_permalink ($post->ID) ) . $this->slug; 
-            //TODO: For static home pages generate the link to the selected page, still doesn't work
-            if (($show_on_front == 'page') && ($page_on_front == get_the_ID()))
-                $url = trailingslashit ( $post->guid ) . $this->slug;
+			$url = trailingslashit( get_permalink( $post->ID ) ) . $this->slug;
+			//TODO: For static home pages generate the link to the selected page, still doesn't work
+			if ( ( $show_on_front == 'page' ) && ( $page_on_front == get_the_ID() ) )
+				$url = trailingslashit( $post->guid ) . $this->slug;
 
 			// 2. Album, pid or tags
-			if (isset ($args['album']) && ($args['gallery'] == false) )
+			if ( isset ( $args['album'] ) && ( $args['gallery'] == false ) )
 				$url .= '/' . $args['album'];
-			elseif  (isset ($args['album']) && isset ($args['gallery']) )
+			elseif ( isset ( $args['album'] ) && isset ( $args['gallery'] ) )
 				$url .= '/' . $args['album'] . '/' . $args['gallery'];
-				
-			if  (isset ($args['gallerytag']))
+
+			if ( isset ( $args['gallerytag'] ) )
 				$url .= '/tags/' . $args['gallerytag'];
-				
-			if  (isset ($args['pid']))
-				$url .= '/image/' . $args['pid'];			
-			
+
+			if ( isset ( $args['pid'] ) )
+				$url .= '/image/' . $args['pid'];
+
 			// 3. Navigation
-			if  (isset ($args['nggpage']) && ($args['nggpage']) )
+			if ( isset ( $args['nggpage'] ) && ( $args['nggpage'] ) )
 				$url .= '/page-' . $args['nggpage'];
-            elseif (isset ($args['nggpage']) && ($args['nggpage'] === false) && ( count($args) == 1 ) )
-                $url = trailingslashit ( get_permalink ($post->ID) ); // special case instead of showing page-1, we show the clean url
-			
+			elseif ( isset ( $args['nggpage'] ) && ( $args['nggpage'] === false ) && ( count( $args ) == 1 ) )
+				$url = trailingslashit( get_permalink( $post->ID ) ); // special case instead of showing page-1, we show the clean url
+
 			// 4. Show images or Slideshow
-			if  (isset ($args['show']))
+			if ( isset ( $args['show'] ) )
 				$url .= ( $args['show'] == 'slide' ) ? '/slideshow' : '/images';
 
-			return apply_filters('ngg_get_permalink', $url, $args);
-			
-		} else {			
+			return apply_filters( 'ngg_get_permalink', $url, $args );
+
+		} else {
 			// we need to add the page/post id at the start_page otherwise we don't know which gallery is clicked
-			if (is_home())
+			if ( is_home() )
 				$args['pageid'] = get_the_ID();
-			
-			if (($show_on_front == 'page') && ($page_on_front == get_the_ID()))
+
+			if ( ( $show_on_front == 'page' ) && ( $page_on_front == get_the_ID() ) )
 				$args['page_id'] = get_the_ID();
-			
-			if ( !is_singular() )
-				$query = htmlspecialchars( add_query_arg($args, get_permalink( get_the_ID() )) );
+
+			if ( ! is_singular() )
+				$query = htmlspecialchars( add_query_arg( $args, get_permalink( get_the_ID() ) ) );
 			else
 				$query = htmlspecialchars( add_query_arg( $args ) );
-			
-            return apply_filters('ngg_get_permalink', $query, $args);
+
+			return apply_filters( 'ngg_get_permalink', $query, $args );
 		}
 	}
 
 	/**
-	* The permalinks needs to be flushed after activation
-	*/
-	function flush() { 
+	 * The permalinks needs to be flushed after activation
+	 */
+	function flush() {
 		global $wp_rewrite, $ngg;
-		
-        // reload slug, maybe it changed during the flush routine
-        $this->slug = $ngg->options['permalinkSlug'];
-        
-		if ($ngg->options['usePermalinks'])
-			add_action('generate_rewrite_rules', array(&$this, 'RewriteRules'));
-			
+
+		// reload slug, maybe it changed during the flush routine
+		$this->slug = $ngg->options['permalinkSlug'];
+
+		if ( $ngg->options['usePermalinks'] )
+			add_action( 'generate_rewrite_rules', array(&$this, 'RewriteRules' ) );
+
 		$wp_rewrite->flush_rules();
 	}
 
 	/**
-	* add some more vars to the big wp_query
-	*/
-	function add_queryvars( $query_vars ){
-		
+	 * add some more vars to the big wp_query
+	 */
+	function add_queryvars( $query_vars ) {
+
 		$query_vars[] = 'pid';
 		$query_vars[] = 'pageid';
 		$query_vars[] = 'nggpage';
@@ -188,59 +193,59 @@ class nggRewrite {
 		$query_vars[] = 'album';
 		$query_vars[] = 'gallerytag';
 		$query_vars[] = 'show';
-        $query_vars[] = 'callback';
+		$query_vars[] = 'callback';
 
 		return $query_vars;
 	}
-	
+
 	/**
-	* rewrite the blog title if the gallery is used
-	*/	
-	function rewrite_title($title) {
-		
+	 * rewrite the blog title if the gallery is used
+	 */
+	function rewrite_title( $title ) {
+
 		$new_title = '';
 		// the separataor
 		$sep = ' &laquo; ';
-		
+
 		// $_GET from wp_query
-		$pid     = get_query_var('pid');
-		$pageid  = get_query_var('pageid');
-		$nggpage = get_query_var('nggpage');
-		$gallery = get_query_var('gallery');
-		$album   = get_query_var('album');
-		$tag  	 = get_query_var('gallerytag');
-		$show    = get_query_var('show');
+		$pid = get_query_var( 'pid' );
+		$pageid = get_query_var( 'pageid' );
+		$nggpage = get_query_var( 'nggpage' );
+		$gallery = get_query_var( 'gallery' );
+		$album = get_query_var( 'album' );
+		$tag = get_query_var( 'gallerytag' );
+		$show = get_query_var( 'show' );
 
 		//TODO: I could parse for the Picture name , gallery etc, but this increase the queries
 		//TODO: Class nggdb need to cache the query for the nggfunctions.php
 
 		if ( $show == 'slide' )
-			$new_title .= __('Slideshow', 'nggallery') . $sep ;
+			$new_title .= __( 'Slideshow', 'nggallery' ) . $sep;
 		elseif ( $show == 'show' )
-			$new_title .= __('Gallery', 'nggallery') . $sep ;	
+			$new_title .= __( 'Gallery', 'nggallery' ) . $sep;
 
-		if ( !empty($pid) )
-			$new_title .= __('Picture', 'nggallery') . ' ' . esc_attr($pid) . $sep ;
+		if ( ! empty ( $pid ) )
+			$new_title .= __( 'Picture', 'nggallery' ) . ' ' . esc_attr( $pid ) . $sep;
 
-		if ( !empty($album) )
-			$new_title .= __('Album', 'nggallery') . ' ' . esc_attr($album) . $sep ;
+		if ( ! empty ( $album ) )
+			$new_title .= __( 'Album', 'nggallery' ) . ' ' . esc_attr( $album ) . $sep;
 
-		if ( !empty($gallery) )
-			$new_title .= __('Gallery', 'nggallery') . ' ' . esc_attr($gallery) . $sep ;
-			
-		if ( !empty($nggpage) )
-			$new_title .= __('Page', 'nggallery') . ' ' . esc_attr($nggpage) . $sep ;
-		
+		if ( ! empty ( $gallery ) )
+			$new_title .= __( 'Gallery', 'nggallery' ) . ' ' . esc_attr( $gallery ) . $sep;
+
+		if ( ! empty ( $nggpage ) )
+			$new_title .= __( 'Page', 'nggallery' ) . ' ' . esc_attr( $nggpage ) . $sep;
+
 		//esc_attr should avoid XSS like http://domain/?gallerytag=%3C/title%3E%3Cscript%3Ealert(document.cookie)%3C/script%3E
-		if ( !empty($tag) )
-			$new_title .= esc_attr($tag) . $sep;
-		
+		if ( ! empty ( $tag ) )
+			$new_title .= esc_attr( $tag ) . $sep;
+
 		//prepend the data
 		$title = $new_title . $title;
-		
+
 		return $title;
 	}
-	
+
 	/**
 	 * Canonical support for a better SEO (Dupilcat content), not longer nedded for Wp 2.9
 	 * See : http://googlewebmastercentral.blogspot.com/2009/02/specify-your-canonical.html
@@ -248,49 +253,48 @@ class nggRewrite {
 	 * @deprecated
 	 * @return string $meta 
 	 */
-	function add_canonical_meta()
-    {
-            // create the meta link
- 			$meta  = "\n<link rel='canonical' href='" . get_permalink() ."' />";
- 			// add a filter for SEO plugins, so they can remove it
- 			echo apply_filters('ngg_add_canonical_meta', $meta);
-  			
-        return; 
-    }
-		
+	function add_canonical_meta() {
+		// create the meta link
+		$meta = "\n<link rel='canonical' href='" . get_permalink() . "' />";
+		// add a filter for SEO plugins, so they can remove it
+		echo apply_filters( 'ngg_add_canonical_meta', $meta );
+
+		return;
+	}
+
 	/**
-	* The actual rewrite rules
-	*/
-	function RewriteRules($wp_rewrite) {
-        global $ngg;
-        
-		$rewrite_rules = array (
-            // XML request
-            $this->slug . '/slideshow/([0-9]+)/?$' => 'index.php?imagerotator=true&gid=$matches[1]'
-		);  
-        
-        $rewrite_rules = array_merge($rewrite_rules, $this->generate_rewrite_rules() ); 
-		$wp_rewrite->rules = array_merge($rewrite_rules, $wp_rewrite->rules);		
+	 * The actual rewrite rules
+	 */
+	function RewriteRules( $wp_rewrite ) {
+		global $ngg;
+
+		$rewrite_rules = array(
+			// XML request
+			$this->slug . '/slideshow/([0-9]+)/?$' => 'index.php?imagerotator=true&gid=$matches[1]'
+		);
+
+		$rewrite_rules = array_merge( $rewrite_rules, $this->generate_rewrite_rules() );
+		$wp_rewrite->rules = array_merge( $rewrite_rules, $wp_rewrite->rules );
 	}
 
 	/**
 	 * Mainly a copy of the same function in wp-includes\rewrite.php
-     * Adding the NGG tags to each post & page. Never found easier and proper way to handle this with other functions.
+	 * Adding the NGG tags to each post & page. Never found easier and proper way to handle this with other functions.
 	 * 
 	 * @return array the permalink structure
 	 */
 	function generate_rewrite_rules() {
-        global $wp_rewrite;	   
-        
-        $rewrite_rules = array();
-        $permalink_structure =  $wp_rewrite->permalink_structure;      
-		
-        //get everything up to the first rewrite tag
-		$front = substr($permalink_structure, 0, strpos($permalink_structure, '%'));
+		global $wp_rewrite;
+
+		$rewrite_rules = array();
+		$permalink_structure = $wp_rewrite->permalink_structure;
+
+		//get everything up to the first rewrite tag
+		$front = substr( $permalink_structure, 0, strpos( $permalink_structure, '%' ) );
 		//build an array of the tags (note that said array ends up being in $tokens[0])
-		preg_match_all('/%.+?%/', $permalink_structure, $tokens);
-        
-		$num_tokens = count($tokens[0]);
+		preg_match_all( '/%.+?%/', $permalink_structure, $tokens );
+
+		$num_tokens = count( $tokens[0] );
 
 		$this->index = $wp_rewrite->index; //probably 'index.php'
 
@@ -298,50 +302,50 @@ class nggRewrite {
 		//tagname=$matches[i] where i is the current $i
 		for ( $i = 0; $i < $num_tokens; ++$i ) {
 			if ( 0 < $i )
-				$queries[$i] = $queries[$i - 1] . '&';
+				$queries[ $i ] = $queries[ $i - 1 ] . '&';
 			else
-				$queries[$i] = '';
+				$queries[ $i ] = '';
 
-			$query_token = str_replace($wp_rewrite->rewritecode, $wp_rewrite->queryreplace, $tokens[0][$i]) . $wp_rewrite->preg_index($i+1);
-			$queries[$i] .= $query_token;
+			$query_token = str_replace( $wp_rewrite->rewritecode, $wp_rewrite->queryreplace, $tokens[0][ $i ] ) . $wp_rewrite->preg_index( $i + 1 );
+			$queries[ $i ] .= $query_token;
 		}
 
 		//get the structure, minus any cruft (stuff that isn't tags) at the front
 		$structure = $permalink_structure;
 		if ( $front != '/' )
-			$structure = str_replace($front, '', $structure);
+			$structure = str_replace( $front, '', $structure );
 
 		//create a list of dirs to walk over, making rewrite rules for each level
 		//so for example, a $structure of /%year%/%month%/%postname% would create
 		//rewrite rules for /%year%/, /%year%/%month%/ and /%year%/%month%/%postname%
-		$structure = trim($structure, '/');
+		$structure = trim( $structure, '/' );
 
 		//strip slashes from the front of $front
-		$struct = preg_replace('|^/+|', '', $front);
+		$struct = preg_replace( '|^/+|', '', $front );
 
 		//get the struct for this dir, and trim slashes off the front
 		$struct .= $structure . '/'; //accumulate. see comment near explode('/', $structure) above
-		$struct = ltrim($struct, '/');
+		$struct = ltrim( $struct, '/' );
 
 		//replace tags with regexes
-		$match = str_replace($wp_rewrite->rewritecode, $wp_rewrite->rewritereplace, $struct);
+		$match = str_replace( $wp_rewrite->rewritecode, $wp_rewrite->rewritereplace, $struct );
 
 		//make a list of tags, and store how many there are in $num_toks
-		$num_toks = preg_match_all('/%.+?%/', $struct, $toks);
+		$num_toks = preg_match_all( '/%.+?%/', $struct, $toks );
 
 		//get the 'tagname=$matches[i]'
-		$query = ( isset($queries) && is_array($queries) ) ? $queries[$num_toks - 1] : '';
-       
-        if ( $num_toks ) {
-            // In the case we build for each and every page ( based on a simple %pagename% rule ) the rewrite rules,
-            // we need to add them first, then the post rules
-            if ( $wp_rewrite->use_verbose_page_rules )
-                $rewrite_rules = array_merge ( $this->page_rewrite_rules(), $this->add_rewrite_rules( $match, $query, $num_toks ) );
-            else
-                $rewrite_rules = array_merge ( $this->add_rewrite_rules( $match, $query, $num_toks ), $this->page_rewrite_rules() );
-        }
-        
-        return $rewrite_rules;
+		$query = ( isset ( $queries ) && is_array( $queries ) ) ? $queries[ $num_toks - 1 ] : '';
+
+		if ( $num_toks ) {
+			// In the case we build for each and every page ( based on a simple %pagename% rule ) the rewrite rules,
+			// we need to add them first, then the post rules
+			if ( $wp_rewrite->use_verbose_page_rules )
+				$rewrite_rules = array_merge( $this->page_rewrite_rules(), $this->add_rewrite_rules( $match, $query, $num_toks ) );
+			else
+				$rewrite_rules = array_merge( $this->add_rewrite_rules( $match, $query, $num_toks ), $this->page_rewrite_rules() );
+		}
+
+		return $rewrite_rules;
 	}
 
 	/**
@@ -357,78 +361,78 @@ class nggRewrite {
 	 * @return array
 	 */
 	function page_rewrite_rules() {
-        global $wp_rewrite;
- 
+		global $wp_rewrite;
+
 		$rewrite_rules = array();
 
 		if ( ! $wp_rewrite->use_verbose_page_rules ) {
-            
-            $rewrite_rules = $this->add_rewrite_rules( "(.+?)/", 'pagename=$matches[1]', 1 );
-    		return $rewrite_rules;
+
+			$rewrite_rules = $this->add_rewrite_rules( "(.+?)/", 'pagename=$matches[1]', 1 );
+			return $rewrite_rules;
 		}
 
 		$page_uris = $wp_rewrite->page_uri_index();
 		$uris = $page_uris[0];
 
 		if ( is_array( $uris ) ) {
-  
+
 			foreach ( $uris as $uri => $pagename ) {
-                $rewrite_rules = array_merge($rewrite_rules, $this->add_rewrite_rules( "($uri)/", 'pagename=$matches[1]', 1 ) );
+				$rewrite_rules = array_merge( $rewrite_rules, $this->add_rewrite_rules( "($uri)/", 'pagename=$matches[1]', 1 ) );
 			}
-                
+
 		}
 
 		return $rewrite_rules;
 	}
 
-    /**
-     * Build the final structure of the rewrite rules based on match/query
-     * 
-     * @since 1.8.3
-     * @param string $match
-     * @param string $query
-     * @param int $num_toks
-     * @return array
-     */
-    function add_rewrite_rules( $match, $query, $num_toks ) {
-        global $wp_rewrite;
-        
-        $rewrite_rules = array();
-            
-        foreach ( $this->ngg_rules as $regex => $new_query) {
-            
-            // first add your nextgen slug
-            $final_match = $match . $this->slug;
-           
-            //add regex parameter
-            $final_match .= $regex;
-            // check how often we found matches fields
-            $count = substr_count($new_query, '[matches]');
-            // we need to know how many tags before
-            $offset = $num_toks;
-            // build the query and count up the matches : tagname=$matches[x]
-            for ( $i = 0; $i < $count; $i++ ) {
-                $new_query = preg_replace('/\[matches\]/', '$matches[' . ++$offset . ']', $new_query, 1);
-            }
-            $final_query = $query . $new_query;
+	/**
+	 * Build the final structure of the rewrite rules based on match/query
+	 * 
+	 * @since 1.8.3
+	 * @param string $match
+	 * @param string $query
+	 * @param int $num_toks
+	 * @return array
+	 */
+	function add_rewrite_rules( $match, $query, $num_toks ) {
+		global $wp_rewrite;
 
-            //close the match and finalise the query
-            $final_match .= '?$';
-            $final_query = $this->index . '?' . $final_query;
+		$rewrite_rules = array();
 
-            $rewrite_rules = array_merge($rewrite_rules, array($final_match => $final_query));
+		foreach ( $this->ngg_rules as $regex => $new_query ) {
 
-        }
+			// first add your nextgen slug
+			$final_match = $match . $this->slug;
+
+			//add regex parameter
+			$final_match .= $regex;
+			// check how often we found matches fields
+			$count = substr_count( $new_query, '[matches]' );
+			// we need to know how many tags before
+			$offset = $num_toks;
+			// build the query and count up the matches : tagname=$matches[x]
+			for ( $i = 0; $i < $count; $i++ ) {
+				$new_query = preg_replace( '/\[matches\]/', '$matches[' . ++$offset . ']', $new_query, 1 );
+			}
+			$final_query = $query . $new_query;
+
+			//close the match and finalise the query
+			$final_match .= '?$';
+			$final_query = $this->index . '?' . $final_query;
+
+			$rewrite_rules = array_merge( $rewrite_rules, array( $final_match => $final_query ) );
+
+		}
 		return $rewrite_rules;
-    }
-	
+	}
+
 }  // of nggRewrite CLASS
 
-    global $nggRewrite;
+global $nggRewrite;
 
-    if ( class_exists('nggRewrite') ){
-        $nggRewrite = new nggRewrite();
-    }
+if ( class_exists( 'nggRewrite' ) ) {
+	$nggRewrite = new nggRewrite();
+}
 
 
 ?>

--- a/lib/shortcodes.php
+++ b/lib/shortcodes.php
@@ -9,422 +9,420 @@
 
 class NextGEN_shortcodes {
 
-	function __construct()
-	{
+	function __construct() {
 		//Long posts should require a higher limit, see http://core.trac.wordpress.org/ticket/8553
-		@ini_set('pcre.backtrack_limit', 500000);
+		@ini_set( 'pcre.backtrack_limit', 500000 );
 
-        // convert the old shortcode
-        add_filter('the_content', array(&$this, 'convert_shortcode'));
-		add_filter('loop_start',  array(&$this, 'reset_globals'));
+		// convert the old shortcode
+		add_filter( 'the_content', array(&$this, 'convert_shortcode' ) );
+		add_filter( 'loop_start', array(&$this, 'reset_globals' ) );
 
-        // do_shortcode on the_excerpt could causes several unwanted output. Uncomment it on your own risk
-        // add_filter('the_excerpt', array(&$this, 'convert_shortcode'));
-        // add_filter('the_excerpt', 'do_shortcode', 11);
+		// do_shortcode on the_excerpt could causes several unwanted output. Uncomment it on your own risk
+		// add_filter('the_excerpt', array(&$this, 'convert_shortcode'));
+		// add_filter('the_excerpt', 'do_shortcode', 11);
 
-        add_shortcode( 'singlepic', array(&$this, 'show_singlepic' ) );
-        add_shortcode( 'album', array(&$this, 'show_album' ) );
+		add_shortcode( 'singlepic', array(&$this, 'show_singlepic' ) );
+		add_shortcode( 'album', array(&$this, 'show_album' ) );
 		add_shortcode( 'nggalbum', array(&$this, 'show_album' ) );
-        add_shortcode( 'nggallery', array(&$this, 'show_gallery') );
-        add_shortcode( 'imagebrowser', array(&$this, 'show_imagebrowser' ) );
-        add_shortcode( 'slideshow', array(&$this, 'show_slideshow' ) );
-        add_shortcode( 'nggtags', array(&$this, 'show_tags' ) );
-        add_shortcode( 'thumb', array(&$this, 'show_thumbs' ) );
-        add_shortcode( 'random', array(&$this, 'show_random' ) );
-        add_shortcode( 'recent', array(&$this, 'show_recent' ) );
-        add_shortcode( 'tagcloud', array(&$this, 'show_tagcloud' ) );
+		add_shortcode( 'nggallery', array(&$this, 'show_gallery' ) );
+		add_shortcode( 'imagebrowser', array(&$this, 'show_imagebrowser' ) );
+		add_shortcode( 'slideshow', array(&$this, 'show_slideshow' ) );
+		add_shortcode( 'nggtags', array(&$this, 'show_tags' ) );
+		add_shortcode( 'thumb', array(&$this, 'show_thumbs' ) );
+		add_shortcode( 'random', array(&$this, 'show_random' ) );
+		add_shortcode( 'recent', array(&$this, 'show_recent' ) );
+		add_shortcode( 'tagcloud', array(&$this, 'show_tagcloud' ) );
 	}
 
-	function reset_globals()
-	{
-		unset($GLOBALS['subalbum']);
-		unset($GLOBALS['nggShowGallery']);
+	function reset_globals() {
+		unset( $GLOBALS['subalbum'] );
+		unset( $GLOBALS['nggShowGallery'] );
 	}
 
-     /**
-       * NextGEN_shortcodes::convert_shortcode()
-       * convert old shortcodes to the new WordPress core style
-       * [gallery=1]  ->> [nggallery id=1]
-       *
-       * @param string $content Content to search for shortcodes
-       * @return string Content with new shortcodes.
-       */
-    function convert_shortcode($content) {
-
-        $ngg_options = nggGallery::get_option('ngg_options');
-
-        if ( stristr( $content, '[singlepic' )) {
-            $search = "@\[singlepic=(\d+)(|,\d+|,)(|,\d+|,)(|,watermark|,web20|,)(|,right|,center|,left|,)\]@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    // remove the comma
-                    $match[2] = ltrim($match[2], ',');
-                    $match[3] = ltrim($match[3], ',');
-                    $match[4] = ltrim($match[4], ',');
-                    $match[5] = ltrim($match[5], ',');
-                    $replace = "[singlepic id=\"{$match[1]}\" w=\"{$match[2]}\" h=\"{$match[3]}\" mode=\"{$match[4]}\" float=\"{$match[5]}\" ]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        if ( stristr( $content, '[album' )) {
-            $search = "@(?:<p>)*\s*\[album\s*=\s*(\w+|^\+)(|,extend|,compact)\]\s*(?:</p>)*@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    // remove the comma
-                    $match[2] = ltrim($match[2],',');
-                    $replace = "[album id=\"{$match[1]}\" template=\"{$match[2]}\"]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        if ( stristr( $content, '[gallery' )) {
-            $search = "@(?:<p>)*\s*\[gallery\s*=\s*(\w+|^\+)\]\s*(?:</p>)*@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    $replace = "[nggallery id=\"{$match[1]}\"]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        if ( stristr( $content, '[imagebrowser' )) {
-            $search = "@(?:<p>)*\s*\[imagebrowser\s*=\s*(\w+|^\+)\]\s*(?:</p>)*@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    $replace = "[imagebrowser id=\"{$match[1]}\"]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        if ( stristr( $content, '[slideshow' )) {
-            $search = "@(?:<p>)*\s*\[slideshow\s*=\s*(\w+|^\+)(|,(\d+)|,)(|,(\d+))\]\s*(?:</p>)*@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    // remove the comma
-                    $match[3] = ltrim($match[3],',');
-                    $match[5] = ltrim($match[5],',');
-                    $replace = "[slideshow id=\"{$match[1]}\" w=\"{$match[3]}\" h=\"{$match[5]}\"]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        if ( stristr( $content, '[tags' )) {
-            $search = "@(?:<p>)*\s*\[tags\s*=\s*(.*?)\s*\]\s*(?:</p>)*@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    //$replace = "[nggtags gallery=\"{$match[1]}\"]";
-                    $replace = "[nggtags gallery=\"{$match[1]}\" template=\"{$match[2]}\"]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        if ( stristr( $content, '[albumtags' )) {
-            $search = "@(?:<p>)*\s*\[albumtags\s*=\s*(.*?)\s*\]\s*(?:</p>)*@i";
-            if (preg_match_all($search, $content, $matches, PREG_SET_ORDER)) {
-
-                foreach ($matches as $match) {
-                    $replace = "[nggtags album=\"{$match[1]}\"]";
-                    $content = str_replace ($match[0], $replace, $content);
-                }
-            }
-        }
-
-        // attach related images based on category or tags
-        if ($ngg_options['activateTags'])
-            $content .= nggShowRelatedImages();
-
-        return $content;
-    }
-
-    /**
-     * Function to show a single picture:
-     *
-     *     [singlepic id="10" float="none|left|right" width="" height="" mode="none|watermark|web20" link="url" "template="filename" /]
-     *
-     * where
-     *  - id is one picture id
-     *  - float is the CSS float property to apply to the thumbnail
-     *  - width is width of the single picture you want to show (original width if this parameter is missing)
-     *  - height is height of the single picture you want to show (original height if this parameter is missing)
-     *  - mode is one of none, watermark or web20 (transformation applied to the picture)
-     *  - link is optional and could link to a other url instead the full image
-     *  - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
-     *
-     * If the tag contains some text, this will be inserted as an additional caption to the picture too. Example:
-     *      [singlepic id="10"]This is an additional caption[/singlepic]
-     * This tag will show a picture with under it two HTML span elements containing respectively the alttext of the picture
-     * and the additional caption specified in the tag.
-     *
-     * @param array $atts
-     * @param string $caption text
-     * @return the content
-     */
-    function show_singlepic( $atts, $content = '' ) {
-
-        extract(shortcode_atts(array(
-            'id'        => 0,
-            'w'         => '',
-            'h'         => '',
-            'mode'      => '',
-            'float'     => '',
-            'link'      => '',
-            'template'  => ''
-        ), $atts ));
-
-        $out = nggSinglePicture($id, $w, $h, $mode, $float, $template, $content, $link);
-
-        return $out;
-    }
-
-    /**
-     * Function to show a collection of galleries:
-     *
-     * [album id="1,2,4,5,..." template="filename" gallery="filename" /]
-     * where
-     * - id of a album
-     * - template is a name for a album template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
-     * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
-     *
-     * @param array $atts
-     * @return the_content
-     */
-    function show_album( $atts ) {
-
-        extract(shortcode_atts(array(
-            'id'        => 0,
-            'template'  => 'extend',
-            'gallery'   => ''
-        ), $atts ));
-
-        $out = nggShowAlbum($id, $template, $gallery);
-
-        return $out;
-    }
-    /**
-     * Function to show a thumbnail or a set of thumbnails with shortcode of type:
-     *
-     * [gallery id="1,2,4,5,..." template="filename" images="number of images per page" /]
-     * where
-     * - id of a gallery
-     * - images is the number of images per page (optional), 0 will show all images
-     * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
-     *
-     * @param array $atts
-     * @return the_content
-     */
-    function show_gallery( $atts ) {
-
-        global $wpdb;
-
-        extract(shortcode_atts(array(
-            'id'        => 0,
-            'template'  => '',
-            'images'    => false
-        ), $atts ));
-
-        // backward compat for user which uses the name instead, still deprecated
-        if( !is_numeric($id) )
-            $id = $wpdb->get_var( $wpdb->prepare ("SELECT gid FROM $wpdb->nggallery WHERE name = '%s' ", $id) );
-
-        $out = nggShowGallery( $id, $template, $images );
-
-        return $out;
-    }
-
-    function show_imagebrowser( $atts ) {
-
-        global $wpdb;
-
-        extract(shortcode_atts(array(
-            'id'        => 0,
-            'template'  => ''
-        ), $atts ));
-
-        $out = nggShowImageBrowser($id, $template);
-
-        return $out;
-    }
-
-    /**
-     * Render a slideshow.
-     *
-     * @since 1.9.25 Don't use extract anymore. @see https://core.trac.wordpress.org/ticket/22400
-     * @param $atts array The shortcode attributes.
-     *
-     * @return string The output that will be displayed on the page.
-     */
-    function show_slideshow( $atts ) {
-
-        $data = shortcode_atts( array(
-            'id'        => 'random',
-            'w'         => null,
-            'h'         => null,
-            'dots'      => null
-        ), $atts );
-
-        array_map( 'esc_attr', $data );
-
-        if( isset($data['w']) || isset($data['h'])) {
-            $data['autodim'] = false;
-            $data['width'] = $data['w'];
-            $data['height']= $data['h'];
-        } else {
-            unset($data['w'],$data['h']);
-        }
-
-        if($data['dots'] == null) {
-            unset($data['dots']);
-        } else {
-            $data['nav_dots'] = $data['dots'];
-        }
-        try {
-            return nggShowSlideshow( $data['id'], $data );
-        } catch (NGG_Not_Found $e) {
-            return $e->getMessage();
-        }
-    }
-
-    /**
-     * nggtags shortcode implementation
-     * 20140120: Improved: template option.
-     * Reference: based on improvement of Tony Howden's code
-     * http://howden.net.au/thowden/2012/12/nextgen-gallery-wordpress-nggtags-template-caption-option/
-     * Included template to galleries and albums
-     * Included sorting mode: ASC/DESC/RAND
-     * @param $atts
-     * @return $out
-     */
-    function show_tags( $atts ) {
-
-        extract(shortcode_atts(array(
-            'gallery'       => '',
-            'album'         => '',
-            'template'      => '',
-            'sort'          => ''
-        ), $atts ));
-
-        //gallery/album contains tag list comma separated of terms to filtering out.
-        //Counterintuitive: I'd like something like tags='red,green' and then to specify album/gallery instead.
-        $modes = array ('ASC','DESC','RAND');
-
-        $sorting = strtoupper($sort);
-
-        if (!in_array(strtoupper($sorting), $modes)) {
-            $sorting = 'NOTSET';
-        }
-
-        if ( !empty($album) )
-            $out = nggShowAlbumTags  ($album, $template, $sorting);
-        else
-            $out = nggShowGalleryTags($gallery, $template, $sorting);
-        return $out;
-    }
-
-    /**
-     * Function to show a thumbnail or a set of thumbnails with shortcode of type:
-     *
-     * [thumb id="1,2,4,5,..." template="filename" /]
-     * where
-     * - id is one or more picture ids
-     * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
-     *
-     * @param array $atts
-     * @return the_content
-     */
-    function show_thumbs( $atts ) {
-
-        extract(shortcode_atts(array(
-            'id'        => '',
-            'template'  => ''
-        ), $atts));
-
-        // make an array out of the ids
-        $pids = explode( ',', $id );
-
-        // Some error checks
-        if ( count($pids) == 0 )
-            return __('[Pictures not found]','nggallery');
-
-        $picturelist = nggdb::find_images_in_list( $pids );
-
-        // show gallery
-        if ( is_array($picturelist) )
-            $out = nggCreateGallery($picturelist, false, $template);
-        return $out;
-    }
-
-    /**
-     * Function to show a gallery of random or the most recent images with shortcode of type:
-     *
-     * [random max="7" template="filename" id="2" /]
-     * [recent max="7" template="filename" id="3" mode="date" /]
-     * where
-     * - max is the maximum number of random or recent images to show
-     * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
-     * - id is the gallery id, if the recent/random pictures shall be taken from a specific gallery only
-     * - mode is either "id" (which takes the latest additions to the databse, default)
-     *               or "date" (which takes the latest pictures by EXIF date)
-     *               or "sort" (which takes the pictures by user sort order)
-     *
-     * @param array $atts
-     * @return the_content
-     */
-    function show_random( $atts ) {
-
-        extract(shortcode_atts(array(
-            'max'       => '',
-            'template'  => '',
-            'id'        => 0
-        ), $atts));
-
-        $out = nggShowRandomRecent('random', $max, $template, $id);
-
-        return $out;
-    }
-
-    function show_recent( $atts ) {
-
-        extract(shortcode_atts(array(
-            'max'       => '',
-            'template'  => '',
-            'id'        => 0,
-            'mode'      => 'id'
-        ), $atts));
-
-        $out = nggShowRandomRecent($mode, $max, $template, $id);
-
-        return $out;
-    }
-
-    /**
-     * Shortcode for the Image tag cloud
-     * Usage : [tagcloud template="filename" /]
-     *
-     * @param array $atts
-     * @return the content
-     */
-    function show_tagcloud( $atts ) {
-
-        extract(shortcode_atts(array(
-            'template'  => ''
-        ), $atts));
-
-        $out = nggTagCloud( '', $template );
-
-        return $out;
-    }
+	/**
+	 * NextGEN_shortcodes::convert_shortcode()
+	 * convert old shortcodes to the new WordPress core style
+	 * [gallery=1]  ->> [nggallery id=1]
+	 *
+	 * @param string $content Content to search for shortcodes
+	 * @return string Content with new shortcodes.
+	 */
+	static function convert_shortcode( $content ) {
+
+		$ngg_options = nggGallery::get_option( 'ngg_options' );
+
+		if ( stristr( $content, '[singlepic' ) ) {
+			$search = "@\[singlepic=(\d+)(|,\d+|,)(|,\d+|,)(|,watermark|,web20|,)(|,right|,center|,left|,)\]@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					// remove the comma
+					$match[2] = ltrim( $match[2], ',' );
+					$match[3] = ltrim( $match[3], ',' );
+					$match[4] = ltrim( $match[4], ',' );
+					$match[5] = ltrim( $match[5], ',' );
+					$replace = "[singlepic id=\"{$match[1]}\" w=\"{$match[2]}\" h=\"{$match[3]}\" mode=\"{$match[4]}\" float=\"{$match[5]}\" ]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		if ( stristr( $content, '[album' ) ) {
+			$search = "@(?:<p>)*\s*\[album\s*=\s*(\w+|^\+)(|,extend|,compact)\]\s*(?:</p>)*@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					// remove the comma
+					$match[2] = ltrim( $match[2], ',' );
+					$replace = "[album id=\"{$match[1]}\" template=\"{$match[2]}\"]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		if ( stristr( $content, '[gallery' ) ) {
+			$search = "@(?:<p>)*\s*\[gallery\s*=\s*(\w+|^\+)\]\s*(?:</p>)*@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					$replace = "[nggallery id=\"{$match[1]}\"]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		if ( stristr( $content, '[imagebrowser' ) ) {
+			$search = "@(?:<p>)*\s*\[imagebrowser\s*=\s*(\w+|^\+)\]\s*(?:</p>)*@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					$replace = "[imagebrowser id=\"{$match[1]}\"]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		if ( stristr( $content, '[slideshow' ) ) {
+			$search = "@(?:<p>)*\s*\[slideshow\s*=\s*(\w+|^\+)(|,(\d+)|,)(|,(\d+))\]\s*(?:</p>)*@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					// remove the comma
+					$match[3] = ltrim( $match[3], ',' );
+					$match[5] = ltrim( $match[5], ',' );
+					$replace = "[slideshow id=\"{$match[1]}\" w=\"{$match[3]}\" h=\"{$match[5]}\"]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		if ( stristr( $content, '[tags' ) ) {
+			$search = "@(?:<p>)*\s*\[tags\s*=\s*(.*?)\s*\]\s*(?:</p>)*@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					//$replace = "[nggtags gallery=\"{$match[1]}\"]";
+					$replace = "[nggtags gallery=\"{$match[1]}\" template=\"{$match[2]}\"]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		if ( stristr( $content, '[albumtags' ) ) {
+			$search = "@(?:<p>)*\s*\[albumtags\s*=\s*(.*?)\s*\]\s*(?:</p>)*@i";
+			if ( preg_match_all( $search, $content, $matches, PREG_SET_ORDER ) ) {
+
+				foreach ( $matches as $match ) {
+					$replace = "[nggtags album=\"{$match[1]}\"]";
+					$content = str_replace( $match[0], $replace, $content );
+				}
+			}
+		}
+
+		// attach related images based on category or tags
+		if ( $ngg_options['activateTags'] )
+			$content .= nggShowRelatedImages();
+
+		return $content;
+	}
+
+	/**
+	 * Function to show a single picture:
+	 *
+	 *     [singlepic id="10" float="none|left|right" width="" height="" mode="none|watermark|web20" link="url" "template="filename" /]
+	 *
+	 * where
+	 *  - id is one picture id
+	 *  - float is the CSS float property to apply to the thumbnail
+	 *  - width is width of the single picture you want to show (original width if this parameter is missing)
+	 *  - height is height of the single picture you want to show (original height if this parameter is missing)
+	 *  - mode is one of none, watermark or web20 (transformation applied to the picture)
+	 *  - link is optional and could link to a other url instead the full image
+	 *  - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
+	 *
+	 * If the tag contains some text, this will be inserted as an additional caption to the picture too. Example:
+	 *      [singlepic id="10"]This is an additional caption[/singlepic]
+	 * This tag will show a picture with under it two HTML span elements containing respectively the alttext of the picture
+	 * and the additional caption specified in the tag.
+	 *
+	 * @param array $atts
+	 * @param string $caption text
+	 * @return string the content
+	 */
+	function show_singlepic( $atts, $content = '' ) {
+
+		extract( shortcode_atts( array(
+			'id' => 0,
+			'w' => '',
+			'h' => '',
+			'mode' => '',
+			'float' => '',
+			'link' => '',
+			'template' => ''
+		), $atts ) );
+
+		$out = nggSinglePicture( $id, $w, $h, $mode, $float, $template, $content, $link );
+
+		return $out;
+	}
+
+	/**
+	 * Function to show a collection of galleries:
+	 *
+	 * [album id="1,2,4,5,..." template="filename" gallery="filename" /]
+	 * where
+	 * - id of a album
+	 * - template is a name for a album template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
+	 * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
+	 *
+	 * @param array $atts
+	 * @return string the content
+	 */
+	function show_album( $atts ) {
+
+		extract( shortcode_atts( array(
+			'id' => 0,
+			'template' => 'extend',
+			'gallery' => ''
+		), $atts ) );
+
+		$out = nggShowAlbum( $id, $template, $gallery );
+
+		return $out;
+	}
+	/**
+	 * Function to show a thumbnail or a set of thumbnails with shortcode of type:
+	 *
+	 * [gallery id="1,2,4,5,..." template="filename" images="number of images per page" /]
+	 * where
+	 * - id of a gallery
+	 * - images is the number of images per page (optional), 0 will show all images
+	 * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
+	 *
+	 * @param array $atts
+	 * @return string the content
+	 */
+	function show_gallery( $atts ) {
+
+		global $wpdb;
+
+		extract( shortcode_atts( array(
+			'id' => 0,
+			'template' => '',
+			'images' => false
+		), $atts ) );
+
+		// backward compat for user which uses the name instead, still deprecated
+		if ( ! is_numeric( $id ) )
+			$id = $wpdb->get_var( $wpdb->prepare( "SELECT gid FROM $wpdb->nggallery WHERE name = '%s' ", $id ) );
+
+		$out = nggShowGallery( $id, $template, $images );
+
+		return $out;
+	}
+
+	function show_imagebrowser( $atts ) {
+
+		global $wpdb;
+
+		extract( shortcode_atts( array(
+			'id' => 0,
+			'template' => ''
+		), $atts ) );
+
+		$out = nggShowImageBrowser( $id, $template );
+
+		return $out;
+	}
+
+	/**
+	 * Render a slideshow.
+	 *
+	 * @since 1.9.25 Don't use extract anymore. @see https://core.trac.wordpress.org/ticket/22400
+	 * @param $atts array The shortcode attributes.
+	 *
+	 * @return string The output that will be displayed on the page.
+	 */
+	function show_slideshow( $atts ) {
+
+		$data = shortcode_atts( array(
+			'id' => 'random',
+			'w' => null,
+			'h' => null,
+			'dots' => null
+		), $atts );
+
+		array_map( 'esc_attr', $data );
+
+		if ( isset( $data['w'] ) || isset( $data['h'] ) ) {
+			$data['autodim'] = false;
+			$data['width'] = $data['w'];
+			$data['height'] = $data['h'];
+		} else {
+			unset( $data['w'], $data['h'] );
+		}
+
+		if ( $data['dots'] == null ) {
+			unset( $data['dots'] );
+		} else {
+			$data['nav_dots'] = $data['dots'];
+		}
+		try {
+			return nggShowSlideshow( $data['id'], $data );
+		} catch (NGG_Not_Found $e) {
+			return $e->getMessage();
+		}
+	}
+
+	/**
+	 * nggtags shortcode implementation
+	 * 20140120: Improved: template option.
+	 * Reference: based on improvement of Tony Howden's code
+	 * http://howden.net.au/thowden/2012/12/nextgen-gallery-wordpress-nggtags-template-caption-option/
+	 * Included template to galleries and albums
+	 * Included sorting mode: ASC/DESC/RAND
+	 * @param $atts
+	 * @return $out
+	 */
+	function show_tags( $atts ) {
+
+		extract( shortcode_atts( array(
+			'gallery' => '',
+			'album' => '',
+			'template' => '',
+			'sort' => ''
+		), $atts ) );
+
+		//gallery/album contains tag list comma separated of terms to filtering out.
+		//Counterintuitive: I'd like something like tags='red,green' and then to specify album/gallery instead.
+		$modes = array( 'ASC', 'DESC', 'RAND' );
+
+		$sorting = strtoupper( $sort );
+
+		if ( ! in_array( strtoupper( $sorting ), $modes ) ) {
+			$sorting = 'NOTSET';
+		}
+
+		if ( ! empty( $album ) )
+			$out = nggShowAlbumTags( $album, $template, $sorting );
+		else
+			$out = nggShowGalleryTags( $gallery, $template, $sorting );
+		return $out;
+	}
+
+	/**
+	 * Function to show a thumbnail or a set of thumbnails with shortcode of type:
+	 *
+	 * [thumb id="1,2,4,5,..." template="filename" /]
+	 * where
+	 * - id is one or more picture ids
+	 * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
+	 *
+	 * @param array $atts
+	 * @return string the content
+	 */
+	function show_thumbs( $atts ) {
+
+		extract( shortcode_atts( array(
+			'id' => '',
+			'template' => ''
+		), $atts ) );
+
+		// make an array out of the ids
+		$pids = explode( ',', $id );
+
+		// Some error checks
+		if ( count( $pids ) == 0 )
+			return __( '[Pictures not found]', 'nggallery' );
+
+		$picturelist = nggdb::find_images_in_list( $pids );
+
+		// show gallery
+		if ( is_array( $picturelist ) )
+			$out = nggCreateGallery( $picturelist, false, $template );
+		return $out;
+	}
+
+	/**
+	 * Function to show a gallery of random or the most recent images with shortcode of type:
+	 *
+	 * [random max="7" template="filename" id="2" /]
+	 * [recent max="7" template="filename" id="3" mode="date" /]
+	 * where
+	 * - max is the maximum number of random or recent images to show
+	 * - template is a name for a gallery template, which is located in themefolder/nggallery or plugins/nextgen-gallery/view
+	 * - id is the gallery id, if the recent/random pictures shall be taken from a specific gallery only
+	 * - mode is either "id" (which takes the latest additions to the databse, default)
+	 *               or "date" (which takes the latest pictures by EXIF date)
+	 *               or "sort" (which takes the pictures by user sort order)
+	 *
+	 * @param array $atts
+	 * @return string the content
+	 */
+	function show_random( $atts ) {
+
+		extract( shortcode_atts( array(
+			'max' => '',
+			'template' => '',
+			'id' => 0
+		), $atts ) );
+
+		$out = nggShowRandomRecent( 'random', $max, $template, $id );
+
+		return $out;
+	}
+
+	function show_recent( $atts ) {
+
+		extract( shortcode_atts( array(
+			'max' => '',
+			'template' => '',
+			'id' => 0,
+			'mode' => 'id'
+		), $atts ) );
+
+		$out = nggShowRandomRecent( $mode, $max, $template, $id );
+
+		return $out;
+	}
+
+	/**
+	 * Shortcode for the Image tag cloud
+	 * Usage : [tagcloud template="filename" /]
+	 *
+	 * @param array $atts
+	 * @return string the content
+	 */
+	function show_tagcloud( $atts ) {
+
+		extract( shortcode_atts( array(
+			'template' => ''
+		), $atts ) );
+
+		$out = nggTagCloud( '', $template );
+
+		return $out;
+	}
 
 }
 

--- a/lib/sitemap.php
+++ b/lib/sitemap.php
@@ -1,129 +1,129 @@
 <?php
 /**
-* Main PHP Class for XML Image Sitemaps
-*
-* @author 		Alex Rabe
-* @version      1.0
-* @copyright 	Copyright 2011
-*
-*/
+ * Main PHP Class for XML Image Sitemaps
+ *
+ * @author 		Alex Rabe
+ * @version      1.0
+ * @copyright 	Copyright 2011
+ *
+ */
 class nggSitemaps {
 
-    var $images	= array();
+	var $images = array();
 
-    /**
-     * nggSitemaps::__construct()
-     *
-     * @return
-     */
-    function __construct() {
+	/**
+	 * nggSitemaps::__construct()
+	 *
+	 * @return
+	 */
+	function __construct() {
 
-        add_filter('wpseo_sitemap_urlimages', array( &$this, 'add_wpseo_xml_sitemap_images'), 10, 2);
+		add_filter( 'wpseo_sitemap_urlimages', array(&$this, 'add_wpseo_xml_sitemap_images' ), 10, 2 );
 
-    }
+	}
 
-    /**
-     * Filter support for WordPress SEO by Yoast 0.4.0 or higher ( http://wordpress.org/extend/plugins/wordpress-seo/ )
-     *
-     * @since Version 1.8.0
-     * @param array $images
-     * @param int $post ID
-     * @return array $image list of all founded images
-     */
-    function add_wpseo_xml_sitemap_images( $images, $post_id )  {
+	/**
+	 * Filter support for WordPress SEO by Yoast 0.4.0 or higher ( http://wordpress.org/extend/plugins/wordpress-seo/ )
+	 *
+	 * @since Version 1.8.0
+	 * @param array $images
+	 * @param int $post ID
+	 * @return array $image list of all founded images
+	 */
+	function add_wpseo_xml_sitemap_images( $images, $post_id ) {
 
-        $this->images = $images;
+		$this->images = $images;
 
-        // first get the content of the post/page
-        $p = get_post($post_id);
+		// first get the content of the post/page
+		$p = get_post( $post_id );
 
-        // Backward check for older images
-        $p->post_content = NextGEN_Shortcodes::convert_shortcode($p->post_content);
+		// Backward check for older images
+		$p->post_content = NextGEN_Shortcodes::convert_shortcode( $p->post_content );
 
-        // Don't process the images in the normal way
-  		remove_all_shortcodes();
+		// Don't process the images in the normal way
+		remove_all_shortcodes();
 
-        // We cannot parse at this point a album, just galleries & single images
-        add_shortcode( 'singlepic', array(&$this, 'add_images' ) );
-        add_shortcode( 'thumb', array(&$this, 'add_images' ) );
-        add_shortcode( 'nggallery', array(&$this, 'add_gallery') );
-        add_shortcode( 'imagebrowser', array(&$this, 'add_gallery' ) );
-        add_shortcode( 'slideshow', array(&$this, 'add_gallery' ) );
+		// We cannot parse at this point a album, just galleries & single images
+		add_shortcode( 'singlepic', array(&$this, 'add_images' ) );
+		add_shortcode( 'thumb', array(&$this, 'add_images' ) );
+		add_shortcode( 'nggallery', array(&$this, 'add_gallery' ) );
+		add_shortcode( 'imagebrowser', array(&$this, 'add_gallery' ) );
+		add_shortcode( 'slideshow', array(&$this, 'add_gallery' ) );
 
-        // Search now for shortcodes
-        do_shortcode( $p->post_content );
+		// Search now for shortcodes
+		do_shortcode( $p->post_content );
 
-        return $this->images;
-    }
+		return $this->images;
+	}
 
-    /**
-     * Parse the gallery/imagebrowser/slideshow shortcode and return all images into an array
-     *
-     * @param string $atts
-     * @return
-     */
-    function add_gallery( $atts ) {
+	/**
+	 * Parse the gallery/imagebrowser/slideshow shortcode and return all images into an array
+	 *
+	 * @param array $atts
+	 * @return
+	 */
+	function add_gallery( $atts ) {
 
-        global $wpdb,$nggdb;
+		global $wpdb, $nggdb;
 
-        extract(shortcode_atts(array(
-            'id'        => 0
-        ), $atts ));
+		extract( shortcode_atts( array(
+			'id' => 0
+		), $atts ) );
 
-        // backward compat for user which uses the name instead, still deprecated
-        if( !is_numeric($id) )
-            $id = $wpdb->get_var( $wpdb->prepare ("SELECT gid FROM $wpdb->nggallery WHERE name = '%s' ", $id) );
+		// backward compat for user which uses the name instead, still deprecated
+		if ( ! is_numeric( $id ) )
+			$id = $wpdb->get_var( $wpdb->prepare( "SELECT gid FROM $wpdb->nggallery WHERE name = '%s' ", $id ) );
 
-        //20140106:shouldn't call it statically when is not...
-        //$images = nggdb::get_gallery($id, 'pid', 'ASC', true, 1000);
-        $images = $nggdb->get_gallery($id, 'pid', 'ASC', true, 1000);
+		//20140106:shouldn't call it statically when is not...
+		//$images = nggdb::get_gallery($id, 'pid', 'ASC', true, 1000);
+		$images = $nggdb->get_gallery( $id, 'pid', 'ASC', true, 1000 );
 
-        foreach ($images as $image) {
-            $newimage = array();
-            $newimage['src']   = $newimage['sc'] = $image->imageURL;
-            if ( !empty($image->title) )
-                $newimage['title'] = $image->title;
-            if ( !empty($image->alttext) )
-                $newimage['alt']   = $image->alttext;
-            $this->images[] = $newimage;
-        }
+		foreach ( $images as $image ) {
+			$newimage = array();
+			$newimage['src'] = $newimage['sc'] = $image->imageURL;
+			if ( ! empty( $image->title ) )
+				$newimage['title'] = $image->title;
+			if ( ! empty( $image->alttext ) )
+				$newimage['alt'] = $image->alttext;
+			$this->images[] = $newimage;
+		}
 
-        return '';
-    }
+		return '';
+	}
 
-    /**
-     * Parse the single image shortcode and return all images into an array
-     *
-     * @param array $atts
-     * @return
-     */
-    function add_images( $atts ) {
+	/**
+	 * Parse the single image shortcode and return all images into an array
+	 *
+	 * @param array $atts
+	 * @return
+	 */
+	function add_images( $atts ) {
 
-        extract(shortcode_atts(array(
-            'id'        => 0
-        ), $atts ));
+		extract( shortcode_atts( array(
+			'id' => 0
+		), $atts ) );
 
-        // make an array out of the ids (for thumbs shortcode))
-        $pids = explode( ',', $id );
+		// make an array out of the ids (for thumbs shortcode))
+		$pids = explode( ',', $id );
 
-        // Some error checks
-        if ( count($pids) == 0 )
-            return;
+		// Some error checks
+		if ( count( $pids ) == 0 )
+			return;
 
-        $images = nggdb::find_images_in_list( $pids );
+		$images = nggdb::find_images_in_list( $pids );
 
-        foreach ($images as $image) {
-            $newimage = array();
-            $newimage['src']   = $newimage['sc'] = $image->imageURL;
-            if ( !empty($image->title) )
-                $newimage['title'] = $image->title;
-            if ( !empty($image->alttext) )
-                $newimage['alt']   = $image->alttext;
-            $this->images[] = $newimage;
-        }
+		foreach ( $images as $image ) {
+			$newimage = array();
+			$newimage['src'] = $newimage['sc'] = $image->imageURL;
+			if ( ! empty( $image->title ) )
+				$newimage['title'] = $image->title;
+			if ( ! empty( $image->alttext ) )
+				$newimage['alt'] = $image->alttext;
+			$this->images[] = $newimage;
+		}
 
-        return '';
-    }
+		return '';
+	}
 
 }
 $nggSitemaps = new nggSitemaps();

--- a/lib/swfobject.php
+++ b/lib/swfobject.php
@@ -1,197 +1,197 @@
 <?php
-if ( !class_exists('swfobject') ) :
-/**
- * swfobject - PHP class for creating dynamic content of SWFObject V2.1
- * 
- * @author Alex Rabe
- * @package NextGEN Gallery
- * @version 0.6
- * 
- * @access public
- * @example http://code.google.com/p/swfobject/
- */
-class swfobject {
+if ( ! class_exists( 'swfobject' ) ) :
 	/**
-     * id of the HTML element
-     *
-     * @var string
-     */
-    var $id;
-	/**
-     * specifies the width of your SWF
-     *
-     * @var string
-     * @private
-     */
-    var $width;
-	/**
-     * specifies the height of your SWF
-     *
-     * @var string
-     * @privat
-     */
-    var $height;
-	/**
-     * the javascript output
-     *
-     * @var string
-     */
-    var $js;
-	/**
-     * the replacemnt message
-     *
-     * @var string
-     */
-    var $message = 'The <a href="http://www.macromedia.com/go/getflashplayer">Flash Player</a> and <a href="http://www.mozilla.com/firefox/">a browser with Javascript support</a> are needed..';			
-	/**
-     * the classname for the div element
-     *
-     * @var string
-     */
-    var $classname = 'swfobject';			
-	/**
-     * array of flashvars
-     *
-     * @var array
-     */
-    var $flashvars;
-    /**
-     * array of nested object element params
-     *
-     * @var array
-     */
-    var $params;
-    /**
-     * array of object's attributest
-     *
-     * @var array
-     */
-    var $attributes;
-
-	/**
-	 * swfobject::swfobject()
+	 * swfobject - PHP class for creating dynamic content of SWFObject V2.1
 	 * 
-	 * @param string $swfUrl (required) specifies the URL of your SWF
-	 * @param string $id (required) specifies the id of the HTML element (containing your alternative content) you would like to have replaced by your Flash content
-	 * @param string $width (required) specifies the width of your SWF
-	 * @param string $height (required) specifies the height of your SWF
-	 * @param string $version (required) specifies the Flash player version your SWF is published for (format is: "major.minor.release")
-	 * @param string $expressInstallSwfurl (optional) specifies the URL of your express install SWF and activates Adobe express install
-	 * @param array $flashvars (optional) specifies your flashvars with name:value pairs
-	 * @param array $params (optional) specifies your nested object element params with name:value pair
-	 * @param array $attributes (optional) specifies your object's attributes with name:value pairs
-	 * @return string the content
+	 * @author Alex Rabe
+	 * @package NextGEN Gallery
+	 * @version 0.6
+	 * 
+	 * @access public
+	 * @example http://code.google.com/p/swfobject/
 	 */
-	function swfobject( $swfUrl, $id, $width, $height, $version, $expressInstallSwfurl = false, $flashvars = false, $params = false, $attributes = false ) {
-	
-		global $swfCounter;
-		
-		// look for a other swfobject instance
-		if ( !isset($swfCounter) )
-			$swfCounter = 1;
-		
-		$this->id = $id . '_' . $swfCounter;
-		$this->width = $width;
-		$this->height = $height;		
-		
-		$this->flashvars  = ( is_array($flashvars) )  ? $flashvars : array();
-		$this->params     = ( is_array($params) )     ? $params : array();
-		$this->attributes = ( is_array($attributes) ) ? $attributes : array();
+	class swfobject {
+		/**
+		 * id of the HTML element
+		 *
+		 * @var string
+		 */
+		var $id;
+		/**
+		 * specifies the width of your SWF
+		 *
+		 * @var string
+		 * @private
+		 */
+		var $width;
+		/**
+		 * specifies the height of your SWF
+		 *
+		 * @var string
+		 * @privat
+		 */
+		var $height;
+		/**
+		 * the javascript output
+		 *
+		 * @var string
+		 */
+		var $js;
+		/**
+		 * the replacemnt message
+		 *
+		 * @var string
+		 */
+		var $message = 'The <a href="http://www.macromedia.com/go/getflashplayer">Flash Player</a> and <a href="http://www.mozilla.com/firefox/">a browser with Javascript support</a> are needed..';
+		/**
+		 * the classname for the div element
+		 *
+		 * @var string
+		 */
+		var $classname = 'swfobject';
+		/**
+		 * array of flashvars
+		 *
+		 * @var array
+		 */
+		var $flashvars;
+		/**
+		 * array of nested object element params
+		 *
+		 * @var array
+		 */
+		var $params;
+		/**
+		 * array of object's attributest
+		 *
+		 * @var array
+		 */
+		var $attributes;
 
-		$this->embedSWF = 'swfobject.embedSWF("'. $swfUrl .'", "'. $this->id .'", "'. $width .'", "'. $height .'", "'. $version .'", '. $expressInstallSwfurl .', this.flashvars, this.params , this.attr );' . "\n";
-	}
-	
-	function output () {
-		
-		global $swfCounter;
-		
-		// count up if we have more than one swfobject
-		$swfCounter++;
-		
-		$out  = "\n" . '<div class="'. $this->classname .'" id="'. $this->id  .'" style="width:'.$this->width .'px; height:'. $this->height .'px;">';
-		$out .= "\n" . $this->message;
-		$out .= "\n" . '</div>';
-		
-		return $out;
-	}
-	
-	function javascript () {
+		/**
+		 * swfobject::swfobject()
+		 * 
+		 * @param string $swfUrl (required) specifies the URL of your SWF
+		 * @param string $id (required) specifies the id of the HTML element (containing your alternative content) you would like to have replaced by your Flash content
+		 * @param string $width (required) specifies the width of your SWF
+		 * @param string $height (required) specifies the height of your SWF
+		 * @param string $version (required) specifies the Flash player version your SWF is published for (format is: "major.minor.release")
+		 * @param string $expressInstallSwfurl (optional) specifies the URL of your express install SWF and activates Adobe express install
+		 * @param array $flashvars (optional) specifies your flashvars with name:value pairs
+		 * @param array $params (optional) specifies your nested object element params with name:value pair
+		 * @param array $attributes (optional) specifies your object's attributes with name:value pairs
+		 * @return string the content
+		 */
+		function __construct( $swfUrl, $id, $width, $height, $version, $expressInstallSwfurl = false, $flashvars = false, $params = false, $attributes = false ) {
 
-		//Build javascript
-		$this->js  = "\nvar " . $this->id  . " = {\n";
-		$this->js .= $this->add_js_parameters('params', $this->params) . ",\n";
-		$this->js .= $this->add_js_parameters('flashvars', $this->flashvars) . ",\n";
-		$this->js .= $this->add_js_parameters('attr', $this->attributes) . ",\n";
-		$this->js .= "\tstart : function() {" . "\n\t\t";
-		$this->js .= $this->embedSWF;
-		$this->js .= "\t}\n}\n";
-		$this->js .= $this->id  . '.start();';
-	
-		return $this->js;
-	}
-	
-	function add_flashvars ( $key, $value, $default = '', $type = '', $prefix = '' ) {
+			global $swfCounter;
 
-		if ( is_bool( $value ) )
-			$value = ( $value ) ? 'true' : 'false';
-		elseif ( $type == 'bool' )
-			$value = ( $value == '1' ) ? 'true' : 'false';
-		
-		// do not add the variable if we hit the default setting 	
-		if ( $value == $default )	
-			return;
-			
-		$this->flashvars[$key] = $prefix . $value;
-		return;
-	}
+			// look for a other swfobject instance
+			if ( ! isset ( $swfCounter ) )
+				$swfCounter = 1;
 
-	function add_params ( $key, $value, $default = '', $type = '', $prefix = '' ) {
+			$this->id = $id . '_' . $swfCounter;
+			$this->width = $width;
+			$this->height = $height;
 
-		if ( is_bool( $value ) )
-			$value = ( $value ) ? 'true' : 'false';
-		elseif ( $type == 'bool' )
-			$value = ( $value == '1' ) ? 'true' : 'false';
-		
-		// do not add the variable if we hit the default setting 	
-		if ( $value == $default )	
-			return;
-			
-		$this->params[$key] = $prefix . $value;
-		return;
-	}
+			$this->flashvars = ( is_array( $flashvars ) ) ? $flashvars : array();
+			$this->params = ( is_array( $params ) ) ? $params : array();
+			$this->attributes = ( is_array( $attributes ) ) ? $attributes : array();
 
-	function add_attributes ( $key, $value, $default = '', $type = '', $prefix = '' ) {
-
-		if ( is_bool( $value ) )
-			$value = ( $value ) ? 'true' : 'false';
-		elseif ( $type == 'bool' )
-			$value = ( $value == '1' ) ? 'true' : 'false';
-		
-		// do not add the variable if we hit the default setting 	
-		if ( $value == $default )	
-			return;
-		
-		$this->attributes[$key] = $prefix . $value;
-		return;
-	}
-	
-	function add_js_parameters( $name, $params ) {
-		$list = '';
-		if ( is_array($params) ) {
-			foreach ($params as $key => $value) {
-				if  ( !empty($list) )
-					$list .= ",";
-				if (false === strrpos($key, '.') )		
-					$list .= "\n\t\t" . $key . ' : ' . '"' . $value .'"';
-				else
-					$list .= "\n\t\t'" . $key . '\' : ' . '"' . $value .'"';	
-			}
+			$this->embedSWF = 'swfobject.embedSWF("' . $swfUrl . '", "' . $this->id . '", "' . $width . '", "' . $height . '", "' . $version . '", ' . $expressInstallSwfurl . ', this.flashvars, this.params , this.attr );' . "\n";
 		}
-		$js = "\t" . $name . ' : {' . $list . '}';		
-		return $js;		
+
+		function output() {
+
+			global $swfCounter;
+
+			// count up if we have more than one swfobject
+			$swfCounter++;
+
+			$out = "\n" . '<div class="' . $this->classname . '" id="' . $this->id . '" style="width:' . $this->width . 'px; height:' . $this->height . 'px;">';
+			$out .= "\n" . $this->message;
+			$out .= "\n" . '</div>';
+
+			return $out;
+		}
+
+		function javascript() {
+
+			//Build javascript
+			$this->js = "\nvar " . $this->id . " = {\n";
+			$this->js .= $this->add_js_parameters( 'params', $this->params ) . ",\n";
+			$this->js .= $this->add_js_parameters( 'flashvars', $this->flashvars ) . ",\n";
+			$this->js .= $this->add_js_parameters( 'attr', $this->attributes ) . ",\n";
+			$this->js .= "\tstart : function() {" . "\n\t\t";
+			$this->js .= $this->embedSWF;
+			$this->js .= "\t}\n}\n";
+			$this->js .= $this->id . '.start();';
+
+			return $this->js;
+		}
+
+		function add_flashvars( $key, $value, $default = '', $type = '', $prefix = '' ) {
+
+			if ( is_bool( $value ) )
+				$value = ( $value ) ? 'true' : 'false';
+			elseif ( $type == 'bool' )
+				$value = ( $value == '1' ) ? 'true' : 'false';
+
+			// do not add the variable if we hit the default setting 	
+			if ( $value == $default )
+				return;
+
+			$this->flashvars[ $key ] = $prefix . $value;
+			return;
+		}
+
+		function add_params( $key, $value, $default = '', $type = '', $prefix = '' ) {
+
+			if ( is_bool( $value ) )
+				$value = ( $value ) ? 'true' : 'false';
+			elseif ( $type == 'bool' )
+				$value = ( $value == '1' ) ? 'true' : 'false';
+
+			// do not add the variable if we hit the default setting 	
+			if ( $value == $default )
+				return;
+
+			$this->params[ $key ] = $prefix . $value;
+			return;
+		}
+
+		function add_attributes( $key, $value, $default = '', $type = '', $prefix = '' ) {
+
+			if ( is_bool( $value ) )
+				$value = ( $value ) ? 'true' : 'false';
+			elseif ( $type == 'bool' )
+				$value = ( $value == '1' ) ? 'true' : 'false';
+
+			// do not add the variable if we hit the default setting 	
+			if ( $value == $default )
+				return;
+
+			$this->attributes[ $key ] = $prefix . $value;
+			return;
+		}
+
+		function add_js_parameters( $name, $params ) {
+			$list = '';
+			if ( is_array( $params ) ) {
+				foreach ( $params as $key => $value ) {
+					if ( ! empty ( $list ) )
+						$list .= ",";
+					if ( false === strrpos( $key, '.' ) )
+						$list .= "\n\t\t" . $key . ' : ' . '"' . $value . '"';
+					else
+						$list .= "\n\t\t'" . $key . '\' : ' . '"' . $value . '"';
+				}
+			}
+			$js = "\t" . $name . ' : {' . $list . '}';
+			return $js;
+		}
+
 	}
-	
-}
 endif;
 
 ?>

--- a/lib/xmlrpc.php
+++ b/lib/xmlrpc.php
@@ -6,7 +6,11 @@
  * @author Alex Rabe
  *
  */
-class nggXMLRPC{
+class nggXMLRPC {
+
+	private IXR_Error $error = new IXR_Error( 500, __( 'Internal Server Error' ) );
+
+	private IXR_Error $wrongUsernamePassword = new IXR_Error( 401, __( 'Wrong username or password' ) );
 
 	/**
 	 * Init the methods for the XMLRPC hook
@@ -14,30 +18,30 @@ class nggXMLRPC{
 	 */
 	function __construct() {
 
-		add_filter('xmlrpc_methods', array(&$this, 'add_methods') );
+		add_filter( 'xmlrpc_methods', array(&$this, 'add_methods' ) );
 	}
 
-	function add_methods($methods) {
+	function add_methods( $methods ) {
 
-		$methods['ngg.installed'] = array(&$this, 'nggInstalled');
-        // Image methods
-	    $methods['ngg.getImage'] = array(&$this, 'getImage');
-	    $methods['ngg.getImages'] = array(&$this, 'getImages');
-	    $methods['ngg.uploadImage'] = array(&$this, 'uploadImage');
-        $methods['ngg.editImage'] = array(&$this, 'editImage');
-        $methods['ngg.deleteImage'] = array(&$this, 'deleteImage');
-        // Gallery methods
-	    $methods['ngg.getGallery'] = array(&$this, 'getGallery');
-	    $methods['ngg.getGalleries'] = array(&$this, 'getGalleries');
-	    $methods['ngg.newGallery'] = array(&$this, 'newGallery');
-        $methods['ngg.editGallery'] = array(&$this, 'editGallery');
-        $methods['ngg.deleteGallery'] = array(&$this, 'deleteGallery');
-        // Album methods
-	    $methods['ngg.getAlbum'] = array(&$this, 'getAlbum');
-   	    $methods['ngg.getAlbums'] = array(&$this, 'getAlbums');
-        $methods['ngg.newAlbum'] = array(&$this, 'newAlbum');
-	    $methods['ngg.editAlbum'] = array(&$this, 'editAlbum');
-        $methods['ngg.deleteAlbum'] = array(&$this, 'deleteAlbum');
+		$methods['ngg.installed'] = array(&$this, 'nggInstalled' );
+		// Image methods
+		$methods['ngg.getImage'] = array(&$this, 'getImage' );
+		$methods['ngg.getImages'] = array(&$this, 'getImages' );
+		$methods['ngg.uploadImage'] = array(&$this, 'uploadImage' );
+		$methods['ngg.editImage'] = array(&$this, 'editImage' );
+		$methods['ngg.deleteImage'] = array(&$this, 'deleteImage' );
+		// Gallery methods
+		$methods['ngg.getGallery'] = array(&$this, 'getGallery' );
+		$methods['ngg.getGalleries'] = array(&$this, 'getGalleries' );
+		$methods['ngg.newGallery'] = array(&$this, 'newGallery' );
+		$methods['ngg.editGallery'] = array(&$this, 'editGallery' );
+		$methods['ngg.deleteGallery'] = array(&$this, 'deleteGallery' );
+		// Album methods
+		$methods['ngg.getAlbum'] = array(&$this, 'getAlbum' );
+		$methods['ngg.getAlbums'] = array(&$this, 'getAlbums' );
+		$methods['ngg.newAlbum'] = array(&$this, 'newAlbum' );
+		$methods['ngg.editAlbum'] = array(&$this, 'editAlbum' );
+		$methods['ngg.deleteAlbum'] = array(&$this, 'deleteAlbum' );
 
 		return $methods;
 	}
@@ -45,19 +49,19 @@ class nggXMLRPC{
 	/**
 	 * Check if it's an csv string, then serialize it.
 	 *
-     * @since 1.9.2
+	 * @since 1.9.2
 	 * @param string $data
-	 * @return serialized string
+	 * @return string serialized csv
 	 */
 	function is_serialized( $data ) {
 
-        // if it isn't a string, we don't serialize it.
-        if ( ! is_string( $data ) )
-            return false;
+		// if it isn't a string, we don't serialize it.
+		if ( ! is_string( $data ) )
+			return false;
 
-        if ($data && !strpos( $data , '{')) {
-        	$items = explode(',', $data);
-        	return serialize($items);
+		if ( $data && ! strpos( $data, '{' ) ) {
+			$items = explode( ',', $data );
+			return serialize( $items );
 		}
 
 		return $data;
@@ -69,9 +73,9 @@ class nggXMLRPC{
 	 * @since 1.4
 	 *
 	 * @param none
-	 * @return string version number
+	 * @return array version number
 	 */
-	function nggInstalled($args) {
+	function nggInstalled( $args ) {
 		global $ngg;
 		return array( 'version' => $ngg->version );
 	}
@@ -83,22 +87,22 @@ class nggXMLRPC{
 	 *
 	 * @param string $username User's username.
 	 * @param string $password User's password.
-	 * @return mixed WP_User object if authentication passed, false otherwise
+	 * @return WP_Error|WP_User|bool WP_User object if authentication passed, false otherwise
 	 */
-	function login($username, $password) {
+	function login( $username, $password ) {
 		global $wp_version;
 
-		if (version_compare($wp_version,"3.5","<")) {
-			if ( !get_option( 'enable_xmlrpc' ) ) {
-				$this->error = new IXR_Error( 405, sprintf( __('XML-RPC services are disabled on this blog.  An admin user can enable them at %s'),  admin_url('options-writing.php') ) );
+		if ( version_compare( $wp_version, "3.5", "<" ) ) {
+			if ( ! get_option( 'enable_xmlrpc' ) ) {
+				$this->error = new IXR_Error( 405, sprintf( __( 'XML-RPC services are disabled on this blog.  An admin user can enable them at %s' ), admin_url( 'options-writing.php' ) ) );
 				return false;
 			}
 		}
 
-        $user = wp_authenticate($username, $password);
+		$user = wp_authenticate( $username, $password );
 
-		if (is_wp_error($user)) {
-			$this->error = new IXR_Error(403, __('Bad login/pass combination.'));
+		if ( is_wp_error( $user ) ) {
+			$this->error = new IXR_Error( 403, __( 'Bad login/pass combination.' ) );
 			return false;
 		}
 
@@ -124,49 +128,48 @@ class nggXMLRPC{
 	 *	          o bool overwrite (optional)
 	 *			  o int gallery
 	 *			  o int image_id  (optional)
-	 * @return array with image meta data
+	 * @return array|IXR_Error with image meta data
 	 */
-	function uploadImage($args) {
+	function uploadImage( $args ) {
 		global $wpdb;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 		require_once ( 'meta.php' );			// meta data import
 
-		$blog_ID	= (int) $args[0];
-		$username	= $wpdb->escape($args[1]);
-		$password	= $wpdb->escape($args[2]);
-		$data		= $args[3];
+		$blog_ID = (int) $args[0];
+		$username = esc_sql( $args[1] );
+		$password = esc_sql( $args[2] );
+		$data = $args[3];
 
 		$name = $data['name'];
 		$type = $data['type'];
 		$bits = $data['bits'];
 
 		// gallery & image id
-		$gid  	= (int) $data['gallery'];  // required field
-		$pid  	= (int) $data['image_id']; // optional but more foolproof of overwrite
-		$image	= false; // container for the image object
+		$gid = (int) $data['gallery'];  // required field
+		$pid = (int) $data['image_id']; // optional but more foolproof of overwrite
+		$image = false; // container for the image object
 
-		error_log('O', '(NGG) Received '.strlen($bits).' bytes');
+		error_log( 'O', '(NGG) Received ' . strlen( $bits ) . ' bytes' );
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) ) {
+			return $this->wrongUsernamePassword;
+		}
 
 		// Check if you have the correct capability for upload
-		if ( !current_user_can('NextGEN Upload images') ) {
-			error_log('O', '(NGG) User does not have upload_files capability');
-			$this->error = new IXR_Error(401, __('You are not allowed to upload files to this site.'));
-			return $this->error;
+		if ( ! current_user_can( 'NextGEN Upload images' ) ) {
+			error_log( 'O', '(NGG) User does not have upload_files capability' );
+			return new IXR_Error( 401, __( 'You are not allowed to upload files to this site.' ) );
 		}
 
 		// Look for the gallery , could we find it ?
-		if ( !$gallery = nggdb::find_gallery($gid) )
-			return new IXR_Error(404, __('Could not find gallery ' . $gid ));
+		if ( ! $gallery = nggdb::find_gallery( $gid ) )
+			return new IXR_Error( 404, __( 'Could not find gallery ' . $gid ) );
 
 		// Now check if you have the correct capability for this gallery
-		if ( !nggAdmin::can_manage_this_gallery($gallery->author) ) {
-			error_log('O', '(NGG) User does not have upload_files capability');
-			$this->error = new IXR_Error(401, __('You are not allowed to upload files to this gallery.'));
-			return $this->error;
+		if ( ! nggAdmin::can_manage_this_gallery( $gallery->author ) ) {
+			error_log( 'O', '(NGG) User does not have upload_files capability' );
+			return new IXR_Error( 401, __( 'You are not allowed to upload files to this gallery.' ) );
 		}
 
 		//clean filename and extract extension
@@ -174,40 +177,39 @@ class nggXMLRPC{
 		$name = $filepart['basename'];
 
 		// check for allowed extension and if it's an image file
-		$ext = array('jpg', 'png', 'gif');
-		if ( !in_array($filepart['extension'], $ext) ){
-			error_log('O', '(NGG) Not allowed file type');
-			$this->error = new IXR_Error(401, __('This is no valid image file.','nggallery'));
-			return $this->error;
+		$ext = array( 'jpg', 'png', 'gif' );
+		if ( ! in_array( $filepart['extension'], $ext ) ) {
+			error_log( 'O', '(NGG) Not allowed file type' );
+			return new IXR_Error( 401, __( 'This is no valid image file.', 'nggallery' ) );
 		}
 
 		// in the case you would overwrite the image, let's delete the old one first
-		if(!empty($data["overwrite"]) && ($data["overwrite"] == true)) {
+		if ( ! empty( $data["overwrite"] ) && ( $data["overwrite"] == true ) ) {
 
 			// search for the image based on the filename, if it's not already provided
-			if ($pid == 0)
-				$pid = $wpdb->get_col(" SELECT pid FROM {$wpdb->nggpictures} WHERE filename = '{$name}' AND galleryid = '{$gid}' ");
+			if ( $pid == 0 )
+				$pid = $wpdb->get_col( " SELECT pid FROM {$wpdb->nggpictures} WHERE filename = '{$name}' AND galleryid = '{$gid}' " );
 
-			if ( !$image = nggdb::find_image( $pid ) )
-				return new IXR_Error(404, __('Could not find image id ' . $pid ));
+			if ( ! $image = nggdb::find_image( $pid ) )
+				return new IXR_Error( 404, __( 'Could not find image id ' . $pid ) );
 
 			// sync the gallery<->image parameter, otherwise we may copy it to the wrong gallery
 			$gallery = $image;
 
 			// delete now the image
-			if ( !@unlink( $image->imagePath ) ) {
-				$errorString = sprintf(__('Failed to delete image %1$s ','nggallery'), $image->imagePath);
-				error_log('O', '(NGG) ' . $errorString);
-				return new IXR_Error(500, $errorString);
+			if ( ! @unlink( $image->imagePath ) ) {
+				$errorString = sprintf( __( 'Failed to delete image %1$s ', 'nggallery' ), $image->imagePath );
+				error_log( 'O', '(NGG) ' . $errorString );
+				return new IXR_Error( 500, $errorString );
 			}
 		}
 
 		// upload routine from wp core, load first the image to the upload folder, $upload['file'] contain the path
-		$upload = wp_upload_bits($name, $type, $bits);
-		if ( ! empty($upload['error']) ) {
-			$errorString = sprintf(__('Could not write file %1$s (%2$s)'), $name, $upload['error']);
-			error_log('O', '(NGG) ' . $errorString);
-			return new IXR_Error(500, $errorString);
+		$upload = wp_upload_bits( $name, $type, $bits );
+		if ( ! empty( $upload['error'] ) ) {
+			$errorString = sprintf( __( 'Could not write file %1$s (%2$s)' ), $name, $upload['error'] );
+			error_log( 'O', '(NGG) ' . $errorString );
+			return new IXR_Error( 500, $errorString );
 		}
 
 		// this is the dir to the gallery
@@ -215,25 +217,25 @@ class nggXMLRPC{
 
 		// check if the filename already exist, if not add a counter index
 		$filename = wp_unique_filename( $path, $name );
-		$destination = $path . '/'. $filename;
+		$destination = $path . '/' . $filename;
 
 		// Move files to gallery folder
-		if ( !@rename($upload['file'], $destination ) ) {
-			$errorString = sprintf(__('Failed to move image %1$s to %2$s','nggallery'), '<strong>' . $upload['file'] . '</strong>', $destination);
-			error_log('O', '(NGG) ' . $errorString);
-			return new IXR_Error(500, $errorString);
+		if ( ! @rename( $upload['file'], $destination ) ) {
+			$errorString = sprintf( __( 'Failed to move image %1$s to %2$s', 'nggallery' ), '<strong>' . $upload['file'] . '</strong>', $destination );
+			error_log( 'O', '(NGG) ' . $errorString );
+			return new IXR_Error( 500, $errorString );
 		}
 
 		//add to database if it's a new image
-		if(empty($data["overwrite"]) || ($data["overwrite"] == false)) {
+		if ( empty( $data["overwrite"] ) || ( $data["overwrite"] == false ) ) {
 			$pid_array = nggAdmin::add_Images( $gallery->gid, array( $filename ) );
 			// the first element is our new image id
-			if (count($pid_array) == 1)
+			if ( count( $pid_array ) == 1 )
 				$pid = $pid_array[0];
 		}
 
 		//get all information about the image, in the case it's a new one
-		if (!$image)
+		if ( ! $image )
 			$image = nggdb::find_image( $pid );
 
 		// create again the thumbnail, should return a '1'
@@ -254,36 +256,37 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *	    	- int image_id
-	 * @return true
+	 * @return IXR_Error|true
 	 */
-	function deleteImage($args) {
+	function deleteImage( $args ) {
 
 		global $nggdb, $ngg;
 
-        require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-        $id    	    = (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
+		;
 
-		if ( !$image = nggdb::find_image($id) )
-			return(new IXR_Error(404, __("Invalid image ID")));
+		if ( ! $image = nggdb::find_image( $id ) )
+			return ( new IXR_Error( 404, __( "Invalid image ID" ) ) );
 
-		if ( !current_user_can( 'NextGEN Manage gallery' ) && !nggAdmin::can_manage_this_gallery($image->author) )
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) && ! nggAdmin::can_manage_this_gallery( $image->author ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to edit this image' ) );
 
-		if ($ngg->options['deleteImg']) {
-            @unlink($image->imagePath);
-            @unlink($image->thumbPath);
-            @unlink($image->imagePath . "_backup" );
-        }
+		if ( $ngg->options['deleteImg'] ) {
+			@unlink( $image->imagePath );
+			@unlink( $image->thumbPath );
+			@unlink( $image->imagePath . "_backup" );
+		}
 
-        nggdb::delete_image ( $id );
+		nggdb::delete_image( $id );
 
 		return true;
 
@@ -303,37 +306,38 @@ class nggXMLRPC{
 	 *	    	- string alt/title text
 	 *	    	- string description
 	 *	    	- int exclude from gallery (0 or 1)
-	 * @return true if success
+	 * @return IXR_Error|true if success
 	 */
-	function editImage($args) {
+	function editImage( $args ) {
 
 		global $ngg;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$id      	= (int) $args[3];
-        $alttext    = $args[4];
-        $description= $args[5];
-        $exclude    = (int) $args[6];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
+		$alttext = $args[4];
+		$description = $args[5];
+		$exclude = (int) $args[6];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
+		;
 
-		if ( !$image = nggdb::find_image($id)  )
-			return(new IXR_Error(404, __( 'Invalid image ID' )));
+		if ( ! $image = nggdb::find_image( $id ) )
+			return ( new IXR_Error( 404, __( 'Invalid image ID' ) ) );
 
-        if ( !current_user_can( 'NextGEN Manage gallery' ) && !nggAdmin::can_manage_this_gallery($image->author) )
-            return new IXR_Error( 401, __( 'Sorry, you must be able to edit this image' ) );
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) && ! nggAdmin::can_manage_this_gallery( $image->author ) )
+			return new IXR_Error( 401, __( 'Sorry, you must be able to edit this image' ) );
 
-		if ( !empty( $id ) )
-			$result = nggdb::update_image($id, false, false, $description, $alttext, $exclude);
+		if ( ! empty( $id ) )
+			$result = nggdb::update_image( $id, false, false, $description, $alttext, $exclude );
 
-		if ( !$result )
-			return new IXR_Error(500, __('Sorry, could not update the image'));
+		if ( ! $result )
+			return new IXR_Error( 500, __( 'Sorry, could not update the image' ) );
 
 		return true;
 
@@ -350,34 +354,35 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *	    	- string new gallery name
-	 * @return int with new gallery ID
+	 * @return IXR_Error|int with new gallery ID
 	 */
-	function newGallery($args) {
+	function newGallery( $args ) {
 
 		global $ngg;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$name   	= $args[3];
-		$id 		= false;
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$name = $args[3];
+		$id = false;
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
+		;
 
-		if( !current_user_can( 'NextGEN Manage gallery' ) )
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage galleries' ) );
 
-		if ( !empty( $name ) )
-			$id = nggAdmin::create_gallery($name, $ngg->options['gallerypath'], false);
+		if ( ! empty( $name ) )
+			$id = nggAdmin::create_gallery( $name, $ngg->options['gallerypath'], false );
 
-		if ( !$id )
-			return new IXR_Error(500, __('Sorry, could not create the gallery'));
+		if ( ! $id )
+			return new IXR_Error( 500, __( 'Sorry, could not create the gallery' ) );
 
-		return($id);
+		return ( $id );
 
 	}
 
@@ -395,39 +400,39 @@ class nggXMLRPC{
 	 *	    	- string gallery name
 	 *	    	- string title
 	 *	    	- string description
-     *          - int ID of the preview picture
-	 * @return true if success
+	 *          - int ID of the preview picture
+	 * @return IXR_Error|true if success
 	 */
-	function editGallery($args) {
+	function editGallery( $args ) {
 
 		global $ngg;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$id      	= (int) $args[3];
-		$name 		= $args[4];
-        $title      = $args[5];
-        $description= $args[6];
-        $previewpic = (int) $args[7];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
+		$name = $args[4];
+		$title = $args[5];
+		$description = $args[6];
+		$previewpic = (int) $args[7];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
-		if ( !$gallery = nggdb::find_gallery($id)  )
-			return(new IXR_Error(404, __("Invalid gallery ID")));
+		if ( ! $gallery = nggdb::find_gallery( $id ) )
+			return ( new IXR_Error( 404, __( "Invalid gallery ID" ) ) );
 
-        if ( !current_user_can( 'NextGEN Manage gallery' ) && !nggAdmin::can_manage_this_gallery($gallery->author) )
-            return new IXR_Error( 401, __( 'Sorry, you must be able to manage this gallery' ) );
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) && ! nggAdmin::can_manage_this_gallery( $gallery->author ) )
+			return new IXR_Error( 401, __( 'Sorry, you must be able to manage this gallery' ) );
 
-		if ( !empty( $name ) )
-			$result = nggdb::update_gallery($id, $name, false, $title, $description, false, $previewpic);
+		if ( ! empty( $name ) )
+			$result = nggdb::update_gallery( $id, $name, false, $title, $description, false, $previewpic );
 
-		if ( !$result )
-			return new IXR_Error(500, __('Sorry, could not update the gallery'));
+		if ( ! $result )
+			return new IXR_Error( 500, __( 'Sorry, could not update the gallery' ) );
 
 		return true;
 
@@ -444,38 +449,38 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *	    	- string new album name
-     *          - int id of preview image
-     *          - string description
-     *          - string serialized array of galleries or a comma-separated string of gallery IDs
-	 * @return int with new album ID
+	 *          - int id of preview image
+	 *          - string description
+	 *          - string serialized array of galleries or a comma-separated string of gallery IDs
+	 * @return IXR_Error|int with new album ID
 	 */
-	function newAlbum($args) {
+	function newAlbum( $args ) {
 
 		global $ngg;
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$name   	= $args[3];
-		$preview   	= (int) $args[4];
-        $description= $args[5];
-        $galleries 	= $this->is_serialized($args[6]);
-        $id 		= false;
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$name = $args[3];
+		$preview = (int) $args[4];
+		$description = $args[5];
+		$galleries = $this->is_serialized( $args[6] );
+		$id = false;
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
-		if( !current_user_can( 'NextGEN Edit album' ) || !nggGallery::current_user_can( 'NextGEN Add/Delete album' ) )
+		if ( ! current_user_can( 'NextGEN Edit album' ) || ! nggGallery::current_user_can( 'NextGEN Add/Delete album' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage albums' ) );
 
-		if ( !empty( $name ) )
+		if ( ! empty( $name ) )
 			$id = $result = nggdb::add_album( $name, $preview, $description, $galleries );
 
-		if ( !$id )
-			return new IXR_Error(500, __('Sorry, could not create the album'));
+		if ( ! $id )
+			return new IXR_Error( 500, __( 'Sorry, could not create the album' ) );
 
-		return($id);
+		return ( $id );
 
 	}
 
@@ -491,41 +496,42 @@ class nggXMLRPC{
 	 *	    	- string password
 	 *	    	- int album ID
 	 *	    	- string album name
-     *          - int id of preview image
-     *          - string description
-     *          - string serialized array of galleries or a comma-separated string of gallery IDs
-	 * @return true if success
+	 *          - int id of preview image
+	 *          - string description
+	 *          - string serialized array of galleries or a comma-separated string of gallery IDs
+	 * @return IXR_Error|true if success
 	 */
-	function editAlbum($args) {
+	function editAlbum( $args ) {
 
 		global $ngg;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$id      	= (int) $args[3];
-		$name   	= $args[4];
-		$preview   	= (int) $args[5];
-        $description= $args[6];
-        $galleries 	= $this->is_serialized($args[7]);
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
+		$name = $args[4];
+		$preview = (int) $args[5];
+		$description = $args[6];
+		$galleries = $this->is_serialized( $args[7] );
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
+		;
 
-		if ( !$album = nggdb::find_album($id) )
-			return(new IXR_Error(404, __("Invalid album ID")));
+		if ( ! $album = nggdb::find_album( $id ) )
+			return ( new IXR_Error( 404, __( "Invalid album ID" ) ) );
 
-		if( !current_user_can( 'NextGEN Edit album' ) )
+		if ( ! current_user_can( 'NextGEN Edit album' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage albums' ) );
 
-		if ( !empty( $name ) )
-			$result = nggdb::update_album($id, $name, $preview, $description, $galleries);
+		if ( ! empty( $name ) )
+			$result = nggdb::update_album( $id, $name, $preview, $description, $galleries );
 
-		if ( !$result )
-			return new IXR_Error(500, __('Sorry, could not update the album'));
+		if ( ! $result )
+			return new IXR_Error( 500, __( 'Sorry, could not update the album' ) );
 
 		return true;
 
@@ -542,28 +548,29 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *	    	- int album id
-	 * @return true
+	 * @return IXR_Error|true
 	 */
-	function deleteAlbum($args) {
+	function deleteAlbum( $args ) {
 
 		global $nggdb;
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-        $id    	    = (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
+		;
 
-		if ( !$album = nggdb::find_album($id) )
-			return(new IXR_Error(404, __("Invalid album ID")));
+		if ( ! $album = nggdb::find_album( $id ) )
+			return ( new IXR_Error( 404, __( "Invalid album ID" ) ) );
 
-		if( !current_user_can( 'NextGEN Edit album' ) && !nggGallery::current_user_can( 'NextGEN Add/Delete album' ) )
+		if ( ! current_user_can( 'NextGEN Edit album' ) && ! nggGallery::current_user_can( 'NextGEN Add/Delete album' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage albums' ) );
 
-		$nggdb->delete_album($id);
+		$nggdb->delete_album( $id );
 
 		return true;
 
@@ -580,30 +587,30 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *	    	- int gallery_id
-	 * @return true
+	 * @return IXR_Error|true
 	 */
-	function deleteGallery($args) {
+	function deleteGallery( $args ) {
 
 		global $nggdb;
 
-        require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-        $id    	    = (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
-		if ( !$gallery = nggdb::find_gallery($id) )
-			return(new IXR_Error(404, __("Invalid gallery ID")));
+		if ( ! $gallery = nggdb::find_gallery( $id ) )
+			return ( new IXR_Error( 404, __( "Invalid gallery ID" ) ) );
 
-		if ( !current_user_can( 'NextGEN Manage gallery' ) && !nggAdmin::can_manage_this_gallery($gallery->author) )
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) && ! nggAdmin::can_manage_this_gallery( $gallery->author ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage galleries' ) );
 
-		$nggdb->delete_gallery($id);
+		$nggdb->delete_gallery( $id );
 
 		return true;
 
@@ -619,26 +626,27 @@ class nggXMLRPC{
 	 * 			- int blog_id
 	 *	    	- string username
 	 *	    	- string password
-	 * @return array with all galleries
+	 * @return IXR_Error|array with all galleries
 	 */
-	function getAlbums($args) {
+	function getAlbums( $args ) {
 
 		global $nggdb;
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
+		;
 
-		if( !current_user_can( 'NextGEN Edit album' ) )
+		if ( ! current_user_can( 'NextGEN Edit album' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage albums' ) );
 
-		$album_list = $nggdb->find_all_album('id', 'ASC', 0, 0 );
+		$album_list = $nggdb->find_all_album( 'id', 'ASC', 0, 0 );
 
-		return($album_list);
+		return ( $album_list );
 
 	}
 
@@ -653,26 +661,26 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *          - int album_id
-	 * @return array with the album object
+	 * @return IXR_Error|nggImage|null with the album object
 	 */
-	function getAlbum($args) {
+	function getAlbum( $args ) {
 
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$id         = (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$id = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
-		if( !current_user_can( 'NextGEN Edit album' ) )
+		if ( ! current_user_can( 'NextGEN Edit album' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage albums' ) );
 
 		$album = nggdb::find_album( $id );
 
-		return($album);
+		return ( $album );
 
 	}
 
@@ -686,26 +694,26 @@ class nggXMLRPC{
 	 * 			- int blog_id
 	 *	    	- string username
 	 *	    	- string password
-	 * @return array with all galleries
+	 * @return IXR_Error|array with all galleries
 	 */
-	function getGalleries($args) {
+	function getGalleries( $args ) {
 
 		global $nggdb;
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
-		if( !current_user_can( 'NextGEN Manage gallery' ) )
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage galleries' ) );
 
-		$gallery_list = $nggdb->find_all_galleries('gid', 'asc', true, 0, 0, false);
+		$gallery_list = $nggdb->find_all_galleries( 'gid', 'asc', true, 0, 0, false );
 
-		return($gallery_list);
+		return ( $gallery_list );
 
 	}
 
@@ -720,27 +728,27 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *          - int gallery_id
-	 * @return array with the gallery object
+	 * @return IXR_Error|array with the gallery object
 	 */
-	function getGallery($args) {
+	function getGallery( $args ) {
 
 		global $nggdb;
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$gid		= (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$gid = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
-		if( !current_user_can( 'NextGEN Manage gallery' ) )
+		if ( ! current_user_can( 'NextGEN Manage gallery' ) )
 			return new IXR_Error( 401, __( 'Sorry, you must be able to manage galleries' ) );
 
-		$gallery = $nggdb->find_gallery($gid);
+		$gallery = $nggdb->find_gallery( $gid );
 
-		return($gallery);
+		return ( $gallery );
 
 	}
 
@@ -755,38 +763,37 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *	    	- int gallery_id
-	 * @return array with all images
+	 * @return IXR_Error|array with all images
 	 */
-	function getImages($args) {
+	function getImages( $args ) {
 
 		global $nggdb;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$gid    	= (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$gid = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
 		// Look for the gallery , could we find it ?
-		if ( !$gallery = nggdb::find_gallery( $gid ) )
-			return new IXR_Error(404, __('Could not find gallery ' . $gid ));
+		if ( ! $gallery = nggdb::find_gallery( $gid ) )
+			return new IXR_Error( 404, __( 'Could not find gallery ' . $gid ) );
 
 		// Now check if you have the correct capability for this gallery
-		if ( !nggAdmin::can_manage_this_gallery($gallery->author) ) {
-			error_log('O', '(NGG) User does not have upload_files capability');
-			$this->error = new IXR_Error(401, __('You are not allowed to upload files to this gallery.'));
-			return $this->error;
+		if ( ! nggAdmin::can_manage_this_gallery( $gallery->author ) ) {
+			error_log( 'O', '(NGG) User does not have upload_files capability' );
+			return new IXR_Error( 401, __( 'You are not allowed to upload files to this gallery.' ) );
 		}
 
 		// get picture values
 		$picture_list = $nggdb->get_gallery( $gid, 'pid', 'ASC', false );
 
-		return($picture_list);
+		return ( $picture_list );
 
 	}
 
@@ -801,42 +808,41 @@ class nggXMLRPC{
 	 *	    	- string username
 	 *	    	- string password
 	 *          - int picture_id
-	 * @return array with image properties
+	 * @return IXR_Error|array with image properties
 	 */
-	function getImage($args) {
+	function getImage( $args ) {
 
 		global $nggdb;
 
-		require_once ( dirname ( dirname( __FILE__ ) ). '/admin/functions.php' );	// admin functions
+		require_once ( dirname( dirname( __FILE__ ) ) . '/admin/functions.php' );	// admin functions
 
-        $this->escape($args);
-		$blog_ID    = (int) $args[0];
-		$username	= $args[1];
-		$password	= $args[2];
-		$pid    	= (int) $args[3];
+		$this->escape( $args );
+		$blog_ID = (int) $args[0];
+		$username = $args[1];
+		$password = $args[2];
+		$pid = (int) $args[3];
 
-		if ( !$user = $this->login($username, $password) )
-			return $this->error;
+		if ( ! $user = $this->login( $username, $password ) )
+			return $this->wrongUsernamePassword;
 
 		// get picture
 		$image = $nggdb->find_image( $pid );
 
-		if ($image) {
+		if ( $image ) {
 			$gid = $image->galleryid;
 
 			// Look for the gallery , could we find it ?
-			if ( !$gallery = nggdb::find_gallery( $gid ) )
-				return new IXR_Error(404, __('Could not find gallery ' . $gid ));
+			if ( ! $gallery = nggdb::find_gallery( $gid ) )
+				return new IXR_Error( 404, __( 'Could not find gallery ' . $gid ) );
 
 			// Now check if you have the correct capability for this gallery
-			if ( !nggAdmin::can_manage_this_gallery($gallery->author) ) {
-				error_log('O', '(NGG) User does not have upload_files capability');
-				$this->error = new IXR_Error(401, __('You are not allowed to upload files to this gallery.'));
-				return $this->error;
+			if ( ! nggAdmin::can_manage_this_gallery( $gallery->author ) ) {
+				error_log( 'O', '(NGG) User does not have upload_files capability' );
+				return new IXR_Error( 401, __( 'You are not allowed to upload files to this gallery.' ) );
 			}
 		}
 
-		return($image);
+		return ( $image );
 
 	}
 
@@ -844,25 +850,25 @@ class nggXMLRPC{
 	 * Sanitize string or array of strings for database.
 	 *
 	 * @since 1.7.0
-     * @author WordPress Core
-     * @filesource inludes/class-wp-xmlrpc-server.php
+	 * @author WordPress Core
+	 * @filesource inludes/class-wp-xmlrpc-server.php
 	 *
 	 * @param string|array $array Sanitize single string or array of strings.
 	 * @return string|array Type matches $array and sanitized for the database.
 	 */
-	function escape(&$array) {
+	function escape( &$array ) {
 		global $wpdb;
 
-		if (!is_array($array)) {
-			return($wpdb->escape($array));
+		if ( ! is_array( $array ) ) {
+			return ( esc_sql( $array ) );
 		} else {
 			foreach ( (array) $array as $k => $v ) {
-				if ( is_array($v) ) {
-					$this->escape($array[$k]);
-				} else if ( is_object($v) ) {
+				if ( is_array( $v ) ) {
+					$this->escape( $array[ $k ] );
+				} else if ( is_object( $v ) ) {
 					//skip
 				} else {
-					$array[$k] = $wpdb->escape($v);
+					$array[ $k ] = esc_sql( $v );
 				}
 			}
 		}

--- a/nggallery.php
+++ b/nggallery.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'nggLoader' ) ) {
 		public array $options = [];
 		private bool $add_PHP5_notice = false;
 		private bool $add_PHP7_notice = false;
-		private string $memory_limit = '0';
+		public string $memory_limit = '0';
 		private string $plugin_name = '';
 		private string $translator = '';
 		private NGG_Admin_Launcher $nggAdminPanel;

--- a/nggallery.php
+++ b/nggallery.php
@@ -28,16 +28,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 // Stop direct call
-if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('You are not allowed to call this page directly.'); }
+if ( preg_match( '#' . basename( __FILE__ ) . '#', $_SERVER['PHP_SELF'] ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
 
 /**
  * Indicates that a clean exit occured. Handled by set_exception_handler
  */
-if (!class_exists('E_Clean_Exit')) {
-    class E_Clean_Exit extends RuntimeException
-    {
+if ( ! class_exists( 'E_Clean_Exit' ) ) {
+	class E_Clean_Exit extends RuntimeException {
 
-    }
+	}
 }
 
 //If NextGEN is activated, deactivate this plugin, and warn about it!
@@ -46,31 +47,35 @@ check_nextgen::nextgen_activated();
 /**
  * Loads the NextGEN plugin
  */
-if (!class_exists('nggLoader')) {
+if ( ! class_exists( 'nggLoader' ) ) {
 
-    /**
-     * Class nggLoader
-     */
-    class nggLoader {
+	/**
+	 * Class nggLoader
+	 */
+	class nggLoader {
 
-		var $version = '1.9.35';
-		var $dbversion   = '1.8.3';
-		var $minimum_WP  = '4.0';
-		var $options     = '';
-		var $manage_page;
-		var $add_PHP5_notice = false;
+		public string $version = '1.9.35';
+		private string $dbversion = '1.8.3';
+		private string $minimum_WP = '4.0';
+		public array $options = [];
+		private bool $add_PHP5_notice = false;
+		private bool $add_PHP7_notice = false;
+		private string $memory_limit = '0';
+		private string $plugin_name = '';
+		private string $translator = '';
+		private NGG_Admin_Launcher $nggAdminPanel;
 
-        /**
-         * class constructor
-         */
-        function __construct() {
+		/**
+		 * class constructor
+		 */
+		function __construct() {
 
 			// Stop the plugin if we missed the requirements
-			if ( ( !$this->required_version() ) || ( !$this->check_memory_limit() )  )
+			if ( ( ! $this->required_version() ) || ( ! $this->check_memory_limit() ) )
 				return;
 
 			// Set error handler
-			set_exception_handler(array(&$this, 'exception_handler'));
+			set_exception_handler( array(&$this, 'exception_handler' ) );
 
 			// Get some constants first
 			$this->load_options();
@@ -78,158 +83,166 @@ if (!class_exists('nggLoader')) {
 			$this->define_tables();
 			$this->load_dependencies();
 
-			$this->plugin_name = basename(dirname(__FILE__)).'/'.basename(__FILE__);
+			$this->plugin_name = basename( dirname( __FILE__ ) ) . '/' . basename( __FILE__ );
 
 			// Init options & tables during activation & deregister init option
-			register_activation_hook( $this->plugin_name, array(&$this, 'activate') );
-			register_deactivation_hook( $this->plugin_name, array(&$this, 'deactivate') );
+			register_activation_hook( $this->plugin_name, array(&$this, 'activate' ) );
+			register_deactivation_hook( $this->plugin_name, array(&$this, 'deactivate' ) );
 
 			// Register a uninstall hook to remove all tables & option automatic
-			register_uninstall_hook( $this->plugin_name, array(__CLASS__, 'uninstall') );
+			register_uninstall_hook( $this->plugin_name, array( __CLASS__, 'uninstall' ) );
 
 			// Start this plugin once all other plugins are fully loaded
-			add_action( 'plugins_loaded', array(&$this, 'start_plugin') );
+			add_action( 'plugins_loaded', array(&$this, 'start_plugin' ) );
 
 			// Register_taxonomy must be used during the init
-			add_action( 'init', array(&$this, 'register_taxonomy') );
-			add_action( 'wpmu_new_blog', array(&$this, 'multisite_new_blog'), 10, 6);
+			add_action( 'init', array(&$this, 'register_taxonomy' ) );
+			add_action( 'wpmu_new_blog', array(&$this, 'multisite_new_blog' ), 10, 6 );
 
 			// Add a message for PHP4 Users, can disable the update message later on
-			if (version_compare(PHP_VERSION, '5.0.0', '<'))
-				add_filter('transient_update_plugins', array(&$this, 'disable_upgrade'));
+			if ( version_compare( PHP_VERSION, '5.0.0', '<' ) )
+				add_filter( 'transient_update_plugins', array(&$this, 'disable_upgrade' ) );
 
 			//Add some links on the plugin page
-			add_filter('plugin_row_meta', array(&$this, 'add_plugin_links'), 10, 2);
+			add_filter( 'plugin_row_meta', array(&$this, 'add_plugin_links' ), 10, 2 );
 
 			// Check for the header / footer
 			add_action( 'init', array(&$this, 'test_head_footer_init' ) );
 
 			// Show NextGEN version in header
-			add_action('wp_head', array('nggGallery', 'nextgen_version') );
+			add_action( 'wp_head', array( 'nggGallery', 'nextgen_version' ) );
 
 			// Handle upload requests
-			add_action('init', array(&$this, 'handle_upload_request'));
+			add_action( 'init', array(&$this, 'handle_upload_request' ) );
 		}
 
-	    function show_upgrade_message() {
-		    if( is_network_admin() ) {
-			    $url = network_admin_url('admin.php?page=' . NGGFOLDER);
-		    } else {
-			    $url = admin_url('admin.php?page=' . NGGFOLDER);
-		    }
-		    ?>
+		function show_upgrade_message() {
+			if ( is_network_admin() ) {
+				$url = network_admin_url( 'admin.php?page=' . NGGFOLDER );
+			} else {
+				$url = admin_url( 'admin.php?page=' . NGGFOLDER );
+			}
+			?>
 			<div id="message" class="update-nag">
-				<p><strong><?php _e('NextCellent Gallery requires a database upgrade.', "nggallery") ?> <a href="<?php echo $url ?>"><?php _e('Upgrade now.', 'nggallery'); ?></a></strong></p>
+				<p><strong>
+						<?php _e( 'NextCellent Gallery requires a database upgrade.', "nggallery" ) ?> <a href="<?php echo $url ?>">
+							<?php _e( 'Upgrade now.', 'nggallery' ); ?>
+						</a>
+					</strong></p>
 			</div>
 			<?php
-	    }
+		}
 
-        /**
-         * Main start invoked after all plugins are loaded.
-         */
-        function start_plugin() {
+		/**
+		 * Main start invoked after all plugins are loaded.
+		 */
+		function start_plugin() {
 
 			// Load the language file
-            load_plugin_textdomain('nggallery', false, NGGFOLDER . '/lang');
+			load_plugin_textdomain( 'nggallery', false, NGGFOLDER . '/lang' );
 
 			// All credits to the translator
-			$this->translator  = '<p class="hint">'. __('<strong>Translation by : </strong><a target="_blank" href="http://alexrabe.de/wordpress-plugins/nextgen-gallery/languages/">See here</a>', 'nggallery') . '</p>';
-			$this->translator .= '<p class="hint">'. __('<strong>This translation is not yet updated for Version 1.9.0</strong>. If you would like to help with translation, download the current po from the plugin folder and read <a href="http://alexrabe.de/wordpress-plugins/wordtube/translation-of-plugins/">here</a> how you can translate the plugin.', 'nggallery') . '</p>';
+			$this->translator = '<p class="hint">' . __( '<strong>Translation by : </strong><a target="_blank" href="http://alexrabe.de/wordpress-plugins/nextgen-gallery/languages/">See here</a>', 'nggallery' ) . '</p>';
+			$this->translator .= '<p class="hint">' . __( '<strong>This translation is not yet updated for Version 1.9.0</strong>. If you would like to help with translation, download the current po from the plugin folder and read <a href="http://alexrabe.de/wordpress-plugins/wordtube/translation-of-plugins/">here</a> how you can translate the plugin.', 'nggallery' ) . '</p>';
 
 			// Content Filters
-			add_filter('ngg_gallery_name', 'sanitize_title');
+			add_filter( 'ngg_gallery_name', 'sanitize_title' );
 
 			// Check if we are in the admin area
 			if ( is_admin() ) {
 
 				// Pass the init check or show a message
-				if (get_option( 'ngg_init_check' ) != false )
-					add_action( 'admin_notices', function () { echo '<div id="message" class="error"><p><strong>' . get_option( "ngg_init_check" ) . '</strong></p></div>'; } );
+				if ( get_option( 'ngg_init_check' ) != false )
+					add_action( 'admin_notices', function () {
+						echo '<div id="message" class="error"><p><strong>' . get_option( "ngg_init_check" ) . '</strong></p></div>';
+					} );
 
 			} else {
 
 				// Add MRSS to wp_head
-				if ( $this->options['useMediaRSS'] )
-					add_action('wp_head', array('nggMediaRss', 'add_mrss_alternate_link'));
+				if ( @$this->options['useMediaRSS'] )
+					add_action( 'wp_head', array( 'nggMediaRss', 'add_mrss_alternate_link' ) );
 
 				// Look for XML request, before page is render
-				add_action('parse_request',  array(&$this, 'check_request') );
+				add_action( 'parse_request', array(&$this, 'check_request' ) );
 
 				// Add the script and style files
-				add_action('wp_enqueue_scripts', array(&$this, 'load_scripts') );
-				add_action('wp_enqueue_scripts', array(&$this, 'load_styles') );
+				add_action( 'wp_enqueue_scripts', array(&$this, 'load_scripts' ) );
+				add_action( 'wp_enqueue_scripts', array(&$this, 'load_styles' ) );
 
 			}
 
-	        if( get_option( 'ngg_db_version' ) != NGG_DBVERSION && isset($_GET['page']) != "nextcellent" ) {
+			if ( get_option( 'ngg_db_version' ) != NGG_DBVERSION && isset( $_GET['page'] ) != "nextcellent" ) {
 
-		        $ngg_options = get_option('ngg_options');
+				$ngg_options = get_option( 'ngg_options' );
 
-		        /**
-		         * If the silentUpgrade option is not empty, we try and do the upgrade now.
-		         */
-		        if ( !empty( $ngg_options['silentUpgrade'] ) ) {
-			        include_once( dirname( __FILE__ ) . '/admin/functions.php' );
-			        include_once( dirname( __FILE__ ) . '/admin/upgrade.php' );
-			        try {
-				        ngg_upgrade();
-			        } catch (Exception $e) {
-				        add_action( 'admin_notices', function () { echo '<div id="message" class="error"><p><strong>' . __( 'Something went wrong while upgrading NextCellent Gallery.', "nggallery" ) . '</strong></p></div>'; } );
-			        }
-		        } else {
-			        add_action( 'all_admin_notices', array($this,'show_upgrade_message') );
-		        }
-	        }
+				/**
+				 * If the silentUpgrade option is not empty, we try and do the upgrade now.
+				 */
+				if ( ! empty( $ngg_options['silentUpgrade'] ) ) {
+					include_once ( dirname( __FILE__ ) . '/admin/functions.php' );
+					include_once ( dirname( __FILE__ ) . '/admin/upgrade.php' );
+					try {
+						ngg_upgrade();
+					} catch (Exception $e) {
+						add_action( 'admin_notices', function () {
+							echo '<div id="message" class="error"><p><strong>' . __( 'Something went wrong while upgrading NextCellent Gallery.', "nggallery" ) . '</strong></p></div>';
+						} );
+					}
+				} else {
+					add_action( 'all_admin_notices', array( $this, 'show_upgrade_message' ) );
+				}
+			}
 		}
 
-        /**
-         * Look for XML request
-         * @param $wp
-         * 20170920: Deprecated imagerotator.php
-         */
-        function check_request( $wp ) {
+		/**
+		 * Look for XML request
+		 * @param $wp
+		 * 20170920: Deprecated imagerotator.php
+		 */
+		function check_request( $wp ) {
 
-			if ( !array_key_exists('callback', $wp->query_vars) )
+			if ( ! array_key_exists( 'callback', $wp->query_vars ) )
 				return;
 
 
 
-			if ( $wp->query_vars['callback'] == 'json') {
-				require_once (dirname (__FILE__) . '/xml/json.php');
+			if ( $wp->query_vars['callback'] == 'json' ) {
+				require_once ( dirname( __FILE__ ) . '/xml/json.php' );
 				exit();
 			}
 
-			if ( $wp->query_vars['callback'] == 'image') {
-				require_once (dirname (__FILE__) . '/nggshow.php');
+			if ( $wp->query_vars['callback'] == 'image' ) {
+				require_once ( dirname( __FILE__ ) . '/nggshow.php' );
 				exit();
 			}
 
 			//TODO:see trac #12400 could be an option for WP3.0
-			if ( $wp->query_vars['callback'] == 'ngg-ajax') {
-				require_once (dirname (__FILE__) . '/xml/ajax.php');
+			if ( $wp->query_vars['callback'] == 'ngg-ajax' ) {
+				require_once ( dirname( __FILE__ ) . '/xml/ajax.php' );
 				exit();
 			}
 		}
 
-        /**
-         * Check WP version . Return false if not supported, otherwise true
-         * Display msg in case not supported
-         * @return bool
-         */
-        function required_version() {
+		/**
+		 * Check WP version . Return false if not supported, otherwise true
+		 * Display msg in case not supported
+		 * @return bool
+		 */
+		function required_version() {
 			global $wp_version;
 
 			// Check for WP version installation
-			$wp_ok  =  version_compare($wp_version, $this->minimum_WP, '>=');
+			$wp_ok = version_compare( $wp_version, $this->minimum_WP, '>=' );
 
-			if ( ($wp_ok == FALSE) ) {
+			if ( ( $wp_ok == FALSE ) ) {
 				add_action(
 					'admin_notices',
 					function () {
 						global $ngg;
-						printf ('<div id="message" class="error"><p><strong>'
-								. __('Sorry, NextGEN Gallery works only under WordPress %s or higher', "nggallery" )
-								. '</strong></p></div>', $ngg->minimum_WP );
+						printf( '<div id="message" class="error"><p><strong>'
+							. __( 'Sorry, NextGEN Gallery works only under WordPress %s or higher', "nggallery" )
+							. '</strong></p></div>', $ngg->minimum_WP );
 					}
 				);
 				return false;
@@ -237,32 +250,33 @@ if (!class_exists('nggLoader')) {
 			return true;
 		}
 
-        /**
-         * Checks if there is enough memory to perform the plugin
-         * Inner working: get memory value from memory_limit. If -1 there is no memory limit
-         * If there is 16MB or less, send msg
-         * Returns false if there is enough memory, otherwise false.
-         * @return bool
-         */
-        function check_memory_limit() {
+		/**
+		 * Checks if there is enough memory to perform the plugin
+		 * Inner working: get memory value from memory_limit. If -1 there is no memory limit
+		 * If there is 16MB or less, send msg
+		 * Returns false if there is enough memory, otherwise false.
+		 * @return bool
+		 */
+		function check_memory_limit() {
 
 			// get the real memory limit before some increase it
-			$this->memory_limit = ini_get('memory_limit');
+			$this->memory_limit = ini_get( 'memory_limit' );
 
 			// PHP docs : Note that to have no memory limit, set this directive to -1.
-			if ($this->memory_limit == -1 ) return true;
+			if ( $this->memory_limit == -1 )
+				return true;
 
 			// Yes, we reached Gigabyte limits, so check if it's a megabyte limit
-			if (strtolower( substr($this->memory_limit, -1) ) == 'm') {
+			if ( strtolower( substr( $this->memory_limit, -1 ) ) == 'm' ) {
 
-				$this->memory_limit = (int) substr( $this->memory_limit, 0, -1);
+				$this->memory_limit = (int) substr( $this->memory_limit, 0, -1 );
 
 				//This works only with enough memory, 16MB is silly, wordpress requires already 16MB :-)
-				if ( ($this->memory_limit != 0) && ($this->memory_limit < 16 ) ) {
+				if ( ( $this->memory_limit != 0 ) && ( $this->memory_limit < 16 ) ) {
 					add_action(
 						'admin_notices',
 						function () {
-							echo '<div id="message" class="error"><p><strong>' . __('Sorry, NextCellent Gallery works only with a Memory Limit of 16 MB or higher', 'nggallery') . '</strong></p></div>';
+							echo '<div id="message" class="error"><p><strong>' . __( 'Sorry, NextCellent Gallery works only with a Memory Limit of 16 MB or higher', 'nggallery' ) . '</strong></p></div>';
 						}
 					);
 					return false;
@@ -271,17 +285,17 @@ if (!class_exists('nggLoader')) {
 			return true;
 		}
 
-        /**
-         * add dynamic properties to global wpdb object.
-         */
+		/**
+		 * add dynamic properties to global wpdb object.
+		 */
 
-        function define_tables() {
+		function define_tables() {
 			global $wpdb;
 
 			// add database pointer
-			$wpdb->nggpictures					= $wpdb->prefix . 'ngg_pictures';
-			$wpdb->nggallery					= $wpdb->prefix . 'ngg_gallery';
-			$wpdb->nggalbum						= $wpdb->prefix . 'ngg_album';
+			$wpdb->nggpictures = $wpdb->prefix . 'ngg_pictures';
+			$wpdb->nggallery = $wpdb->prefix . 'ngg_gallery';
+			$wpdb->nggalbum = $wpdb->prefix . 'ngg_album';
 
 		}
 
@@ -291,94 +305,96 @@ if (!class_exists('nggLoader')) {
 
 			// Register the NextGEN taxonomy
 			$args = array(
-					'label' => __('Picture tag', 'nggallery'),
-					'template' => __('Picture tag: %2$l.', 'nggallery'),
-					'helps' => __('Separate picture tags with commas.', 'nggallery'),
-					'sort' => true,
-					'args' => array('orderby' => 'term_order')
-					);
+				'label' => __( 'Picture tag', 'nggallery' ),
+				'template' => __( 'Picture tag: %2$l.', 'nggallery' ),
+				'helps' => __( 'Separate picture tags with commas.', 'nggallery' ),
+				'sort' => true,
+				'args' => array( 'orderby' => 'term_order' )
+			);
 
 			register_taxonomy( 'ngg_tag', 'nggallery', $args );
 		}
 
-        /**
-         * Define several constants
-         * 20140517 - Suppressed unused constant
-         */
-        function define_constant() {
+		/**
+		 * Define several constants
+		 * 20140517 - Suppressed unused constant
+		 */
+		function define_constant() {
 
 			global $wp_version;
 
 			// Minimum required database version
-			define('NGG_DBVERSION', $this->dbversion);
+			define( 'NGG_DBVERSION', $this->dbversion );
 
 			// required for Windows & XAMPP
-			define('WINABSPATH', str_replace("\\", "/", ABSPATH) );
-			define('NGG_CONTENT_DIR', str_replace("\\","/", WP_CONTENT_DIR) );
+			define( 'WINABSPATH', str_replace( "\\", "/", ABSPATH ) );
+			define( 'NGG_CONTENT_DIR', str_replace( "\\", "/", WP_CONTENT_DIR ) );
 
 			// define URL
-			define('NGGFOLDER', basename( dirname(__FILE__) ) );
+			define( 'NGGFOLDER', basename( dirname( __FILE__ ) ) );
 
-			define('NGGALLERY_ABSPATH', trailingslashit( str_replace("\\","/", WP_PLUGIN_DIR . '/' . NGGFOLDER ) ) );
-			define('NGGALLERY_URLPATH', trailingslashit( plugins_url( NGGFOLDER ) ) );
+			define( 'NGGALLERY_ABSPATH', trailingslashit( str_replace( "\\", "/", WP_PLUGIN_DIR . '/' . NGGFOLDER ) ) );
+			define( 'NGGALLERY_URLPATH', trailingslashit( plugins_url( NGGFOLDER ) ) );
 
 			// look for imagerotator
-			define('NGGALLERY_IREXIST', !empty( $this->options['irURL'] ));
+			define( 'NGGALLERY_IREXIST', ! empty( @$this->options['irURL'] ) );
 
 			// get value for safe mode
-			if ( (gettype( ini_get('safe_mode') ) == 'string') ) {
+			if ( ( gettype( ini_get( 'safe_mode' ) ) == 'string' ) ) {
 				// if sever did in in a other way
-				if ( ini_get('safe_mode') == 'off' ) define('SAFE_MODE', FALSE);
-				else define( 'SAFE_MODE', ini_get('safe_mode') );
+				if ( ini_get( 'safe_mode' ) == 'off' )
+					define( 'SAFE_MODE', FALSE );
+				else
+					define( 'SAFE_MODE', ini_get( 'safe_mode' ) );
 			} else
-			define( 'SAFE_MODE', ini_get('safe_mode') );
+				define( 'SAFE_MODE', ini_get( 'safe_mode' ) );
 
-			if ( version_compare($wp_version, '3.2.999', '>') )
-				define('IS_WP_3_3', TRUE);
+			if ( version_compare( $wp_version, '3.2.999', '>' ) )
+				define( 'IS_WP_3_3', TRUE );
 		}
 
-        /**
-         * Load libraries
-         */
-        function load_dependencies() {
+		/**
+		 * Load libraries
+		 */
+		function load_dependencies() {
 
 			// Load global libraries												// average memory usage (in bytes)
-			require_once (dirname (__FILE__) . '/lib/core.php');					//  94.840
-			require_once (dirname (__FILE__) . '/lib/ngg-db.php');					// 132.400
-			require_once (dirname (__FILE__) . '/lib/image.php');					//  59.424
-			require_once (dirname (__FILE__) . '/lib/tags.php');				    // 117.136
-			require_once (dirname (__FILE__) . '/lib/post-thumbnail.php');			//  n.a.
-	        require_once( dirname( __FILE__ ) . '/widgets/class-ngg-slideshow-widget.php' );
-	        require_once( dirname( __FILE__ ) . '/widgets/class-ngg-media-rss-widget.php' );
-	        require_once( dirname( __FILE__ ) . '/widgets/class-ngg-gallery-widget.php' );
-			require_once (dirname (__FILE__) . '/lib/multisite.php');
-			require_once (dirname (__FILE__) . '/lib/sitemap.php');
+			require_once ( dirname( __FILE__ ) . '/lib/core.php' );					//  94.840
+			require_once ( dirname( __FILE__ ) . '/lib/ngg-db.php' );					// 132.400
+			require_once ( dirname( __FILE__ ) . '/lib/image.php' );					//  59.424
+			require_once ( dirname( __FILE__ ) . '/lib/tags.php' );				    // 117.136
+			require_once ( dirname( __FILE__ ) . '/lib/post-thumbnail.php' );			//  n.a.
+			require_once ( dirname( __FILE__ ) . '/widgets/class-ngg-slideshow-widget.php' );
+			require_once ( dirname( __FILE__ ) . '/widgets/class-ngg-media-rss-widget.php' );
+			require_once ( dirname( __FILE__ ) . '/widgets/class-ngg-gallery-widget.php' );
+			require_once ( dirname( __FILE__ ) . '/lib/multisite.php' );
+			require_once ( dirname( __FILE__ ) . '/lib/sitemap.php' );
 
 			// Load frontend libraries
-			require_once (dirname (__FILE__) . '/lib/navigation.php');		        // 242.016
-			require_once (dirname (__FILE__) . '/nggfunctions.php');		        // n.a.
-			require_once (dirname (__FILE__) . '/lib/shortcodes.php'); 		        // 92.664
+			require_once ( dirname( __FILE__ ) . '/lib/navigation.php' );		        // 242.016
+			require_once ( dirname( __FILE__ ) . '/nggfunctions.php' );		        // n.a.
+			require_once ( dirname( __FILE__ ) . '/lib/shortcodes.php' ); 		        // 92.664
 
 			// Add to the toolbar
-			add_action( 'admin_bar_menu', array( &$this, 'admin_bar_menu' ), 999 );
+			add_action( 'admin_bar_menu', array(&$this, 'admin_bar_menu' ), 999 );
 
 			//Just needed if you access remote to WordPress
-			if ( defined('XMLRPC_REQUEST') )
-				require_once (dirname (__FILE__) . '/lib/xmlrpc.php');
+			if ( defined( 'XMLRPC_REQUEST' ) )
+				require_once ( dirname( __FILE__ ) . '/lib/xmlrpc.php' );
 
 			// We didn't need all stuff during a AJAX operation
-			if ( defined('DOING_AJAX') )
-				require_once (dirname (__FILE__) . '/admin/ajax.php');
+			if ( defined( 'DOING_AJAX' ) )
+				require_once ( dirname( __FILE__ ) . '/admin/ajax.php' );
 			else {
-				require_once (dirname (__FILE__) . '/lib/meta.php');				// 131.856
-				require_once (dirname (__FILE__) . '/lib/media-rss.php');			//  82.768
-				require_once (dirname (__FILE__) . '/lib/rewrite.php');				//  71.936
-				include_once (dirname (__FILE__) . '/admin/tinymce/tinymce.php'); 	//  22.408
+				require_once ( dirname( __FILE__ ) . '/lib/meta.php' );				// 131.856
+				require_once ( dirname( __FILE__ ) . '/lib/media-rss.php' );			//  82.768
+				require_once ( dirname( __FILE__ ) . '/lib/rewrite.php' );				//  71.936
+				include_once ( dirname( __FILE__ ) . '/admin/tinymce/tinymce.php' ); 	//  22.408
 
 				// Load backend libraries
 				if ( is_admin() ) {
-					require_once (dirname (__FILE__) . '/admin/class-ngg-admin-launcher.php');
-					require_once (dirname (__FILE__) . '/admin/media-upload.php');
+					require_once ( dirname( __FILE__ ) . '/admin/class-ngg-admin-launcher.php' );
+					require_once ( dirname( __FILE__ ) . '/admin/media-upload.php' );
 					$this->nggAdminPanel = new NGG_Admin_Launcher();
 				}
 			}
@@ -400,197 +416,197 @@ if (!class_exists('nggLoader')) {
 			if ( current_user_can( 'NextGEN Upload images' ) ) {
 				$wp_admin_bar->add_node( array(
 					'parent' => 'new-content',
-					'id'     => 'ngg-menu-add-gallery',
-					'title'  => __( 'NextCellent Gallery / Images', 'nggallery' ),
-					'href'   => admin_url( 'admin.php?page=nggallery-add-gallery' )
+					'id' => 'ngg-menu-add-gallery',
+					'title' => __( 'NextCellent Gallery / Images', 'nggallery' ),
+					'href' => admin_url( 'admin.php?page=nggallery-add-gallery' )
 				) );
 			}
 
 			//If the user is in the admin screen, there is no need to display this.
-			if ( !is_admin() ) {
+			if ( ! is_admin() ) {
 				$wp_admin_bar->add_node( array(
 					'parent' => 'site-name',
-					'id'     => 'ngg-menu-overview',
-					'title'  => __( 'NextCellent', 'nggallery' ),
-					'href'   => admin_url( 'admin.php?page=' . NGGFOLDER )
+					'id' => 'ngg-menu-overview',
+					'title' => __( 'NextCellent', 'nggallery' ),
+					'href' => admin_url( 'admin.php?page=' . NGGFOLDER )
 				) );
 				if ( current_user_can( 'NextGEN Manage gallery' ) ) {
 					$wp_admin_bar->add_node( array(
 						'parent' => 'ngg-menu-overview',
-						'id'     => 'ngg-menu-manage-gallery',
-						'title'  => __( 'Gallery', 'nggallery' ),
-						'href'   => admin_url( 'admin.php?page=nggallery-manage' )
+						'id' => 'ngg-menu-manage-gallery',
+						'title' => __( 'Gallery', 'nggallery' ),
+						'href' => admin_url( 'admin.php?page=nggallery-manage' )
 					) );
 				}
 				if ( current_user_can( 'NextGEN Edit album' ) ) {
 					$wp_admin_bar->add_node( array(
 						'parent' => 'ngg-menu-overview',
-						'id'     => 'ngg-menu-manage-album',
-						'title'  => __( 'Albums', 'nggallery' ),
-						'href'   => admin_url( 'admin.php?page=nggallery-manage-album' )
+						'id' => 'ngg-menu-manage-album',
+						'title' => __( 'Albums', 'nggallery' ),
+						'href' => admin_url( 'admin.php?page=nggallery-manage-album' )
 					) );
 				}
 				if ( current_user_can( 'NextGEN Manage tags' ) ) {
 					$wp_admin_bar->add_node( array(
 						'parent' => 'ngg-menu-overview',
-						'id'     => 'ngg-menu-tags',
-						'title'  => __( 'Tags', 'nggallery' ),
-						'href'   => admin_url( 'admin.php?page=nggallery-tags' )
+						'id' => 'ngg-menu-tags',
+						'title' => __( 'Tags', 'nggallery' ),
+						'href' => admin_url( 'admin.php?page=nggallery-tags' )
 					) );
 				}
 				if ( current_user_can( 'NextGEN Change options' ) ) {
 					$wp_admin_bar->add_node( array(
 						'parent' => 'ngg-menu-overview',
-						'id'     => 'ngg-menu-options',
-						'title'  => __( 'Settings', 'nggallery' ),
-						'href'   => admin_url( 'admin.php?page=nggallery-options' )
+						'id' => 'ngg-menu-options',
+						'title' => __( 'Settings', 'nggallery' ),
+						'href' => admin_url( 'admin.php?page=nggallery-options' )
 					) );
 				}
 				if ( current_user_can( 'NextGEN Change style' ) ) {
 					$wp_admin_bar->add_node( array(
 						'parent' => 'ngg-menu-overview',
-						'id'     => 'ngg-menu-style',
-						'title'  => __( 'Style', 'nggallery' ),
-						'href'   => admin_url( 'admin.php?page=nggallery-style' )
+						'id' => 'ngg-menu-style',
+						'title' => __( 'Style', 'nggallery' ),
+						'href' => admin_url( 'admin.php?page=nggallery-style' )
 					) );
 				}
 			}
 		}
 
-        /**
-         * Load scripts depending options defined
-         * 20150106: Added js for Qunit
-         * 20150107: jquery is almost mandatory... Should it be enqueued only when lightbox is activated?
-         */
-        function load_scripts() {
+		/**
+		 * Load scripts depending options defined
+		 * 20150106: Added js for Qunit
+		 * 20150107: jquery is almost mandatory... Should it be enqueued only when lightbox is activated?
+		 */
+		function load_scripts() {
 
 			// if you want to prevent Nextcellent load the scripts (for testing or development purposes), add this constant
-			if ( defined('NGG_SKIP_LOAD_SCRIPTS') )
+			if ( defined( 'NGG_SKIP_LOAD_SCRIPTS' ) )
 				return;
 
 			//	activate Thickbox
-			if ($this->options['thumbEffect'] == 'thickbox') {
+			if ( @$this->options['thumbEffect'] == 'thickbox' ) {
 				wp_enqueue_script( 'thickbox' );
 				// Load the thickbox images after all other scripts
-				add_action( 'wp_footer', array(&$this, 'load_thickbox_images'), 11 );
+				add_action( 'wp_footer', array(&$this, 'load_thickbox_images' ), 11 );
 
 			}
 
 			// activate jquery.lightbox
-			if ($this->options['thumbEffect'] == 'lightbox') {
-				wp_enqueue_script('jquery');
+			if ( @$this->options['thumbEffect'] == 'lightbox' ) {
+				wp_enqueue_script( 'jquery' );
 			}
 
 			// activate modified Shutter reloaded if not use the Shutter plugin
-			if ( ($this->options['thumbEffect'] == "shutter") && !function_exists('srel_makeshutter') ) {
-				wp_register_script('shutter', NGGALLERY_URLPATH .'shutter/shutter-reloaded.js', false ,'1.3.3');
-				wp_localize_script('shutter', 'shutterSettings', array(
-							'msgLoading' => __('L O A D I N G', 'nggallery'),
-							'msgClose' => __('Click to Close', 'nggallery'),
-							'imageCount' => '1'
+			if ( ( @$this->options['thumbEffect'] == "shutter" ) && ! function_exists( 'srel_makeshutter' ) ) {
+				wp_register_script( 'shutter', NGGALLERY_URLPATH . 'shutter/shutter-reloaded.js', [], '1.3.3' );
+				wp_localize_script( 'shutter', 'shutterSettings', array(
+					'msgLoading' => __( 'L O A D I N G', 'nggallery' ),
+					'msgClose' => __( 'Click to Close', 'nggallery' ),
+					'imageCount' => '1'
 				) );
 				wp_enqueue_script( 'shutter' );
 			}
 
 			// required for the slideshow
-			if ( NGGALLERY_IREXIST == true && $this->options['enableIR'] == '1' && nggGallery::detect_mobile_phone() === false )
-				wp_enqueue_script('swfobject');
-			else if ($this->options['galShowSlide']) {
-				wp_enqueue_script('owl', NGGALLERY_URLPATH .'js/owl.carousel.min.js', array('jquery'), '2.3.4');
+			if ( NGGALLERY_IREXIST == true && @$this->options['enableIR'] == '1' && nggGallery::detect_mobile_phone() === false )
+				wp_enqueue_script( 'swfobject' );
+			else if ( @$this->options['galShowSlide'] ) {
+				wp_enqueue_script( 'owl', NGGALLERY_URLPATH . 'js/owl.carousel.min.js', array( 'jquery' ), '2.3.4' );
 			}
 
 			// Load AJAX navigation script, works only with shutter script as we need to add the listener
-			if ( $this->options['galAjaxNav'] ) {
-				if ( ($this->options['thumbEffect'] == "shutter") || function_exists('srel_makeshutter') ) {
-					wp_enqueue_script ( 'ngg_script', NGGALLERY_URLPATH . 'js/ngg.js', array('jquery', 'jquery-ui-tooltip'), '2.1');
-					wp_localize_script( 'ngg_script', 'ngg_ajax', array('path'		=> NGGALLERY_URLPATH,
-																		'callback'  => trailingslashit( home_url() ) . 'index.php?callback=ngg-ajax',
-																		'loading'	=> __('loading', 'nggallery'),
+			if ( @$this->options['galAjaxNav'] ) {
+				if ( ( @$this->options['thumbEffect'] == "shutter" ) || function_exists( 'srel_makeshutter' ) ) {
+					wp_enqueue_script( 'ngg_script', NGGALLERY_URLPATH . 'js/ngg.js', array( 'jquery', 'jquery-ui-tooltip' ), '2.1' );
+					wp_localize_script( 'ngg_script', 'ngg_ajax', array( 'path' => NGGALLERY_URLPATH,
+						'callback' => trailingslashit( home_url() ) . 'index.php?callback=ngg-ajax',
+						'loading' => __( 'loading', 'nggallery' ),
 					) );
 				}
 			}
 
 			// If activated, add PicLens/Cooliris javascript to footer
-			if ( $this->options['usePicLens'] )
+			if ( @$this->options['usePicLens'] )
 				nggMediaRss::add_piclens_javascript();
 
 			// Added Qunit for javascript unit testing
-            $nxc=isset($_GET['nextcellent'])?$_GET['nextcellent']:"";
-			if ($nxc) {
-				wp_enqueue_script( "qunit-init"       , NGGALLERY_URLPATH . "js/nxc.main.js"        , array ('jquery')); //main q-unit call
-				wp_enqueue_script( "qunit"            , NGGALLERY_URLPATH . "js/qunit-1.16.0.js"    , array ('jquery')); //qunit core
-				wp_enqueue_script( "nextcellent-test" , NGGALLERY_URLPATH . "js/nxc.test.js", array ('jquery')); //unit testing specific for nextcellent
+			$nxc = isset( $_GET['nextcellent'] ) ? $_GET['nextcellent'] : "";
+			if ( $nxc ) {
+				wp_enqueue_script( "qunit-init", NGGALLERY_URLPATH . "js/nxc.main.js", array( 'jquery' ) ); //main q-unit call
+				wp_enqueue_script( "qunit", NGGALLERY_URLPATH . "js/qunit-1.16.0.js", array( 'jquery' ) ); //qunit core
+				wp_enqueue_script( "nextcellent-test", NGGALLERY_URLPATH . "js/nxc.test.js", array( 'jquery' ) ); //unit testing specific for nextcellent
 			}
 
 		}
 
 		function load_thickbox_images() {
 			// WP core reference relative to the images. Bad idea
-			echo "\n" . '<script type="text/javascript">tb_pathToImage = "' . site_url() . '/wp-includes/js/thickbox/loadingAnimation.gif";tb_closeImage = "' . site_url() . '/wp-includes/js/thickbox/tb-close.png";</script>'. "\n";
+			echo "\n" . '<script type="text/javascript">tb_pathToImage = "' . site_url() . '/wp-includes/js/thickbox/loadingAnimation.gif";tb_closeImage = "' . site_url() . '/wp-includes/js/thickbox/tb-close.png";</script>' . "\n";
 		}
 
 		/**
-		* Load styles based on options defined
-		* 20150106: added style for Qunit
-		*/
+		 * Load styles based on options defined
+		 * 20150106: added style for Qunit
+		 */
 		function load_styles() {
 
-            //Notice stylesheet selection has this priority:
-            //1-sytlesheet loaded from filter ngg_load_stylesheet
-            //2-nggalery.css on folder's current theme
-            //3-active stylesheet defined on styles.
+			//Notice stylesheet selection has this priority:
+			//1-sytlesheet loaded from filter ngg_load_stylesheet
+			//2-nggalery.css on folder's current theme
+			//3-active stylesheet defined on styles.
 
 			if ( $css_file = nggGallery::get_theme_css_file() ) {
-				wp_enqueue_style('NextGEN', $css_file , false, '1.0.0', 'screen');
-			} elseif ($this->options['activateCSS']) {
+				wp_enqueue_style( 'NextGEN', $css_file, [], '1.0.0', 'screen' );
+			} elseif ( @$this->options['activateCSS'] ) {
 				//convert the path to an URL
 				$replace = content_url();
-				$path = str_replace( NGG_CONTENT_DIR , $replace, $this->options['CSSfile']); 
-				wp_enqueue_style('NextGEN', $path, false, '1.0.0', 'screen');
+				$path = str_replace( NGG_CONTENT_DIR, $replace, @$this->options['CSSfile'] );
+				wp_enqueue_style( 'NextGEN', $path, [], '1.0.0', 'screen' );
 			}
 
 
 			//	activate Thickbox
-			if ($this->options['thumbEffect'] == 'thickbox')
-				wp_enqueue_style( 'thickbox');
+			if ( @$this->options['thumbEffect'] == 'thickbox' )
+				wp_enqueue_style( 'thickbox' );
 
 			// activate modified Shutter reloaded if not use the Shutter plugin
-			if ( ($this->options['thumbEffect'] == 'shutter') && !function_exists('srel_makeshutter') )
-				wp_enqueue_style('shutter', NGGALLERY_URLPATH .'shutter/shutter-reloaded.css', false, '1.3.4', 'screen');
+			if ( ( @$this->options['thumbEffect'] == 'shutter' ) && ! function_exists( 'srel_makeshutter' ) )
+				wp_enqueue_style( 'shutter', NGGALLERY_URLPATH . 'shutter/shutter-reloaded.css', [], '1.3.4', 'screen' );
 
 			// Load Owl carousel stylesheets if slideshow enabled
-			if ($this->options['galShowSlide']) {
-				wp_enqueue_style('owl', NGGALLERY_URLPATH . 'css/owl.carousel.min.css', false, '2.3.4', 'screen');
-				wp_enqueue_style('owl-theme', NGGALLERY_URLPATH . 'css/owl.theme.default.min.css', false, '2.3.4', 'screen');
-				wp_enqueue_style('animate', NGGALLERY_URLPATH . 'css/animate.min.css', false, '3.7.2', 'screen');
+			if ( @$this->options['galShowSlide'] ) {
+				wp_enqueue_style( 'owl', NGGALLERY_URLPATH . 'css/owl.carousel.min.css', [], '2.3.4', 'screen' );
+				wp_enqueue_style( 'owl-theme', NGGALLERY_URLPATH . 'css/owl.theme.default.min.css', [], '2.3.4', 'screen' );
+				wp_enqueue_style( 'animate', NGGALLERY_URLPATH . 'css/animate.min.css', [], '3.7.2', 'screen' );
 			}
 
 			// add qunit style if activated. I put 1.0.0 as formula, but it would mean nothing.
 
-            $nxc=isset($_GET['nextcellent'])?$_GET['nextcellent']:"";
-			if ($nxc) {
-				wp_enqueue_style ( "qunit", NGGALLERY_URLPATH . "css/qunit-1.16.0.css" , false, '1.0.0' , 'screen' );
+			$nxc = isset( $_GET['nextcellent'] ) ? $_GET['nextcellent'] : "";
+			if ( $nxc ) {
+				wp_enqueue_style( "qunit", NGGALLERY_URLPATH . "css/qunit-1.16.0.css", [], '1.0.0', 'screen' );
 			}
 
 		}
 
 		function load_options() {
 			// Load the options
-			$this->options = get_option('ngg_options');
+			$this->options = is_array( get_option( 'ngg_options' ) ) ? get_option( 'ngg_options' ) : [];
 		}
 
 		// THX to Shiba for the code
 		// See: http://shibashake.com/wordpress-theme/write-a-plugin-for-wordpress-multi-site
-		function multisite_new_blog($blog_id, $user_id, $domain, $path, $site_id, $meta ) {
+		function multisite_new_blog( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
 			global $wpdb;
 
-			include_once (dirname (__FILE__) . '/admin/class-ngg-installer.php');
+			include_once ( dirname( __FILE__ ) . '/admin/class-ngg-installer.php' );
 
-			if (is_plugin_active_for_network( $this->plugin_name )) {
+			if ( is_plugin_active_for_network( $this->plugin_name ) ) {
 				$current_blog = $wpdb->blogid;
-				switch_to_blog($blog_id);
+				switch_to_blog( $blog_id );
 				NGG_Installer::install();
-				switch_to_blog($current_blog);
+				switch_to_blog( $current_blog );
 			}
 		}
 
@@ -598,8 +614,7 @@ if (!class_exists('nggLoader')) {
 		 * Removes all transients created by NextGEN. Called during activation
 		 * and deactivation routines
 		 */
-		static function remove_transients()
-		{
+		static function remove_transients() {
 			global $wpdb, $_wp_using_ext_object_cache;
 
 			// Fetch all transients
@@ -607,58 +622,65 @@ if (!class_exists('nggLoader')) {
 				SELECT option_name FROM {$wpdb->options}
 				WHERE option_name LIKE '%ngg_request%'
 			";
-			$transient_names = $wpdb->get_col($query);;
+			$transient_names = $wpdb->get_col( $query );
+			;
 
 			// Delete all transients in the database
 			$query = "
 				DELETE FROM {$wpdb->options}
 				WHERE option_name LIKE '%ngg_request%'
 			";
-			$wpdb->query($query);
+			$wpdb->query( $query );
 
 			// If using an external caching mechanism, delete the cached items
-			if ($_wp_using_ext_object_cache) {
-				foreach ($transient_names as $transient) {
-					wp_cache_delete($transient, 'transient');
-					wp_cache_delete(substr($transient, 11), 'transient');
+			if ( $_wp_using_ext_object_cache ) {
+				foreach ( $transient_names as $transient ) {
+					wp_cache_delete( $transient, 'transient' );
+					wp_cache_delete( substr( $transient, 11 ), 'transient' );
 				}
 			}
 		}
 
-        /**
-         * Activation hook
-         * register_activation_hook( $this->plugin_name, array(&$this, 'activate') );
-         * Disable Plugin if PHP version is lower than 5.2
-         * However, why the plugin spread initial validation over so different places? Not need to do that...
-         */
-        function activate() {
+		/**
+		 * Activation hook
+		 * register_activation_hook( $this->plugin_name, array(&$this, 'activate') );
+		 * Disable Plugin if PHP version is lower than 5.2
+		 * However, why the plugin spread initial validation over so different places? Not need to do that...
+		 */
+		function activate() {
 			global $wpdb;
 			//Starting from version 1.8.0 it's works only with PHP5.2
-			if (version_compare(PHP_VERSION, '5.2.0', '<')) {
-					deactivate_plugins($this->plugin_name); // Deactivate ourself
-					wp_die("Sorry, but you can't run this plugin, it requires PHP 5.2 or higher.");
-					return;
+			// if ( version_compare( PHP_VERSION, '5.2.0', '<' ) ) {
+			// 	deactivate_plugins( $this->plugin_name ); // Deactivate ourself
+			// 	wp_die( "Sorry, but you can't run this plugin, it requires PHP 5.2 or higher." );
+			// 	return;
+			// }
+
+			if ( version_compare( PHP_VERSION, '7.3.0', '<' ) ) {
+				deactivate_plugins( $this->plugin_name ); // Deactivate ourself
+				wp_die( "Sorry, but you can't run this plugin, it requires PHP 7.3 or higher." );
+				return;
 			}
 
 			// Clean up transients
 			self::remove_transients();
 
-			include_once (dirname (__FILE__) . '/admin/class-ngg-installer.php');
+			include_once ( dirname( __FILE__ ) . '/admin/class-ngg-installer.php' );
 
-			if (is_multisite()) {
-				$network=isset($_SERVER['SCRIPT_NAME'])?$_SERVER['SCRIPT_NAME']:"";
-				$activate=isset($_GET['action'])?$_GET['action']:"";
-				$isNetwork=($network=='/wp-admin/network/plugins.php')?true:false;
-				$isActivation=($activate=='deactivate')?false:true;
+			if ( is_multisite() ) {
+				$network = isset( $_SERVER['SCRIPT_NAME'] ) ? $_SERVER['SCRIPT_NAME'] : "";
+				$activate = isset( $_GET['action'] ) ? $_GET['action'] : "";
+				$isNetwork = ( $network == '/wp-admin/network/plugins.php' ) ? true : false;
+				$isActivation = ( $activate == 'deactivate' ) ? false : true;
 
-				if ($isNetwork and $isActivation){
+				if ( $isNetwork and $isActivation ) {
 					$old_blog = $wpdb->blogid;
-					$blogids = $wpdb->get_col($wpdb->prepare("SELECT blog_id FROM $wpdb->blogs", NULL));
-					foreach ($blogids as $blog_id) {
-						switch_to_blog($blog_id);
+					$blogids = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM $wpdb->blogs", NULL ) );
+					foreach ( $blogids as $blog_id ) {
+						switch_to_blog( $blog_id );
 						NGG_Installer::install();
 					}
-					switch_to_blog($old_blog);
+					switch_to_blog( $old_blog );
 					return;
 				}
 			}
@@ -670,10 +692,10 @@ if (!class_exists('nggLoader')) {
 
 		}
 
-        /**
-         * delete init options and transients
-         */
-        function deactivate() {
+		/**
+		 * delete init options and transients
+		 */
+		function deactivate() {
 
 			// remove & reset the init check option
 			delete_option( 'ngg_init_check' );
@@ -683,52 +705,60 @@ if (!class_exists('nggLoader')) {
 			self::remove_transients();
 		}
 
-        /**
-         * Uninstall procedure. Pay attention this method is static on the class
-         * See register_uninstall_hook( $this->plugin_name, array(__CLASS__, 'uninstall') );
-         */
-        static function uninstall() {
+		/**
+		 * Uninstall procedure. Pay attention this method is static on the class
+		 * See register_uninstall_hook( $this->plugin_name, array(__CLASS__, 'uninstall') );
+		 */
+		static function uninstall() {
 			// Clean up transients
 			self::remove_transients();
 
-			include_once (dirname (__FILE__) . '/admin/class-ngg-installer.php');
+			include_once ( dirname( __FILE__ ) . '/admin/class-ngg-installer.php' );
 			NGG_Installer::uninstall();
 		}
 
-        /**
-         * @param $option
-         * @return mixed
-         */
-        function disable_upgrade($option){
+		/**
+		 * @param $option
+		 * @return mixed
+		 */
+		function disable_upgrade( $option ) {
 
 			// PHP5.2 is required for NGG V1.4.0
-			if ( version_compare($option->response[ $this->plugin_name ]->new_version, '1.4.0', '>=') )
+			if ( version_compare( $option->response[ $this->plugin_name ]->new_version, '1.4.0', '>=' ) )
 				return $option;
 
-			if( isset($option->response[ $this->plugin_name ]) ){
+			if ( isset( $option->response[ $this->plugin_name ] ) ) {
 				//Clear it''s download link
 				$option->response[ $this->plugin_name ]->package = '';
 
 				//Add a notice message
-				if ($this->add_PHP5_notice == false){
+				// if ( $this->add_PHP5_notice == false ) {
+				// 	add_action( "in_plugin_update_message-$this->plugin_name",
+				// 		function () {
+				// 			echo '<br /><span style="color:red">Please update to PHP5.2 as soon as possible, the plugin is not tested under PHP4 anymore</span>';
+				// 		}
+				// 	);
+				// 	$this->add_PHP5_notice = true;
+				// }
+				if ( $this->add_PHP7_notice == false ) {
 					add_action( "in_plugin_update_message-$this->plugin_name",
 						function () {
-							echo '<br /><span style="color:red">Please update to PHP5.2 as soon as possible, the plugin is not tested under PHP4 anymore</span>';
+							echo '<br /><span style="color:red">Please update to PHP7.3 as soon as possible, the plugin is not tested under PHP5 anymore</span>';
 						}
 					);
-					$this->add_PHP5_notice = true;
+					$this->add_PHP7_notice = true;
 				}
 			}
 			return $option;
 		}
 
 		// Add links to Plugins page
-		function add_plugin_links($links, $file) {
+		function add_plugin_links( $links, $file ) {
 
 			if ( $file == $this->plugin_name ) {
-				$plugin_name = plugin_basename(NGGALLERY_ABSPATH);
-				$links[] = "<a href='admin.php?page={$plugin_name}'>" . __('Overview', 'nggallery') . '</a>';
-				$links[] = '<a href="http://wordpress.org/support/plugin/nextcellent-gallery-nextgen-legacy">' . __('Get help', 'nggallery') . '</a>';
+				$plugin_name = plugin_basename( NGGALLERY_ABSPATH );
+				$links[] = "<a href='admin.php?page={$plugin_name}'>" . __( 'Overview', 'nggallery' ) . '</a>';
+				$links[] = '<a href="http://wordpress.org/support/plugin/nextcellent-gallery-nextgen-legacy">' . __( 'Get help', 'nggallery' ) . '</a>';
 				//$links[] = '<a href="">' . __('Contribute', 'nggallery') . '</a>';
 			}
 			return $links;
@@ -739,35 +769,38 @@ if (!class_exists('nggLoader')) {
 
 			// If test-head query var exists hook into wp_head
 			if ( isset( $_GET['test-head'] ) )
-				add_action( 'wp_head', function () { echo '<!--wp_head-->'; }, 99999 );
+				add_action( 'wp_head', function () {
+					echo '<!--wp_head-->';
+				}, 99999 );
 
 			// If test-footer query var exists hook into wp_footer
 			if ( isset( $_GET['test-footer'] ) )
-				add_action( 'wp_footer', function () { echo '<!--wp_footer-->'; }, 99999 );
+				add_action( 'wp_footer', function () {
+					echo '<!--wp_footer-->';
+				}, 99999 );
 		}
 
 		/**
-		* Handles upload requests
-		*/
-		function handle_upload_request()
-		{
-			if (isset($_GET['nggupload'])) {
-				require_once(implode(DIRECTORY_SEPARATOR, array(
+		 * Handles upload requests
+		 */
+		function handle_upload_request() {
+			if ( isset( $_GET['nggupload'] ) ) {
+				require_once ( implode( DIRECTORY_SEPARATOR, array(
 					NGGALLERY_ABSPATH,
 					'admin',
 					'upload.php'
-				)));
+				) ) );
 				throw new E_Clean_Exit();
 			}
 		}
 
 		/**
-		* Handles clean exits gracefully. Re-raises anything else
-		* @param Exception $ex
-		*/
-		function exception_handler($ex)
-		{
-			if (get_class($ex) != 'E_Clean_Exit') throw $ex;
+		 * Handles clean exits gracefully. Re-raises anything else
+		 * @param Exception $ex
+		 */
+		function exception_handler( $ex ) {
+			if ( get_class( $ex ) != 'E_Clean_Exit' )
+				throw $ex;
 		}
 	}
 
@@ -784,41 +817,43 @@ if (!class_exists('nggLoader')) {
  */
 class check_nextgen {
 
-    static function nextgen_activated() {
+	static function nextgen_activated() {
 
-        if (!function_exists('get_plugin_data')) {
-            include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-        }
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
 
-        $nextcellent_plugin= plugin_basename(__FILE__);
+		$nextcellent_plugin = plugin_basename( __FILE__ );
 
-        $plugin_list = get_plugins();
+		$plugin_list = get_plugins();
 
-        //Loop over all the active plugins
-        foreach ($plugin_list as $plugin_file=>$plugin_data) {
-            //If we found nextcellent, skip it
-            if ($plugin_file==$nextcellent_plugin) continue;
-            //If the plugin is deactivated ignore it.
-            if (!is_plugin_active($plugin_file)) continue;
-            if (strpos($plugin_file,'nggallery.php')!==FALSE) {
-                $version = $plugin_data['Version'];
-                //Check if effectively could be nextgen
-                $is_nextgen= (strpos(strtolower($plugin_data['Name']),'nextgen') !==FALSE);
-                if ($is_nextgen) { //is it?
-                    //Yes, display msg on admin console
-                    add_action(
-                        'admin_notices',
-                        function () {
-                            echo '<div id="message" class="error"><p><strong>' . __('Sorry, NextCellent Gallery is deactivated: NextGEN version ' . $version . ' was detected. Deactivate it before running NextCellent!', 'nggallery') . '</strong></p></div>';
-                        }
-                    );
-                    //Deactivate this plugin
-                    deactivate_plugins($nextcellent_plugin);
-                    return true;
-               }
-            }
-        }
-        return false;
-    }
+		//Loop over all the active plugins
+		foreach ( $plugin_list as $plugin_file => $plugin_data ) {
+			//If we found nextcellent, skip it
+			if ( $plugin_file == $nextcellent_plugin )
+				continue;
+			//If the plugin is deactivated ignore it.
+			if ( ! is_plugin_active( $plugin_file ) )
+				continue;
+			if ( strpos( $plugin_file, 'nggallery.php' ) !== FALSE ) {
+				$version = $plugin_data['Version'];
+				//Check if effectively could be nextgen
+				$is_nextgen = ( strpos( strtolower( $plugin_data['Name'] ), 'nextgen' ) !== FALSE );
+				if ( $is_nextgen ) { //is it?
+					//Yes, display msg on admin console
+					add_action(
+						'admin_notices',
+						function () {
+							echo '<div id="message" class="error"><p><strong>' . __( 'Sorry, NextCellent Gallery is deactivated: NextGEN version ' . $version . ' was detected. Deactivate it before running NextCellent!', 'nggallery' ) . '</strong></p></div>';
+						}
+					);
+					//Deactivate this plugin
+					deactivate_plugins( $nextcellent_plugin );
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 }
 ?>

--- a/nggfunctions.php
+++ b/nggfunctions.php
@@ -4,7 +4,9 @@ class NGG_Not_Found extends Exception {
 
 }
 
-if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('You are not allowed to call this page directly.'); }
+if ( preg_match( '#' . basename( __FILE__ ) . '#', $_SERVER['PHP_SELF'] ) ) {
+	die( 'You are not allowed to call this page directly.' );
+}
 
 /**
  * Return a slideshow.
@@ -15,404 +17,408 @@ if(preg_match('#' . basename(__FILE__) . '#', $_SERVER['PHP_SELF'])) { die('You 
  * @return string The HTML code for the slideshow.
  * @throws NGG_Not_Found
  */
-function nggShowSlideshow( $galleryID, $args = null) {
+function nggShowSlideshow( $galleryID, $args = null ) {
 
-    global $slideCounter, $nggdb, $ngg;
-    $ngg_options = $ngg->options;
+	global $slideCounter, $nggdb, $ngg;
+	$ngg_options = $ngg->options;
 
-    // remove media file from RSS feed
-    if ( is_feed() ) {
-        $out = '[' . nggGallery::i18n($ngg_options['galTextSlide']) . ']';
-        return $out;
-    }
+	// remove media file from RSS feed
+	if ( is_feed() ) {
+		$out = '[' . nggGallery::i18n( $ngg_options['galTextSlide'] ) . ']';
+		return $out;
+	}
 
-    // we need to know the current page id
-    if ( !get_the_ID() ) {
-        $current_page = rand( 5, 15 );
-    } else {
-        $current_page = get_the_ID();
-    }
+	// we need to know the current page id
+	if ( ! get_the_ID() ) {
+		$current_page = rand( 5, 15 );
+	} else {
+		$current_page = get_the_ID();
+	}
 	// look for a other slideshow instance
-	if ( !isset( $slideCounter ) ) $slideCounter = 0;
+	if ( ! isset( $slideCounter ) )
+		$slideCounter = 0;
 
-    // create unique anchor
-    $anchor = 'ngg_slideshow' . $galleryID . $current_page . $slideCounter++;
+	// create unique anchor
+	$anchor = 'ngg_slideshow' . $galleryID . $current_page . $slideCounter++;
 
-    $param = wp_parse_args( $args, array(
-        'width'     => $ngg_options['irWidth'],
-        'height'    => $ngg_options['irHeight'],
-        'class'     => 'ngg-slideshow',
-        'anchor'    => 'ngg_slideshow' . $galleryID . $current_page . $slideCounter++,
-        'time'      => $ngg_options['irRotatetime']*1000,
-        'loop'      => $ngg_options['irLoop'],
-        'drag'      => $ngg_options['irDrag'],
-        'nav'       => $ngg_options['irNavigation'],
-        'nav_dots'  => $ngg_options['irNavigationDots'],
-        'autoplay'  => $ngg_options['irAutoplay'],
-        'hover'     => $ngg_options['irAutoplayHover'],
-        'effect'    => $ngg_options['slideFx'],
-        'click'     => $ngg_options['irClick'],
-        'autodim'   => $ngg_options['irAutoDim'],
-        'number'    => $ngg_options['irNumber']
-    ));
+	$param = wp_parse_args( $args, array(
+		'width' => $ngg_options['irWidth'],
+		'height' => $ngg_options['irHeight'],
+		'class' => 'ngg-slideshow',
+		'anchor' => 'ngg_slideshow' . $galleryID . $current_page . $slideCounter++,
+		'time' => $ngg_options['irRotatetime'] * 1000,
+		'loop' => $ngg_options['irLoop'],
+		'drag' => $ngg_options['irDrag'],
+		'nav' => $ngg_options['irNavigation'],
+		'nav_dots' => $ngg_options['irNavigationDots'],
+		'autoplay' => $ngg_options['irAutoplay'],
+		'hover' => $ngg_options['irAutoplayHover'],
+		'effect' => $ngg_options['slideFx'],
+		'click' => $ngg_options['irClick'],
+		'autodim' => $ngg_options['irAutoDim'],
+		'number' => $ngg_options['irNumber']
+	) );
 
-    /**
-     * Edit the args for a NextCellent slideshow.
-     *
-     * @since 1.9.25beta2
-     *
-     * @param array $args {
-     *     All the arguments.
-     *
-     *     @var int $width The width of the slideshow. Will be ignored if $autodim is true.
-     *     @var int $height The height of the slideshow. Will be ignored if $autodim is set.
-     *     @var string $class The class that will be assigned to the div containing the slideshow.
-     *     @var string $anchor The id that will be assigned to the div containing the slideshow.
-     *     @var int $time The duration of a slide in milliseconds.
-     *     @var bool $loop If the slideshow should loop.
-     *     @var bool $drag If the user can drag through the images.
-     *     @var bool $nav If the navigation elements (next/previous) should be shown.
-     *     @var bool $nav_dots If the navigation dots should be shown.
-     *     @var bool $autoplay If the slideshow should automatically start.
-     *     @var bool $hover If the slideshow should pause when hovering over it.
-     *     @var string $effect With which effect the slideshow should use.
-     *     @var bool $click If the slideshow should go to the next image on click.
-     *     @var bool $autodim If the slideshow should automatically fit (responsive). When true, this will
-     *                        ignore the $width and $height.
-     *     @var int $number The number of images that should be displayed. Only works when the gallery ID
-     *                      is set to random or recent.
-     * }
-     */
-    $param = apply_filters( 'ngg_slideshow_args', $param );
+	/**
+	 * Edit the args for a NextCellent slideshow.
+	 *
+	 * @since 1.9.25beta2
+	 *
+	 * @param array $args {
+	 *     All the arguments.
+	 *
+	 *     @var int $width The width of the slideshow. Will be ignored if $autodim is true.
+	 *     @var int $height The height of the slideshow. Will be ignored if $autodim is set.
+	 *     @var string $class The class that will be assigned to the div containing the slideshow.
+	 *     @var string $anchor The id that will be assigned to the div containing the slideshow.
+	 *     @var int $time The duration of a slide in milliseconds.
+	 *     @var bool $loop If the slideshow should loop.
+	 *     @var bool $drag If the user can drag through the images.
+	 *     @var bool $nav If the navigation elements (next/previous) should be shown.
+	 *     @var bool $nav_dots If the navigation dots should be shown.
+	 *     @var bool $autoplay If the slideshow should automatically start.
+	 *     @var bool $hover If the slideshow should pause when hovering over it.
+	 *     @var string $effect With which effect the slideshow should use.
+	 *     @var bool $click If the slideshow should go to the next image on click.
+	 *     @var bool $autodim If the slideshow should automatically fit (responsive). When true, this will
+	 *                        ignore the $width and $height.
+	 *     @var int $number The number of images that should be displayed. Only works when the gallery ID
+	 *                      is set to random or recent.
+	 * }
+	 */
+	$param = apply_filters( 'ngg_slideshow_args', $param );
 
 	//Get the images
-	if ($galleryID == 'random') {
+	if ( $galleryID == 'random' ) {
 		$images = nggdb::get_random_images( $param['number'] ); //random images
-	} elseif ($galleryID == 'recent') {
-		$images = nggdb::find_last_images(0 , $param['number'] ); //the last images
+	} elseif ( $galleryID == 'recent' ) {
+		$images = nggdb::find_last_images( 0, $param['number'] ); //the last images
 	} else {
-		$images = $nggdb->get_gallery($galleryID); //a gallery
+		$images = $nggdb->get_gallery( $galleryID ); //a gallery
 	}
 
-    if( empty($images) ) {
-        throw new NGG_Not_Found( __( "The gallery was not found.", 'nggallery' ) );
-    }
+	if ( empty( $images ) ) {
+		throw new NGG_Not_Found( __( "The gallery was not found.", 'nggallery' ) );
+	}
 
-    $out  = '<div class="slideshow"><div id="' . $param['anchor'] . '" class="' . $param['class'] . ' owl-carousel owl-theme" ';
+	$out = '<div class="slideshow"><div id="' . $param['anchor'] . '" class="' . $param['class'] . ' owl-carousel owl-theme" ';
 
-    if( !$param['autodim'] ) {
-        $out .=  'style="max-width: ' .  $param['width'] . 'px; max-height: ' . $param['height'] . 'px;"';
-    }
-    $out .= '>';
-	
+	if ( ! $param['autodim'] ) {
+		$out .= 'style="max-width: ' . $param['width'] . 'px; max-height: ' . $param['height'] . 'px;"';
+	}
+	$out .= '>';
+
 	foreach ( $images as $image ) {
-        if( !$param['autodim'] ) {
-            $out .=  '<img src="' . $image->imageURL .'" alt="' . $image->alttext . '" style="max-width: ' .  $param['width'] . 'px; max-height: ' . $param['height'] . 'px; width: auto; height:auto; margin:auto">';
-        } else {
-            $out .= '<img src="' . $image->imageURL .'" alt="' . $image->alttext . '" >';
-        }
+		if ( ! $param['autodim'] ) {
+			$out .= '<img src="' . $image->imageURL . '" alt="' . $image->alttext . '" style="max-width: ' . $param['width'] . 'px; max-height: ' . $param['height'] . 'px; width: auto; height:auto; margin:auto">';
+		} else {
+			$out .= '<img src="' . $image->imageURL . '" alt="' . $image->alttext . '" >';
+		}
 	}
-	
-    $out .= '</div></div>'."\n";
-    $out .= "\n".'<script type="text/javascript">';
+
+	$out .= '</div></div>' . "\n";
+	$out .= "\n" . '<script type="text/javascript">';
 	$out .= "jQuery(document).ready(function($) {
 			var owl = $('#" . $param['anchor'] . "');
 			owl.owlCarousel({
 				items: 1,
-				autoHeight: " . var_export($param['autodim'], true) . ",";
+				autoHeight: " . var_export( $param['autodim'], true ) . ",";
 	if ( $param['nav'] ) {
 		$out .= "nav: true,
-				navText: ['" . __('previous', 'nggallery') ."','" . __('next', 'nggallery') ."'],";
+				navText: ['" . __( 'previous', 'nggallery' ) . "','" . __( 'next', 'nggallery' ) . "'],";
 	}
-	$out .=    "
-	            dots: " .  var_export($param['nav_dots'], true) .",
-	            autoplay: ". var_export($param['autoplay'], true) .",
+	$out .= "
+	            dots: " . var_export( $param['nav_dots'], true ) . ",
+	            autoplay: " . var_export( $param['autoplay'], true ) . ",
 				margin: 10,
 				autoplayTimeout: " . $param['time'] . ",
-				autoplayHoverPause: " . var_export($param['hover'], true) . ",
+				autoplayHoverPause: " . var_export( $param['hover'], true ) . ",
 				animateIn: '" . $param['effect'] . "',
 				animateOut: 'fadeOut',
-				loop: " . var_export($param['loop'], true) . ",
-				mouseDrag: " . var_export($param['drag'], true) .",
-				touchDrag: " . var_export($param['drag'], true) . "
+				loop: " . var_export( $param['loop'], true ) . ",
+				mouseDrag: " . var_export( $param['drag'], true ) . ",
+				touchDrag: " . var_export( $param['drag'], true ) . "
 			});";
-    if ( $param['click'] ) {
-        $out .= "\n" . "$('.owl-item').click( function () {
+	if ( $param['click'] ) {
+		$out .= "\n" . "$('.owl-item').click( function () {
                     owl.trigger( 'next.owl.carousel' );
                 } );";
-    }
+	}
 	$out .= "});";
 
-    $out .= "\n" . '</script>';
+	$out .= "\n" . '</script>';
 
-    return $out;
+	return $out;
 }
 
 /**
  * nggShowGallery() - return a gallery
  *
  * @access public
- * @param int | string ID or slug from a gallery
+ * @param int|string ID or slug from a gallery
  * @param string $template (optional) name for a template file, look for gallery-$template
  * @param int $images (optional) number of images per page
- * @return the content
+ * @return string content
  */
 function nggShowGallery( $galleryID, $template = '', $images = false ) {
 
-    global $nggRewrite,$nggdb;
+	global $nggRewrite, $nggdb;
 
-    $ngg_options = nggGallery::get_option('ngg_options');
+	$ngg_options = nggGallery::get_option( 'ngg_options' );
 
-    //Set sort order value, if not used (upgrade issue)
-    $ngg_options['galSort'] = ($ngg_options['galSort']) ? $ngg_options['galSort'] : 'pid';
-    $ngg_options['galSortDir'] = ($ngg_options['galSortDir'] == 'DESC') ? 'DESC' : 'ASC';
+	//Set sort order value, if not used (upgrade issue)
+	$ngg_options['galSort'] = ( $ngg_options['galSort'] ) ? $ngg_options['galSort'] : 'pid';
+	$ngg_options['galSortDir'] = ( $ngg_options['galSortDir'] == 'DESC' ) ? 'DESC' : 'ASC';
 
-    // get gallery values
-    //TODO: Use pagination limits here to reduce memory needs
-    //20130106:shouldn't call it statically if is not...
-    //$picturelist = nggdb::get_gallery($galleryID, $ngg_options['galSort'], $ngg_options['galSortDir']);
-    //array of nggImage objects returned
-    $picturelist = $nggdb->get_gallery($galleryID, $ngg_options['galSort'], $ngg_options['galSortDir']);
+	// get gallery values
+	//TODO: Use pagination limits here to reduce memory needs
+	//20130106:shouldn't call it statically if is not...
+	//$picturelist = nggdb::get_gallery($galleryID, $ngg_options['galSort'], $ngg_options['galSortDir']);
+	//array of nggImage objects returned
+	$picturelist = $nggdb->get_gallery( $galleryID, $ngg_options['galSort'], $ngg_options['galSortDir'] );
 
-    if ( !$picturelist )
-        return __('[Gallery not found]','nggallery');
+	if ( ! $picturelist )
+		return __( '[Gallery not found]', 'nggallery' );
 
-    // If we have we slug instead the id, we should extract the ID from the first image
-    if ( !is_numeric($galleryID) ) {
-        $first_image = current($picturelist);
-        $galleryID = intval($first_image->gid);
-    }
+	// If we have we slug instead the id, we should extract the ID from the first image
+	if ( ! is_numeric( $galleryID ) ) {
+		$pictureIterator = ( new ArrayObject( $picturelist ) )->getIterator();
+		$first_image = $pictureIterator->current();
+		$galleryID = intval( $first_image->gid );
+	}
 
-    // $_GET from wp_query
-    $show    = get_query_var('show');
-    $pid     = get_query_var('pid');
-    $pageid  = get_query_var('pageid');
+	// $_GET from wp_query
+	$show = get_query_var( 'show' );
+	$pid = get_query_var( 'pid' );
+	$pageid = get_query_var( 'pageid' );
 
-    // set $show if slideshow first
-    if ( empty( $show ) AND ($ngg_options['galShowOrder'] == 'slide')) {
-        if ( is_home() )
-            $pageid = get_the_ID();
+	// set $show if slideshow first
+	if ( empty( $show ) and ( $ngg_options['galShowOrder'] == 'slide' ) ) {
+		if ( is_home() )
+			$pageid = get_the_ID();
 
-        $show = 'slide';
-    }
+		$show = 'slide';
+	}
 
-    // filter to call up the imagebrowser instead of the gallery
-    // use in your theme : add_action( 'ngg_show_imagebrowser_first', function () { return true; } );
-    if ( apply_filters('ngg_show_imagebrowser_first', false, $galleryID ) && $show != 'thumbnails' )  {
-        $out = nggShowImageBrowser( $galleryID, $template );
-        return $out;
-    }
+	// filter to call up the imagebrowser instead of the gallery
+	// use in your theme : add_action( 'ngg_show_imagebrowser_first', function () { return true; } );
+	if ( apply_filters( 'ngg_show_imagebrowser_first', false, $galleryID ) && $show != 'thumbnails' ) {
+		$out = nggShowImageBrowser( $galleryID, $template );
+		return $out;
+	}
 
-    // go on only on this page
-    if ( !is_home() || $pageid == get_the_ID() ) {
+	// go on only on this page
+	if ( ! is_home() || $pageid == get_the_ID() ) {
 
-        // 1st look for ImageBrowser link
-        if ( !empty($pid) && $ngg_options['galImgBrowser'] && ($template != 'carousel') )  {
-            $out = nggShowImageBrowser( $galleryID, $template );
-            return $out;
-        }
+		// 1st look for ImageBrowser link
+		if ( ! empty( $pid ) && $ngg_options['galImgBrowser'] && ( $template != 'carousel' ) ) {
+			$out = nggShowImageBrowser( $galleryID, $template );
+			return $out;
+		}
 
-        // 2nd look for slideshow
-        if ( $show == 'slide' ) {
-            $args['show'] = "gallery";
-            $out  = '<div class="ngg-galleryoverview">';
-            $out .= '<div class="slideshowlink"><a class="slideshowlink" href="' . $nggRewrite->get_permalink($args) . '">'.nggGallery::i18n($ngg_options['galTextGallery']).'</a></div>';
-            $out .= nggShowSlideshow($galleryID);
-            $out .= '</div>'."\n";
-            $out .= '<div class="ngg-clear"></div>'."\n";
-            return $out;
-        }
-    }
+		// 2nd look for slideshow
+		if ( $show == 'slide' ) {
+			$args['show'] = "gallery";
+			$out = '<div class="ngg-galleryoverview">';
+			$out .= '<div class="slideshowlink"><a class="slideshowlink" href="' . $nggRewrite->get_permalink( $args ) . '">' . nggGallery::i18n( $ngg_options['galTextGallery'] ) . '</a></div>';
+			$out .= nggShowSlideshow( $galleryID );
+			$out .= '</div>' . "\n";
+			$out .= '<div class="ngg-clear"></div>' . "\n";
+			return $out;
+		}
+	}
 
-    // get all picture with this galleryid
-    if ( is_array($picturelist) )
-        $out = nggCreateGallery($picturelist, $galleryID, $template, $images);
+	// get all picture with this galleryid
+	if ( is_array( $picturelist ) )
+		$out = nggCreateGallery( $picturelist, $galleryID, $template, $images );
 
-    $out = apply_filters('ngg_show_gallery_content', $out, intval($galleryID));
-    return $out;
+	$out = apply_filters( 'ngg_show_gallery_content', $out, intval( $galleryID ) );
+	return $out;
 }
 
 /**
  * Build a gallery output
  *
  * @access internal
- * @param array $picturelist
+ * @param nggImage[] $picturelist
  * @param bool $galleryID, if you supply a gallery ID, you can add a slideshow link
  * @param string $template (optional) name for a template file, look for gallery-$template
  * @param int $images (optional) number of images per page
- * @return the content
+ * @return string content
  */
-function nggCreateGallery($picturelist, $galleryID = false, $template = '', $images = false) {
-    global $nggRewrite;
+function nggCreateGallery( array $picturelist, $galleryID = false, $template = '', $images = false ) {
+	global $nggRewrite;
 
-    require_once (dirname (__FILE__) . '/lib/media-rss.php');
+	require_once ( dirname( __FILE__ ) . '/lib/media-rss.php' );
 
-    $ngg_options = nggGallery::get_option('ngg_options');
+	$ngg_options = nggGallery::get_option( 'ngg_options' );
 
-    //the shortcode parameter will override global settings, TODO: rewrite this to a class
-    $ngg_options['galImages'] = ( $images === false ) ? $ngg_options['galImages'] : (int) $images;
+	//the shortcode parameter will override global settings, TODO: rewrite this to a class
+	$ngg_options['galImages'] = ( $images === false ) ? $ngg_options['galImages'] : (int) $images;
 
-    $current_pid = false;
+	$current_pid = false;
 
-    // $_GET from wp_query
-    $nggpage  = get_query_var('nggpage');
-    $pageid   = get_query_var('pageid');
-    $pid      = get_query_var('pid');
+	// $_GET from wp_query
+	$nggpage = get_query_var( 'nggpage' );
+	$pageid = get_query_var( 'pageid' );
+	$pid = get_query_var( 'pid' );
 
-    // in case of permalinks the pid is a slug, we need the id
-    if( !is_numeric($pid) && !empty($pid) ) {
-        $picture = nggdb::find_image($pid);
-        $pid = $picture->pid;
-    }
+	// in case of permalinks the pid is a slug, we need the id
+	if ( ! is_numeric( $pid ) && ! empty( $pid ) ) {
+		$picture = nggdb::find_image( $pid );
+		$pid = $picture->pid;
+	}
 
-    // we need to know the current page id
-    $current_page = (get_the_ID() == false) ? 0 : get_the_ID();
+	// we need to know the current page id
+	$current_page = ( get_the_ID() == false ) ? 0 : get_the_ID();
 
-    if ( !is_array($picturelist) )
-        $picturelist = array($picturelist);
+	if ( ! is_array( $picturelist ) )
+		$picturelist = array( $picturelist );
 
-    // Populate galleries values from the first image
-    $first_image = current($picturelist);
-    $gallery = new stdclass;
-    $gallery->ID = (int) $galleryID;
-    $gallery->show_slideshow = false;
-    $gallery->show_piclens = false;
-    $gallery->name = stripslashes ( $first_image->name  );
-    $gallery->title = stripslashes( $first_image->title );
-    $gallery->description = html_entity_decode(stripslashes( $first_image->galdesc));
-    $gallery->pageid = $first_image->pageid;
-    $gallery->anchor = 'ngg-gallery-' . $galleryID . '-' . $current_page;
-    reset($picturelist);
+	$pictureIterator = ( new ArrayObject( $picturelist ) )->getIterator();
 
-    $maxElement  = $ngg_options['galImages'];
-    $thumbwidth  = $ngg_options['thumbwidth'];
-    $thumbheight = $ngg_options['thumbheight'];
+	// Populate galleries values from the first image
+	$first_image = $pictureIterator->current();
+	$gallery = new stdclass;
+	$gallery->ID = (int) $galleryID;
+	$gallery->show_slideshow = false;
+	$gallery->show_piclens = false;
+	$gallery->name = stripslashes( $first_image->name );
+	$gallery->title = stripslashes( $first_image->title );
+	$gallery->description = html_entity_decode( stripslashes( $first_image->galdesc ) );
+	$gallery->pageid = $first_image->pageid;
+	$gallery->anchor = 'ngg-gallery-' . $galleryID . '-' . $current_page;
+	$pictureIterator->rewind();
 
-    // fixed width if needed
-    $gallery->columns    = intval($ngg_options['galColumns']);
-    $gallery->imagewidth = ($gallery->columns > 0) ? 'style="width:' . floor(100/$gallery->columns) . '%;"' : '';
+	$maxElement = $ngg_options['galImages'];
+	$thumbwidth = $ngg_options['thumbwidth'];
+	$thumbheight = $ngg_options['thumbheight'];
 
-    // obsolete in V1.4.0, but kept for compat reason
+	// fixed width if needed
+	$gallery->columns = intval( $ngg_options['galColumns'] );
+	$gallery->imagewidth = ( $gallery->columns > 0 ) ? 'style="width:' . floor( 100 / $gallery->columns ) . '%;"' : '';
+
+	// obsolete in V1.4.0, but kept for compat reason
 	// pre set thumbnail size, from the option, later we look for meta data.
-    $thumbsize = ($ngg_options['thumbfix']) ? $thumbsize = 'width="' . $thumbwidth . '" height="'.$thumbheight . '"' : '';
+	$thumbsize = ( $ngg_options['thumbfix'] ) ? $thumbsize = 'width="' . $thumbwidth . '" height="' . $thumbheight . '"' : '';
 
-    // show slideshow link
-    if ($galleryID) {
-        if ($ngg_options['galShowSlide']) {
-            $gallery->show_slideshow = true;
-            $gallery->slideshow_link = $nggRewrite->get_permalink(array ( 'show' => 'slide') );
-            $gallery->slideshow_link_text = nggGallery::i18n($ngg_options['galTextSlide']);
-        }
-
-        if ($ngg_options['usePicLens']) {
-            $gallery->show_piclens = true;
-            $gallery->piclens_link = "javascript:PicLensLite.start({feedUrl:'" . htmlspecialchars( nggMediaRss::get_gallery_mrss_url($gallery->ID) ) . "'});";
-        }
-    }
-
-    // check for page navigation
-    if ($maxElement > 0) {
-
-        if ( !is_home() || $pageid == $current_page )
-            $page = ( !empty( $nggpage ) ) ? (int) $nggpage : 1;
-        else
-            $page = 1;
-
-        $start = $offset = ( $page - 1 ) * $maxElement;
-
-        $total = count($picturelist);
-
-		//we can work with display:hidden for some javascript effects
-        if (!$ngg_options['galHiddenImg']){
-	        // remove the element if we didn't start at the beginning
-	        if ($start > 0 )
-	            array_splice($picturelist, 0, $start);
-
-	        // return the list of images we need
-	        array_splice($picturelist, $maxElement);
-        }
-
-        $nggNav = new nggNavigation;
-        $navigation = $nggNav->create_navigation($page, $total, $maxElement);
-    } else {
-        $navigation = '<div class="ngg-clear"></div>';
-    }
-
-    //we cannot use the key as index, cause it's filled with the pid
-	$index = 0;
-    foreach ($picturelist as $key => $picture) {
-
-		//needed for hidden images (THX to Sweigold for the main idea at : http://wordpress.org/support/topic/228743/ )
-		$picturelist[$key]->hidden = false;
-		$picturelist[$key]->style  = $gallery->imagewidth;
-
-		if ($maxElement > 0 && $ngg_options['galHiddenImg']) {
-	  		if ( ($index < $start) || ($index > ($start + $maxElement -1)) ){
-				//FZSM Check: dinamically created nggImage doesn't have this properties
-                $picturelist[$key]->hidden = true;
-				$picturelist[$key]->style  = ($gallery->columns > 0) ? 'style="width:' . floor(100/$gallery->columns) . '%;display: none;"' : 'style="display: none;"';
-			}
-  			$index++;
+	// show slideshow link
+	if ( $galleryID ) {
+		if ( $ngg_options['galShowSlide'] ) {
+			$gallery->show_slideshow = true;
+			$gallery->slideshow_link = $nggRewrite->get_permalink( array( 'show' => 'slide' ) );
+			$gallery->slideshow_link_text = nggGallery::i18n( $ngg_options['galTextSlide'] );
 		}
 
-        // get the effect code
-        if ($galleryID)
-            $thumbcode = ($ngg_options['galImgBrowser']) ? '' : $picture->get_thumbcode('set_' . $galleryID);
-        else
-            $thumbcode = ($ngg_options['galImgBrowser']) ? '' : $picture->get_thumbcode(get_the_title());
+		if ( $ngg_options['usePicLens'] ) {
+			$gallery->show_piclens = true;
+			$gallery->piclens_link = "javascript:PicLensLite.start({feedUrl:'" . htmlspecialchars( nggMediaRss::get_gallery_mrss_url( $gallery->ID ) ) . "'});";
+		}
+	}
 
-        // create link for imagebrowser and other effects
-        $args ['nggpage'] = empty($nggpage) || ($template != 'carousel') ? false : $nggpage;  // only needed for carousel mode
-        $args ['pid']     = ($ngg_options['usePermalinks']) ? $picture->image_slug : $picture->pid;
-        $picturelist[$key]->pidlink = $nggRewrite->get_permalink( $args );
+	// check for page navigation
+	if ( $maxElement > 0 ) {
 
-        // generate the thumbnail size if the meta data available
-        if ( isset($picturelist[$key]->meta_data['thumbnail']) && is_array ($size = $picturelist[$key]->meta_data['thumbnail']) )
-        	$thumbsize = 'width="' . $size['width'] . '" height="' . $size['height'] . '"';
+		if ( ! is_home() || $pageid == $current_page )
+			$page = ( ! empty( $nggpage ) ) ? (int) $nggpage : 1;
+		else
+			$page = 1;
 
-        // choose link between imagebrowser or effect
-        $link = ($ngg_options['galImgBrowser']) ? $picturelist[$key]->pidlink : $picture->imageURL;
-        // bad solution : for now we need the url always for the carousel, should be reworked in the future
-        $picturelist[$key]->url = $picture->imageURL;
-        // add a filter for the link
-        $picturelist[$key]->imageURL = apply_filters('ngg_create_gallery_link', $link, $picture);
-        $picturelist[$key]->thumbnailURL = $picture->thumbURL;
-        $picturelist[$key]->size = $thumbsize;
-        $picturelist[$key]->thumbcode = $thumbcode;
-        $picturelist[$key]->caption = ( empty($picture->description) ) ? '&nbsp;' : html_entity_decode ( stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) );
-        $picturelist[$key]->description = ( empty($picture->description) ) ? ' ' : htmlspecialchars ( stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) );
-        $picturelist[$key]->alttext = ( empty($picture->alttext) ) ?  ' ' : htmlspecialchars ( stripslashes(nggGallery::i18n($picture->alttext, 'pic_' . $picture->pid . '_alttext')) );
+		$start = $offset = ( $page - 1 ) * $maxElement;
 
-        // filter to add custom content for the output
-        $picturelist[$key] = apply_filters('ngg_image_object', $picturelist[$key], $picture->pid);
+		$total = count( $picturelist );
 
-        //check if $pid is in the array
-        if ($picture->pid == $pid)
-            $current_pid = $picturelist[$key];
-    }
-    reset($picturelist);
+		//we can work with display:hidden for some javascript effects
+		if ( ! $ngg_options['galHiddenImg'] ) {
+			// remove the element if we didn't start at the beginning
+			if ( $start > 0 )
+				array_splice( $picturelist, 0, $start );
 
-    //for paged galleries, take the first image in the array if it's not in the list
-    $current_pid = ( empty($current_pid) ) ? current( $picturelist ) : $current_pid;
+			// return the list of images we need
+			array_splice( $picturelist, $maxElement );
+		}
 
-    // look for gallery-$template.php or pure gallery.php
-    $filename = ( empty($template) ) ? 'gallery' : 'gallery-' . $template;
+		$nggNav = new nggNavigation;
+		$navigation = $nggNav->create_navigation( $page, $total, $maxElement );
+	} else {
+		$navigation = '<div class="ngg-clear"></div>';
+	}
 
-    //filter functions for custom addons
-    $gallery     = apply_filters( 'ngg_gallery_object', $gallery, $galleryID );
-    $picturelist = apply_filters( 'ngg_picturelist_object', $picturelist, $galleryID );
+	//we cannot use the key as index, cause it's filled with the pid
+	$index = 0;
+	foreach ( $picturelist as $key => $picture ) {
 
-    //additional navigation links
-    $next = ( empty($nggNav->next) ) ? false : $nggNav->next;
-    $prev = ( empty($nggNav->prev) ) ? false : $nggNav->prev;
+		//needed for hidden images (THX to Sweigold for the main idea at : http://wordpress.org/support/topic/228743/ )
+		$picturelist[ $key ]->hidden = false;
+		$picturelist[ $key ]->style = $gallery->imagewidth;
 
-    // create the output
-    $out = nggGallery::capture( $filename, array ('gallery' => $gallery, 'images' => $picturelist, 'pagination' => $navigation, 'current' => $current_pid, 'next' => $next, 'prev' => $prev) );
+		if ( $maxElement > 0 && $ngg_options['galHiddenImg'] ) {
+			if ( ( $index < $start ) || ( $index > ( $start + $maxElement - 1 ) ) ) {
+				//FZSM Check: dinamically created nggImage doesn't have this properties
+				$picturelist[ $key ]->hidden = true;
+				$picturelist[ $key ]->style = ( $gallery->columns > 0 ) ? 'style="width:' . floor( 100 / $gallery->columns ) . '%;display: none;"' : 'style="display: none;"';
+			}
+			$index++;
+		}
 
-    // apply a filter after the output
-    $out = apply_filters('ngg_gallery_output', $out, $picturelist);
+		// get the effect code
+		if ( $galleryID )
+			$thumbcode = ( $ngg_options['galImgBrowser'] ) ? '' : $picture->get_thumbcode( 'set_' . $galleryID );
+		else
+			$thumbcode = ( $ngg_options['galImgBrowser'] ) ? '' : $picture->get_thumbcode( get_the_title() );
 
-    return $out;
+		// create link for imagebrowser and other effects
+		$args['nggpage'] = empty( $nggpage ) || ( $template != 'carousel' ) ? false : $nggpage;  // only needed for carousel mode
+		$args['pid'] = ( $ngg_options['usePermalinks'] ) ? $picture->image_slug : $picture->pid;
+		$picturelist[ $key ]->pidlink = $nggRewrite->get_permalink( $args );
+
+		// generate the thumbnail size if the meta data available
+		if ( isset( $picturelist[ $key ]->meta_data['thumbnail'] ) && is_array( $size = $picturelist[ $key ]->meta_data['thumbnail'] ) )
+			$thumbsize = 'width="' . $size['width'] . '" height="' . $size['height'] . '"';
+
+		// choose link between imagebrowser or effect
+		$link = ( $ngg_options['galImgBrowser'] ) ? $picturelist[ $key ]->pidlink : $picture->imageURL;
+		// bad solution : for now we need the url always for the carousel, should be reworked in the future
+		$picturelist[ $key ]->url = $picture->imageURL;
+		// add a filter for the link
+		$picturelist[ $key ]->imageURL = apply_filters( 'ngg_create_gallery_link', $link, $picture );
+		$picturelist[ $key ]->thumbnailURL = $picture->thumbURL;
+		$picturelist[ $key ]->size = $thumbsize;
+		$picturelist[ $key ]->thumbcode = $thumbcode;
+		$picturelist[ $key ]->caption = ( empty( $picture->description ) ) ? '&nbsp;' : html_entity_decode( stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) );
+		$picturelist[ $key ]->description = ( empty( $picture->description ) ) ? ' ' : htmlspecialchars( stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) );
+		$picturelist[ $key ]->alttext = ( empty( $picture->alttext ) ) ? ' ' : htmlspecialchars( stripslashes( nggGallery::i18n( $picture->alttext, 'pic_' . $picture->pid . '_alttext' ) ) );
+
+		// filter to add custom content for the output
+		$picturelist[ $key ] = apply_filters( 'ngg_image_object', $picturelist[ $key ], $picture->pid );
+
+		//check if $pid is in the array
+		if ( $picture->pid == $pid )
+			$current_pid = $picturelist[ $key ];
+	}
+	$pictureIterator->rewind();
+
+	//for paged galleries, take the first image in the array if it's not in the list
+	$current_pid = ( empty( $current_pid ) ) ? $pictureIterator->current() : $current_pid;
+
+	// look for gallery-$template.php or pure gallery.php
+	$filename = ( empty( $template ) ) ? 'gallery' : 'gallery-' . $template;
+
+	//filter functions for custom addons
+	$gallery = apply_filters( 'ngg_gallery_object', $gallery, $galleryID );
+	$picturelist = apply_filters( 'ngg_picturelist_object', $picturelist, $galleryID );
+
+	//additional navigation links
+	$next = ( empty( $nggNav->next ) ) ? false : $nggNav->next;
+	$prev = ( empty( $nggNav->prev ) ) ? false : $nggNav->prev;
+
+	// create the output
+	$out = nggGallery::capture( $filename, array( 'gallery' => $gallery, 'images' => $picturelist, 'pagination' => $navigation, 'current' => $current_pid, 'next' => $next, 'prev' => $prev ) );
+
+	// apply a filter after the output
+	$out = apply_filters( 'ngg_gallery_output', $out, $picturelist );
+
+	return $out;
 }
 
 /**
@@ -422,58 +428,58 @@ function nggCreateGallery($picturelist, $galleryID = false, $template = '', $ima
  * @param int | string $albumID
  * @param string (optional) $template
  * @param string (optional) $gallery_template
- * @return the content
+ * @return string content
  */
-function nggShowAlbum($albumID, $template = 'extend', $gallery_template = '') {
+function nggShowAlbum( $albumID, $template = 'extend', $gallery_template = '' ) {
 
-    // $_GET from wp_query
-    $gallery  = get_query_var('gallery');
-    $album    = get_query_var('album');
+	// $_GET from wp_query
+	$gallery = get_query_var( 'gallery' );
+	$album = get_query_var( 'album' );
 
-    // in the case somebody uses the '0', it should be 'all' to show all galleries
-    $albumID  = ($albumID == 0) ? 'all' : $albumID;
+	// in the case somebody uses the '0', it should be 'all' to show all galleries
+	$albumID = ( $albumID == 0 ) ? 'all' : $albumID;
 
-    // first look for gallery variable
-    if (!empty( $gallery ))  {
+	// first look for gallery variable
+	if ( ! empty( $gallery ) ) {
 
-        // subalbum support only one instance, you can't use more of them in one post
-        //TODO: causes problems with SFC plugin, due to a second filter callback
+		// subalbum support only one instance, you can't use more of them in one post
+		//TODO: causes problems with SFC plugin, due to a second filter callback
 		global $wp_current_filter;
-        if ( isset($GLOBALS['subalbum']) || isset($GLOBALS['nggShowGallery']))
-                return;
+		if ( isset( $GLOBALS['subalbum'] ) || isset( $GLOBALS['nggShowGallery'] ) )
+			return '';
 
-        // if gallery is submit , then show the gallery instead
-        $out = nggShowGallery( $gallery, $gallery_template );
-        $GLOBALS['nggShowGallery'] = true;
+		// if gallery is submit , then show the gallery instead
+		$out = nggShowGallery( $gallery, $gallery_template );
+		$GLOBALS['nggShowGallery'] = true;
 
-        return $out;
-    }
+		return $out;
+	}
 
-    if ( (empty( $gallery )) && (isset($GLOBALS['subalbum'])) )
-        return;
+	if ( ( empty( $gallery ) ) && ( isset( $GLOBALS['subalbum'] ) ) )
+		return '';
 
-    //redirect to subalbum only one time
-    if (!empty( $album )) {
-        $GLOBALS['subalbum'] = true;
-        $albumID = $album;
-    }
+	//redirect to subalbum only one time
+	if ( ! empty( $album ) ) {
+		$GLOBALS['subalbum'] = true;
+		$albumID = $album;
+	}
 
-    // lookup in the database
-    $album = nggdb::find_album( $albumID );
+	// lookup in the database
+	$album = nggdb::find_album( $albumID );
 
-    // still no success ? , die !
-    if( !$album )
-        return __('[Album not found]','nggallery');
+	// still no success ? , die !
+	if ( ! $album )
+		return __( '[Album not found]', 'nggallery' );
 
-    // ensure to set the slug for "all" albums
-    $album->slug = ($albumID == 'all') ? $album->id : $album->slug;
+	// ensure to set the slug for "all" albums
+	$album->slug = ( $albumID == 'all' ) ? $album->id : $album->slug;
 
-    if ( is_array($album->gallery_ids) )
-        $out = nggCreateAlbum( $album->gallery_ids, $template, $album );
+	if ( is_array( $album->gallery_ids ) )
+		$out = nggCreateAlbum( $album->gallery_ids, $template, $album );
 
-    $out = apply_filters( 'ngg_show_album_content', $out, $album->id );
+	$out = apply_filters( 'ngg_show_album_content', $out, $album->id );
 
-    return $out;
+	return $out;
 }
 
 /**
@@ -483,155 +489,157 @@ function nggShowAlbum($albumID, $template = 'extend', $gallery_template = '') {
  * @param array $galleriesID
  * @param string (optional) $template name for a template file, look for album-$template
  * @param object (optional) $album result from the db
- * @return the content
+ * @return string content
  */
-function nggCreateAlbum( $galleriesID, $template = 'extend', $album = 0) {
-    global $wpdb, $nggRewrite, $nggdb, $ngg;
+function nggCreateAlbum( $galleriesID, $template = 'extend', $album = 0 ) {
+	global $wpdb, $nggRewrite, $nggdb, $ngg;
 
-    // $_GET from wp_query
-    $nggpage  = get_query_var('nggpage');
+	// $_GET from wp_query
+	$nggpage = get_query_var( 'nggpage' );
 
 	// Get options
-    $ngg_options = $ngg->options;
+	$ngg_options = $ngg->options;
 
-    //this option can currently only set via the custom fields
-    $maxElement  = (int) $ngg_options['galPagedGalleries'];
+	//this option can currently only set via the custom fields
+	$maxElement = (int) $ngg_options['galPagedGalleries'];
 
-    $sortorder = $galleriesID;
-    $galleries = array();
+	$sortorder = $galleriesID;
+	$galleries = array();
 
-    // get the galleries information
-    foreach ($galleriesID as $i => $value)
-        $galleriesID[$i] = addslashes($value);
+	// get the galleries information
+	foreach ( $galleriesID as $i => $value )
+		$galleriesID[ $i ] = addslashes( $value );
 
-    $unsort_galleries = $wpdb->get_results('SELECT * FROM '.$wpdb->nggallery.' WHERE gid IN (\''.implode('\',\'', $galleriesID).'\')', OBJECT_K);
+	$unsort_galleries = $wpdb->get_results( 'SELECT * FROM ' . $wpdb->nggallery . ' WHERE gid IN (\'' . implode( '\',\'', $galleriesID ) . '\')', OBJECT_K );
 
-    //TODO: Check this, problem exist when previewpic = 0
-    //$galleries = $wpdb->get_results('SELECT t.*, tt.* FROM '.$wpdb->nggallery.' AS t INNER JOIN '.$wpdb->nggpictures.' AS tt ON t.previewpic = tt.pid WHERE t.gid IN (\''.implode('\',\'', $galleriesID).'\')', OBJECT_K);
+	//TODO: Check this, problem exist when previewpic = 0
+	//$galleries = $wpdb->get_results('SELECT t.*, tt.* FROM '.$wpdb->nggallery.' AS t INNER JOIN '.$wpdb->nggpictures.' AS tt ON t.previewpic = tt.pid WHERE t.gid IN (\''.implode('\',\'', $galleriesID).'\')', OBJECT_K);
 
-    // get the counter values
-    $picturesCounter = $wpdb->get_results('SELECT galleryid, COUNT(*) as counter FROM '.$wpdb->nggpictures.' WHERE galleryid IN (\''.implode('\',\'', $galleriesID).'\') AND exclude != 1 GROUP BY galleryid', OBJECT_K);
-    if ( is_array($picturesCounter) ) {
-        foreach ($picturesCounter as $key => $value)
-            $unsort_galleries[$key]->counter = $value->counter;
-    }
+	// get the counter values
+	$picturesCounter = $wpdb->get_results( 'SELECT galleryid, COUNT(*) as counter FROM ' . $wpdb->nggpictures . ' WHERE galleryid IN (\'' . implode( '\',\'', $galleriesID ) . '\') AND exclude != 1 GROUP BY galleryid', OBJECT_K );
+	if ( is_array( $picturesCounter ) ) {
+		foreach ( $picturesCounter as $key => $value )
+			$unsort_galleries[ $key ]->counter = $value->counter;
+	}
 
-    // get the id's of the preview images
-    $imagesID = array();
-    if ( is_array($unsort_galleries) ) {
-        foreach ($unsort_galleries as $gallery_row)
-            $imagesID[] = $gallery_row->previewpic;
-    }
-    $albumPreview = $wpdb->get_results('SELECT pid, filename FROM '.$wpdb->nggpictures.' WHERE pid IN (\''.implode('\',\'', $imagesID).'\')', OBJECT_K);
+	// get the id's of the preview images
+	$imagesID = array();
+	if ( is_array( $unsort_galleries ) ) {
+		foreach ( $unsort_galleries as $gallery_row )
+			$imagesID[] = $gallery_row->previewpic;
+	}
+	$albumPreview = $wpdb->get_results( 'SELECT pid, filename FROM ' . $wpdb->nggpictures . ' WHERE pid IN (\'' . implode( '\',\'', $imagesID ) . '\')', OBJECT_K );
 
-    // re-order them and populate some
-    foreach ($sortorder as $key) {
+	// re-order them and populate some
+	foreach ( $sortorder as $key ) {
 
 		// Create a gallery object
-		if (isset($unsort_galleries[$key])) $galleries[$key] = $unsort_galleries[$key];
-		else $galleries[$key] = new stdClass;
+		if ( isset( $unsort_galleries[ $key ] ) )
+			$galleries[ $key ] = $unsort_galleries[ $key ];
+		else
+			$galleries[ $key ] = new stdClass;
 
-        //if we have a prefix 'a' then it's a subalbum, instead a gallery
-        if (substr( $key, 0, 1) == 'a') {
-			if (($subalbum = nggdb::find_album(substr($key, 1)))) {
-				$galleries[$key]->counter = count($subalbum->gallery_ids);
-				if ($subalbum->previewpic > 0){
+		//if we have a prefix 'a' then it's a subalbum, instead a gallery
+		if ( substr( $key, 0, 1 ) == 'a' ) {
+			if ( ( $subalbum = nggdb::find_album( substr( $key, 1 ) ) ) ) {
+				$galleries[ $key ]->counter = count( $subalbum->gallery_ids );
+				if ( $subalbum->previewpic > 0 ) {
 					$image = $nggdb->find_image( $subalbum->previewpic );
-					$galleries[$key]->previewurl = isset($image->thumbURL) ? $image->thumbURL : '';
+					$galleries[ $key ]->previewurl = isset( $image->thumbURL ) ? $image->thumbURL : '';
 				}
-				$galleries[$key]->previewpic = $subalbum->previewpic;
-				$galleries[$key]->previewname = $subalbum->name;
+				$galleries[ $key ]->previewpic = $subalbum->previewpic;
+				$galleries[ $key ]->previewname = $subalbum->name;
 
 				//link to the subalbum
 				$args['album'] = ( $ngg_options['usePermalinks'] ) ? $subalbum->slug : $subalbum->id;
 				$args['gallery'] = false;
 				$args['nggpage'] = false;
-				$pageid = (isset($subalbum->pageid) ? $subalbum->pageid : 0);
-				$galleries[$key]->pagelink = ($pageid > 0) ? get_permalink($pageid) : $nggRewrite->get_permalink($args);
-				$galleries[$key]->galdesc = html_entity_decode ( nggGallery::i18n($subalbum->albumdesc) );
-				$galleries[$key]->title = esc_attr(html_entity_decode ( nggGallery::i18n($subalbum->name) ));
+				$pageid = ( isset( $subalbum->pageid ) ? $subalbum->pageid : 0 );
+				$galleries[ $key ]->pagelink = ( $pageid > 0 ) ? get_permalink( $pageid ) : $nggRewrite->get_permalink( $args );
+				$galleries[ $key ]->galdesc = html_entity_decode( nggGallery::i18n( $subalbum->albumdesc ) );
+				$galleries[ $key ]->title = esc_attr( html_entity_decode( nggGallery::i18n( $subalbum->name ) ) );
 			}
-        }
-		elseif (isset($unsort_galleries[$key])) {
-			$galleries[$key] = $unsort_galleries[$key];
+		} elseif ( isset( $unsort_galleries[ $key ] ) ) {
+			$galleries[ $key ] = $unsort_galleries[ $key ];
 
 			// No images found, set counter to 0
-			if (!isset($galleries[$key]->counter)){
-				$galleries[$key]->counter = 0;
-				$galleries[$key]->previewurl = '';
+			if ( ! isset( $galleries[ $key ]->counter ) ) {
+				$galleries[ $key ]->counter = 0;
+				$galleries[ $key ]->previewurl = '';
 			}
 
 			// add the file name and the link
-			if ($galleries[$key]->previewpic  != 0) {
-				$galleries[$key]->previewname = $albumPreview[$galleries[$key]->previewpic]->filename;
-				$galleries[$key]->previewurl  = site_url().'/' . $galleries[$key]->path . '/thumbs/thumbs_' . $albumPreview[$galleries[$key]->previewpic]->filename;
+			if ( $galleries[ $key ]->previewpic != 0 ) {
+				$galleries[ $key ]->previewname = $albumPreview[ $galleries[ $key ]->previewpic ]->filename;
+				$galleries[ $key ]->previewurl = site_url() . '/' . $galleries[ $key ]->path . '/thumbs/thumbs_' . $albumPreview[ $galleries[ $key ]->previewpic ]->filename;
 			} else {
-				$first_image = $wpdb->get_row('SELECT * FROM '. $wpdb->nggpictures .' WHERE exclude != 1 AND galleryid = '. $key .' ORDER by pid DESC limit 0,1');
-				if (isset($first_image)) {
-					$galleries[$key]->previewpic  = $first_image->pid;
-					$galleries[$key]->previewname = $first_image->filename;
-					$galleries[$key]->previewurl  = site_url() . '/' . $galleries[$key]->path . '/thumbs/thumbs_' . $first_image->filename;
+				$first_image = $wpdb->get_row( 'SELECT * FROM ' . $wpdb->nggpictures . ' WHERE exclude != 1 AND galleryid = ' . $key . ' ORDER by pid DESC limit 0,1' );
+				if ( isset( $first_image ) ) {
+					$galleries[ $key ]->previewpic = $first_image->pid;
+					$galleries[ $key ]->previewname = $first_image->filename;
+					$galleries[ $key ]->previewurl = site_url() . '/' . $galleries[ $key ]->path . '/thumbs/thumbs_' . $first_image->filename;
 				}
 			}
 
 			// choose between variable and page link
-			if ($ngg_options['galNoPages']) {
+			if ( $ngg_options['galNoPages'] ) {
 				$args['album'] = ( $ngg_options['usePermalinks'] ) ? $album->slug : $album->id;
-				$args['gallery'] = ( $ngg_options['usePermalinks'] ) ? $galleries[$key]->slug : $key;
+				$args['gallery'] = ( $ngg_options['usePermalinks'] ) ? $galleries[ $key ]->slug : $key;
 				$args['nggpage'] = false;
-				$galleries[$key]->pagelink = $nggRewrite->get_permalink($args);
+				$galleries[ $key ]->pagelink = $nggRewrite->get_permalink( $args );
 
 			} else {
-				$galleries[$key]->pagelink = get_permalink( $galleries[$key]->pageid );
+				$galleries[ $key ]->pagelink = get_permalink( $galleries[ $key ]->pageid );
 			}
 
 			// description can contain HTML tags
-			$galleries[$key]->galdesc = html_entity_decode ( nggGallery::i18n( stripslashes($galleries[$key]->galdesc), 'gal_' . $galleries[$key]->gid . '_description') );
+			$galleries[ $key ]->galdesc = html_entity_decode( nggGallery::i18n( stripslashes( $galleries[ $key ]->galdesc ), 'gal_' . $galleries[ $key ]->gid . '_description' ) );
 
 			// i18n
-			$galleries[$key]->title = esc_attr( html_entity_decode( nggGallery::i18n( $galleries[$key]->title, 'gal_' . $galleries[$key]->gid . '_title' ) ) );
+			$galleries[ $key ]->title = esc_attr( html_entity_decode( nggGallery::i18n( $galleries[ $key ]->title, 'gal_' . $galleries[ $key ]->gid . '_title' ) ) );
 		}
 
-        // apply a filter on gallery object before the output
-        $galleries[$key] = apply_filters('ngg_album_galleryobject', $galleries[$key]);
-    }
+		// apply a filter on gallery object before the output
+		$galleries[ $key ] = apply_filters( 'ngg_album_galleryobject', $galleries[ $key ] );
+	}
 
-    // apply a filter on gallery object before paging starts
-    $galleries = apply_filters('ngg_album_galleries_before_paging', $galleries, $album);
+	// apply a filter on gallery object before paging starts
+	$galleries = apply_filters( 'ngg_album_galleries_before_paging', $galleries, $album );
 
-    // check for page navigation
-    if ($maxElement > 0) {
-        if ( !is_home() || $pageid == get_the_ID() ) {
-            $page = ( !empty( $nggpage ) ) ? (int) $nggpage : 1;
-        }
-        else $page = 1;
+	// check for page navigation
+	if ( $maxElement > 0 ) {
+		if ( ! is_home() || $pageid == get_the_ID() ) {
+			$page = ( ! empty( $nggpage ) ) ? (int) $nggpage : 1;
+		} else
+			$page = 1;
 
-        $start = $offset = ( $page - 1 ) * $maxElement;
+		$start = $offset = ( $page - 1 ) * $maxElement;
 
-        $total = count($galleries);
+		$total = count( $galleries );
 
-        // remove the element if we didn't start at the beginning
-        if ($start > 0 ) array_splice($galleries, 0, $start);
+		// remove the element if we didn't start at the beginning
+		if ( $start > 0 )
+			array_splice( $galleries, 0, $start );
 
-        // return the list of images we need
-        array_splice($galleries, $maxElement);
+		// return the list of images we need
+		array_splice( $galleries, $maxElement );
 
-        $nggNav = new nggNavigation;
-        $navigation = $nggNav->create_navigation($page, $total, $maxElement);
-    } else {
-        $navigation = '<div class="ngg-clear"></div>';
-    }
+		$nggNav = new nggNavigation;
+		$navigation = $nggNav->create_navigation( $page, $total, $maxElement );
+	} else {
+		$navigation = '<div class="ngg-clear"></div>';
+	}
 
-    // apply a filter on $galleries before the output
-    $galleries = apply_filters('ngg_album_galleries', $galleries);
+	// apply a filter on $galleries before the output
+	$galleries = apply_filters( 'ngg_album_galleries', $galleries );
 
-    // if sombody didn't enter any template , take the extend version
-    $filename = ( empty($template) ) ? 'album-extend' : 'album-' . $template ;
+	// if sombody didn't enter any template , take the extend version
+	$filename = ( empty( $template ) ) ? 'album-extend' : 'album-' . $template;
 
-    // create the output
-    $out = nggGallery::capture ( $filename, array ('album' => $album, 'galleries' => $galleries, 'pagination' => $navigation) );
+	// create the output
+	$out = nggGallery::capture( $filename, array( 'album' => $album, 'galleries' => $galleries, 'pagination' => $navigation ) );
 
-    return $out;
+	return $out;
 
 }
 
@@ -641,32 +649,32 @@ function nggCreateAlbum( $galleriesID, $template = 'extend', $album = 0) {
  * @access public
  * @param int|string $galleryID or gallery name
  * @param string $template (optional) name for a template file, look for imagebrowser-$template
- * @return the content
+ * @return string content
  */
-function nggShowImageBrowser($galleryID, $template = '') {
+function nggShowImageBrowser( $galleryID, $template = '' ) {
 
-    global $wpdb,$nggdb;
+	global $wpdb, $nggdb;
 
-    $ngg_options = nggGallery::get_option('ngg_options');
+	$ngg_options = nggGallery::get_option( 'ngg_options' );
 
-    //Set sort order value, if not used (upgrade issue)
-    $ngg_options['galSort'] = ($ngg_options['galSort']) ? $ngg_options['galSort'] : 'pid';
-    $ngg_options['galSortDir'] = ($ngg_options['galSortDir'] == 'DESC') ? 'DESC' : 'ASC';
+	//Set sort order value, if not used (upgrade issue)
+	$ngg_options['galSort'] = ( $ngg_options['galSort'] ) ? $ngg_options['galSort'] : 'pid';
+	$ngg_options['galSortDir'] = ( $ngg_options['galSortDir'] == 'DESC' ) ? 'DESC' : 'ASC';
 
-    // get the pictures
-    //20140106:shouldn't call it statically if is not...
-    //$picturelist = nggdb::get_gallery($galleryID, $ngg_options['galSort'], $ngg_options['galSortDir']);
-    //return array of nggImages
-    $picturelist = $nggdb->get_gallery($galleryID, $ngg_options['galSort'], $ngg_options['galSortDir']);
+	// get the pictures
+	//20140106:shouldn't call it statically if is not...
+	//$picturelist = nggdb::get_gallery($galleryID, $ngg_options['galSort'], $ngg_options['galSortDir']);
+	//return array of nggImages
+	$picturelist = $nggdb->get_gallery( $galleryID, $ngg_options['galSort'], $ngg_options['galSortDir'] );
 
-    if ( is_array($picturelist) )
-        $out = nggCreateImageBrowser($picturelist, $template);
-    else
-        $out = __('[Gallery not found]','nggallery');
+	if ( is_array( $picturelist ) )
+		$out = nggCreateImageBrowser( $picturelist, $template );
+	else
+		$out = __( '[Gallery not found]', 'nggallery' );
 
-    $out = apply_filters('ngg_show_imagebrowser_content', $out, $galleryID);
+	$out = apply_filters( 'ngg_show_imagebrowser_content', $out, $galleryID );
 
-    return $out;
+	return $out;
 
 }
 
@@ -676,96 +684,122 @@ function nggShowImageBrowser($galleryID, $template = '') {
  * @access internal
  * @param array $picturelist
  * @param string $template (optional) name for a template file, look for imagebrowser-$template
- * @return the content
+ * @return string content
  */
-function nggCreateImageBrowser($picturelist, $template = '') {
+function nggCreateImageBrowser( $picturelist, $template = '' ) {
 
-    global $nggRewrite, $ngg;
+	global $nggRewrite, $ngg;
 
-    require_once( dirname (__FILE__) . '/lib/meta.php' );
+	require_once ( dirname( __FILE__ ) . '/lib/meta.php' );
 
-    // $_GET from wp_query
-    $pid  = get_query_var('pid');
+	// $_GET from wp_query
+	$pid = get_query_var( 'pid' );
 
-    // we need to know the current page id
-    $current_page = (get_the_ID() == false) ? 0 : get_the_ID();
+	// we need to know the current page id
+	$current_page = ( get_the_ID() == false ) ? 0 : get_the_ID();
 
-    // create a array with id's for better walk inside
-    $picarray = array();
-    foreach ($picturelist as $picture)
-        $picarray[] = $picture->pid;
+	// create a array with id's for better walk inside
+	$picarray = array();
+	foreach ( $picturelist as $picture ) {
+		$picarray[] = $picture->pid;
+	}
 
-    $total = count($picarray);
+	$picarrayIterator = ( new ArrayObject( $picarray ) )->getIterator();
 
-    if ( !empty( $pid )) {
-        if ( is_numeric($pid) )
-            $act_pid = intval($pid);
-        else {
-            // in the case it's a slug we need to search for the pid
-            foreach ($picturelist as $key => $picture) {
-                if ($picture->image_slug == $pid) {
-                    $act_pid = $key;
-                    break;
-                }
-            }
-        }
-    } else {
-        reset($picarray);
-        $act_pid = current($picarray);
-    }
+	$total = count( $picarray );
 
-    // get ids for back/next
-    $key = array_search($act_pid, $picarray);
-    if (!$key) {
-        $act_pid = reset($picarray);
-        $key = key($picarray);
-    }
-    $back_pid = ( $key >= 1 ) ? $picarray[$key-1] : end($picarray) ;
-    $next_pid = ( $key < ($total-1) ) ? $picarray[$key+1] : reset($picarray) ;
+	if ( ! empty( $pid ) ) {
+		if ( is_numeric( $pid ) )
+			$act_pid = intval( $pid );
+		else {
+			// in the case it's a slug we need to search for the pid
+			foreach ( $picturelist as $key => $picture ) {
+				if ( $picture->image_slug == $pid ) {
+					$act_pid = $key;
+					break;
+				}
+			}
+		}
+	} else {
+		$picarrayIterator->rewind();
+		$act_pid = $picarrayIterator->current();
+	}
 
-    // get the picture data
-    $picture = nggdb::find_image($act_pid);
+	// get ids for back/next
+	$key = array_search( $act_pid, $picarray );
+	if ( ! $key ) {
+		$picarrayIterator->rewind();
+		$act_pid = $picarrayIterator->current();
+		$key = $picarrayIterator->key();
+	}
 
-    // if we didn't get some data, exit now
-    if ($picture == null)
-        return;
+	if ( $key >= 1 ) {
+		$back_pid = $picarray[ $key - 1 ];
+	} else {
+		// set iterator to last element		
+		if ( count( $picarray ) - 1 > 0 ) {
+			while ( $picarrayIterator->key() < count( $picarray ) - 1 ) {
+				$picarrayIterator->next();
+			}
 
-    // add more variables for render output
-    $picture->href_link = $picture->get_href_link();
-    $args ['pid'] = ($ngg->options['usePermalinks']) ? $picturelist[$back_pid]->image_slug : $back_pid;
-    $picture->previous_image_link = $nggRewrite->get_permalink( $args );
-    $picture->previous_pid = $back_pid;
-    $args ['pid'] = ($ngg->options['usePermalinks']) ? $picturelist[$next_pid]->image_slug : $next_pid;
-    $picture->next_image_link  = $nggRewrite->get_permalink( $args );
-    $picture->next_pid = $next_pid;
-    $picture->number = $key + 1;
-    $picture->total = $total;
-    $picture->linktitle = ( empty($picture->description) ) ? ' ' : htmlspecialchars ( stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) );
-    $picture->alttext = ( empty($picture->alttext) ) ?  ' ' : html_entity_decode ( stripslashes(nggGallery::i18n($picture->alttext, 'pic_' . $picture->pid . '_alttext')) );
-    $picture->description = ( empty($picture->description) ) ? ' ' : html_entity_decode ( stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) );
-    $picture->anchor = 'ngg-imagebrowser-' . $picture->galleryid . '-' . $current_page;
+			$back_pid = $picarray[ count( $picarray ) - 1 ];
 
-    // filter to add custom content for the output
-    $picture = apply_filters('ngg_image_object', $picture, $act_pid);
 
-    // let's get the meta data
-    $meta = new nggMeta($act_pid);
-    $meta->sanitize();
-    $exif = $meta->get_EXIF();
-    $iptc = $meta->get_IPTC();
-    $xmp  = $meta->get_XMP();
-    $db   = $meta->get_saved_meta();
+		} else {
+			$back_pid = 0;
+		}
+	}
 
-    //if we get no exif information we try the database
-    $exif = ($exif == false) ? $db : $exif;
+	if ( $key < ( $total - 1 ) ) {
+		$next_pid = $picarray[ $key + 1 ];
+	} else {
+		$picarrayIterator->rewind();
+		$next_pid = $picarrayIterator->current();
+	}
 
-    // look for imagebrowser-$template.php or pure imagebrowser.php
-    $filename = ( empty($template) ) ? 'imagebrowser' : 'imagebrowser-' . $template;
 
-    // create the output
-    $out = nggGallery::capture ( $filename , array ('image' => $picture , 'meta' => $meta, 'exif' => $exif, 'iptc' => $iptc, 'xmp' => $xmp, 'db' => $db) );
+	// get the picture data
+	$picture = nggdb::find_image( $act_pid );
 
-    return $out;
+	// if we didn't get some data, exit now
+	if ( $picture == null )
+		return '';
+	// add more variables for render output
+	$picture->href_link = $picture->get_href_link();
+	$args['pid'] = ( $ngg->options['usePermalinks'] ) ? $picturelist[ $back_pid ]->image_slug : $back_pid;
+	$picture->previous_image_link = $nggRewrite->get_permalink( $args );
+	$picture->previous_pid = $back_pid;
+	$args['pid'] = ( $ngg->options['usePermalinks'] ) ? $picturelist[ $next_pid ]->image_slug : $next_pid;
+	$picture->next_image_link = $nggRewrite->get_permalink( $args );
+	$picture->next_pid = $next_pid;
+	$picture->number = $key + 1;
+	$picture->total = $total;
+	$picture->linktitle = ( empty( $picture->description ) ) ? ' ' : htmlspecialchars( stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) );
+	$picture->alttext = ( empty( $picture->alttext ) ) ? ' ' : html_entity_decode( stripslashes( nggGallery::i18n( $picture->alttext, 'pic_' . $picture->pid . '_alttext' ) ) );
+	$picture->description = ( empty( $picture->description ) ) ? ' ' : html_entity_decode( stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) );
+	$picture->anchor = 'ngg-imagebrowser-' . $picture->galleryid . '-' . $current_page;
+
+	// filter to add custom content for the output
+	$picture = apply_filters( 'ngg_image_object', $picture, $act_pid );
+
+	// let's get the meta data
+	$meta = new nggMeta( $act_pid );
+	$meta->sanitize();
+	$exif = $meta->get_EXIF();
+	$iptc = $meta->get_IPTC();
+	$xmp = $meta->get_XMP();
+	$db = $meta->get_saved_meta();
+
+	//if we get no exif information we try the database
+	$exif = ( $exif == false ) ? $db : $exif;
+
+	// look for imagebrowser-$template.php or pure imagebrowser.php
+	$filename = ( empty( $template ) ) ? 'imagebrowser' : 'imagebrowser-' . $template;
+
+	// create the output
+	$out = nggGallery::capture( $filename, array( 'image' => $picture, 'meta' => $meta, 'exif' => $exif, 'iptc' => $iptc, 'xmp' => $xmp, 'db' => $db ) );
+
+	return $out;
 
 }
 
@@ -781,123 +815,123 @@ function nggCreateImageBrowser($picturelist, $template = '') {
  * @param string $template (optional) name for a template file, look for singlepic-$template
  * @param string $caption (optional) additional caption text
  * @param string $link (optional) link to a other url instead the full image
- * @return the content
+ * @return string content
  */
-function nggSinglePicture($imageID, $width = 250, $height = 250, $mode = '', $float = '' , $template = '', $caption = '', $link = '') {
-    global $post;
+function nggSinglePicture( $imageID, $width = 250, $height = 250, $mode = '', $float = '', $template = '', $caption = '', $link = '' ) {
+	global $post;
 
-    $ngg_options = nggGallery::get_option('ngg_options');
+	$ngg_options = nggGallery::get_option( 'ngg_options' );
 
-    // get picturedata
-    $picture = nggdb::find_image($imageID);
+	// get picturedata
+	$picture = nggdb::find_image( $imageID );
 
-    // if we didn't get some data, exit now
-    if ($picture == null)
-        return __('[SinglePic not found]','nggallery');
+	// if we didn't get some data, exit now
+	if ( $picture == null )
+		return __( '[SinglePic not found]', 'nggallery' );
 
-    // add float to img
-    switch ($float) {
+	// add float to img
+	switch ( $float ) {
 
-        case 'left':
-            $float =' ngg-left';
-        break;
+		case 'left':
+			$float = ' ngg-left';
+			break;
 
-        case 'right':
-            $float =' ngg-right';
-        break;
+		case 'right':
+			$float = ' ngg-right';
+			break;
 
-        case 'center':
-            $float =' ngg-center';
-        break;
+		case 'center':
+			$float = ' ngg-center';
+			break;
 
-        default:
-            $float ='';
-        break;
-    }
+		default:
+			$float = '';
+			break;
+	}
 
-    // clean mode if needed
-    $mode = ( preg_match('/(web20|watermark)/i', $mode) ) ? $mode : '';
+	// clean mode if needed
+	$mode = ( preg_match( '/(web20|watermark)/i', $mode ) ) ? $mode : '';
 
-    //let's initiate the url
-    $picture->thumbnailURL = false;
+	//let's initiate the url
+	$picture->thumbnailURL = false;
 
-    // check fo cached picture
-    if ( $post->post_status == 'publish' )
-        $picture->thumbnailURL = $picture->cached_singlepic_file($width, $height, $mode );
+	// check fo cached picture
+	if ( $post->post_status == 'publish' )
+		$picture->thumbnailURL = $picture->cached_singlepic_file( $width, $height, $mode );
 
-    // if we didn't use a cached image then we take the on-the-fly mode
-    if (!$picture->thumbnailURL)
-        $picture->thumbnailURL = trailingslashit( home_url() ) . 'index.php?callback=image&amp;pid=' . $imageID . '&amp;width=' . $width . '&amp;height=' . $height . '&amp;mode=' . $mode;
+	// if we didn't use a cached image then we take the on-the-fly mode
+	if ( ! $picture->thumbnailURL )
+		$picture->thumbnailURL = trailingslashit( home_url() ) . 'index.php?callback=image&amp;pid=' . $imageID . '&amp;width=' . $width . '&amp;height=' . $height . '&amp;mode=' . $mode;
 
-    // add more variables for render output
-    $picture->imageURL = ( empty($link) ) ? $picture->imageURL : $link;
-    $picture->href_link = $picture->get_href_link();
-    $picture->alttext = html_entity_decode( stripslashes(nggGallery::i18n($picture->alttext, 'pic_' . $picture->pid . '_alttext')) );
-    $picture->linktitle = htmlspecialchars( stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) );
-    $picture->description = html_entity_decode( stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) );
-    $picture->classname = 'ngg-singlepic'. $float;
-    $picture->thumbcode = $picture->get_thumbcode( 'singlepic' . $imageID);
-    $picture->height = (int) $height;
-    $picture->width = (int) $width;
-    $picture->caption = nggGallery::i18n($caption);
+	// add more variables for render output
+	$picture->imageURL = ( empty( $link ) ) ? $picture->imageURL : $link;
+	$picture->href_link = $picture->get_href_link();
+	$picture->alttext = html_entity_decode( stripslashes( nggGallery::i18n( $picture->alttext, 'pic_' . $picture->pid . '_alttext' ) ) );
+	$picture->linktitle = htmlspecialchars( stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) );
+	$picture->description = html_entity_decode( stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) );
+	$picture->classname = 'ngg-singlepic' . $float;
+	$picture->thumbcode = $picture->get_thumbcode( 'singlepic' . $imageID );
+	$picture->height = (int) $height;
+	$picture->width = (int) $width;
+	$picture->caption = nggGallery::i18n( $caption );
 
-    // filter to add custom content for the output
-    $picture = apply_filters('ngg_image_object', $picture, $imageID);
+	// filter to add custom content for the output
+	$picture = apply_filters( 'ngg_image_object', $picture, $imageID );
 
-    // let's get the meta data
-    $meta = new nggMeta($imageID);
-    $meta->sanitize();
-    $exif = $meta->get_EXIF();
-    $iptc = $meta->get_IPTC();
-    $xmp  = $meta->get_XMP();
-    $db   = $meta->get_saved_meta();
+	// let's get the meta data
+	$meta = new nggMeta( $imageID );
+	$meta->sanitize();
+	$exif = $meta->get_EXIF();
+	$iptc = $meta->get_IPTC();
+	$xmp = $meta->get_XMP();
+	$db = $meta->get_saved_meta();
 
-    //if we get no exif information we try the database
-    $exif = ($exif == false) ? $db : $exif;
+	//if we get no exif information we try the database
+	$exif = ( $exif == false ) ? $db : $exif;
 
-    // look for singlepic-$template.php or pure singlepic.php
-    $filename = ( empty($template) ) ? 'singlepic' : 'singlepic-' . $template;
+	// look for singlepic-$template.php or pure singlepic.php
+	$filename = ( empty( $template ) ) ? 'singlepic' : 'singlepic-' . $template;
 
-    // create the output
-    $out = nggGallery::capture ( $filename, array ('image' => $picture , 'meta' => $meta, 'exif' => $exif, 'iptc' => $iptc, 'xmp' => $xmp, 'db' => $db) );
+	// create the output
+	$out = nggGallery::capture( $filename, array( 'image' => $picture, 'meta' => $meta, 'exif' => $exif, 'iptc' => $iptc, 'xmp' => $xmp, 'db' => $db ) );
 
-    $out = apply_filters('ngg_show_singlepic_content', $out, $picture );
+	$out = apply_filters( 'ngg_show_singlepic_content', $out, $picture );
 
-    return $out;
+	return $out;
 }
 /**
  * nggShowGalleryTags() - create a gallery based on the tags
  *
  * @access public
  * @param string $taglist list of tags as csv
- * @return the content
+ * @return string content
  */
-function nggShowGalleryTags($taglist, $template = '',  $sorting = 'ASC') {
+function nggShowGalleryTags( $taglist, $template = '', $sorting = 'ASC' ) {
 
-    // $_GET from wp_query
-    $pid    = get_query_var('pid');
-    $pageid = get_query_var('pageid');
+	// $_GET from wp_query
+	$pid = get_query_var( 'pid' );
+	$pageid = get_query_var( 'pageid' );
 
-    // get now the related images
-    $picturelist = nggTags::find_images_for_tags($taglist , $sorting);
+	// get now the related images
+	$picturelist = nggTags::find_images_for_tags( $taglist, $sorting );
 
-    // look for ImageBrowser if we have a $_GET('pid')
-    if ( $pageid == get_the_ID() || !is_home() )
-        if (!empty( $pid ))  {
-            $out = nggCreateImageBrowser( $picturelist, $template );
-            return $out;
-        }
+	// look for ImageBrowser if we have a $_GET('pid')
+	if ( $pageid == get_the_ID() || ! is_home() )
+		if ( ! empty( $pid ) ) {
+			$out = nggCreateImageBrowser( $picturelist, $template );
+			return $out;
+		}
 
-    // go on if not empty
-    if ( empty($picturelist) )
-        return;
+	// go on if not empty
+	if ( empty( $picturelist ) )
+		return '';
 
-    // show gallery
-    if ( is_array($picturelist) )
-        $out = nggCreateGallery($picturelist, false, $template);
+	// show gallery
+	if ( is_array( $picturelist ) )
+		$out = nggCreateGallery( $picturelist, false, $template );
 
-    $out = apply_filters('ngg_show_gallery_tags_content', $out, $taglist);
-    return $out;
+	$out = apply_filters( 'ngg_show_gallery_tags_content', $out, $taglist );
+	return $out;
 }
 
 
@@ -907,39 +941,39 @@ function nggShowGalleryTags($taglist, $template = '',  $sorting = 'ASC') {
  * @access public
  * @param string $taglist list of tags as csv
  * @param integer $maxImages (optional) limit the number of images to show. 0=no limit
- * @return the content
+ * @return string content
  */
-function nggShowRelatedGallery($taglist, $maxImages = 0) {
+function nggShowRelatedGallery( $taglist, $maxImages = 0 ) {
 
-    $ngg_options = nggGallery::get_option('ngg_options');
+	$ngg_options = nggGallery::get_option( 'ngg_options' );
 
-    // get now the related images
-    $picturelist = nggTags::find_images_for_tags($taglist, 'RAND');
+	// get now the related images
+	$picturelist = nggTags::find_images_for_tags( $taglist, 'RAND' );
 
-    // go on if not empty
-    if ( empty($picturelist) )
-        return;
+	// go on if not empty
+	if ( empty( $picturelist ) )
+		return '';
 
-    // cut the list to maxImages
-    if ( $maxImages > 0 )
-        array_splice($picturelist, $maxImages);
+	// cut the list to maxImages
+	if ( $maxImages > 0 )
+		array_splice( $picturelist, $maxImages );
 
-    // *** build the gallery output
-    $out   = '<div class="ngg-related-gallery">';
-    foreach ($picturelist as $picture) {
+	// *** build the gallery output
+	$out = '<div class="ngg-related-gallery">';
+	foreach ( $picturelist as $picture ) {
 
-        // get the effect code
-        $thumbcode = $picture->get_thumbcode( __('Related images for', 'nggallery') . ' ' . get_the_title());
+		// get the effect code
+		$thumbcode = $picture->get_thumbcode( __( 'Related images for', 'nggallery' ) . ' ' . get_the_title() );
 
-        $out .= '<a href="' . $picture->imageURL . '" title="' . stripslashes(nggGallery::i18n($picture->description, 'pic_' . $picture->pid . '_description')) . '" ' . $thumbcode . ' >';
-        $out .= '<img title="' . stripslashes(nggGallery::i18n($picture->alttext, 'pic_' . $picture->pid . '_alttext')) . '" alt="' . stripslashes(nggGallery::i18n($picture->alttext, 'pic_' . $picture->pid . '_alttext')) . '" src="' . $picture->thumbURL . '" />';
-        $out .= '</a>' . "\n";
-    }
-    $out .= '</div>' . "\n";
+		$out .= '<a href="' . $picture->imageURL . '" title="' . stripslashes( nggGallery::i18n( $picture->description, 'pic_' . $picture->pid . '_description' ) ) . '" ' . $thumbcode . ' >';
+		$out .= '<img title="' . stripslashes( nggGallery::i18n( $picture->alttext, 'pic_' . $picture->pid . '_alttext' ) ) . '" alt="' . stripslashes( nggGallery::i18n( $picture->alttext, 'pic_' . $picture->pid . '_alttext' ) ) . '" src="' . $picture->thumbURL . '" />';
+		$out .= '</a>' . "\n";
+	}
+	$out .= '</div>' . "\n";
 
-    $out = apply_filters('ngg_show_related_gallery_content', $out, $taglist);
+	$out = apply_filters( 'ngg_show_related_gallery_content', $out, $taglist );
 
-    return $out;
+	return $out;
 }
 
 /**
@@ -947,56 +981,56 @@ function nggShowRelatedGallery($taglist, $maxImages = 0) {
  * 20140119: Added template and sort
  * @access public
  * @param string $taglist list of tags as csv
- * @return the content
+ * @return string content
  */
-function nggShowAlbumTags($taglist, $template='', $sorting = 'ASC') {
+function nggShowAlbumTags( $taglist, $template = '', $sorting = 'ASC' ) {
 
-    global $wpdb, $nggRewrite;
+	global $wpdb, $nggRewrite;
 
-    // $_GET from wp_query
-    $tag            = get_query_var('gallerytag');
-    $pageid         = get_query_var('pageid');
+	// $_GET from wp_query
+	$tag = get_query_var( 'gallerytag' );
+	$pageid = get_query_var( 'pageid' );
 
-    // look for gallerytag variable
-    if ( $pageid == get_the_ID() || !is_home() )  {
-        if (!empty( $tag ))  {
+	// look for gallerytag variable
+	if ( $pageid == get_the_ID() || ! is_home() ) {
+		if ( ! empty( $tag ) ) {
 
-            // avoid this evil code $sql = 'SELECT name FROM wp_ngg_tags WHERE slug = \'slug\' union select concat(0x7c,user_login,0x7c,user_pass,0x7c) from wp_users WHERE 1 = 1';
-            $slug = esc_attr( $tag );
-            $tagname = $wpdb->get_var( $wpdb->prepare( "SELECT name FROM $wpdb->terms WHERE slug = %s", $slug ) );
-            $out  = '<div id="albumnav"><span><a href="' . get_permalink() . '" title="' . __('Overview', 'nggallery') .' ">'.__('Overview', 'nggallery').'</a> | '.$tagname.'</span></div>';
-            $out .=  nggShowGalleryTags($slug, $template, $sorting);
-            return $out;
+			// avoid this evil code $sql = 'SELECT name FROM wp_ngg_tags WHERE slug = \'slug\' union select concat(0x7c,user_login,0x7c,user_pass,0x7c) from wp_users WHERE 1 = 1';
+			$slug = esc_attr( $tag );
+			$tagname = $wpdb->get_var( $wpdb->prepare( "SELECT name FROM $wpdb->terms WHERE slug = %s", $slug ) );
+			$out = '<div id="albumnav"><span><a href="' . get_permalink() . '" title="' . __( 'Overview', 'nggallery' ) . ' ">' . __( 'Overview', 'nggallery' ) . '</a> | ' . $tagname . '</span></div>';
+			$out .= nggShowGalleryTags( $slug, $template, $sorting );
+			return $out;
 
-        }
-    }
+		}
+	}
 
-    // get now the related images
-    $picturelist = nggTags::get_album_images($taglist);
+	// get now the related images
+	$picturelist = nggTags::get_album_images( $taglist );
 
-    // go on if not empty
-    if ( empty($picturelist) )
-        return;
+	// go on if not empty
+	if ( empty( $picturelist ) )
+		return '';
 
-    // re-structure the object that we can use the standard template
-    foreach ($picturelist as $key => $picture) {
-        $picturelist[$key]->previewpic  = $picture->pid;
-        $picturelist[$key]->previewname = $picture->filename;
-        $picturelist[$key]->previewurl  = site_url() . '/' . $picture->path . '/thumbs/thumbs_' . $picture->filename;
-        $picturelist[$key]->counter     = $picture->count;
-        $picturelist[$key]->title       = $picture->name;
-        $picturelist[$key]->pagelink    = $nggRewrite->get_permalink( array('gallerytag'=>$picture->slug) );
-    }
+	// re-structure the object that we can use the standard template
+	foreach ( $picturelist as $key => $picture ) {
+		$picturelist[ $key ]->previewpic = $picture->pid;
+		$picturelist[ $key ]->previewname = $picture->filename;
+		$picturelist[ $key ]->previewurl = site_url() . '/' . $picture->path . '/thumbs/thumbs_' . $picture->filename;
+		$picturelist[ $key ]->counter = $picture->count;
+		$picturelist[ $key ]->title = $picture->name;
+		$picturelist[ $key ]->pagelink = $nggRewrite->get_permalink( array( 'gallerytag' => $picture->slug ) );
+	}
 
-    //TODO: Add pagination later
-    $navigation = '<div class="ngg-clear"></div>';
+	//TODO: Add pagination later
+	$navigation = '<div class="ngg-clear"></div>';
 
-    // create the output
-    $out = nggGallery::capture ('album-compact', array ('album' => 0, 'galleries' => $picturelist, 'pagination' => $navigation) );
+	// create the output
+	$out = nggGallery::capture( 'album-compact', array( 'album' => 0, 'galleries' => $picturelist, 'pagination' => $navigation ) );
 
-    $out = apply_filters('ngg_show_album_tags_content', $out, $taglist);
+	$out = apply_filters( 'ngg_show_album_tags_content', $out, $taglist );
 
-    return $out;
+	return $out;
 }
 
 /**
@@ -1005,41 +1039,43 @@ function nggShowAlbumTags($taglist, $template='', $sorting = 'ASC') {
  * @access public
  * @param string $type could be 'tags' or 'category'
  * @param integer $maxImages of images
- * @return related gallery output or empty string if not tags/categories
+ * @return string related gallery output or empty string if not tags/categories
  * 20150309: fix: error when no tags in site.
  * Few simplifications
  */
-function nggShowRelatedImages($type = '', $maxImages = 0) {
-    $ngg_options = nggGallery::get_option('ngg_options');
+function nggShowRelatedImages( $type = '', $maxImages = 0 ) {
+	$ngg_options = nggGallery::get_option( 'ngg_options' );
 
-    if ($type == '') {
-        $type = $ngg_options['appendType'];
-        $maxImages = $ngg_options['maxImages'];
-    }
+	if ( $type == '' ) {
+		$type = $ngg_options['appendType'];
+		$maxImages = $ngg_options['maxImages'];
+	}
 
-    $sluglist = array();
+	$sluglist = array();
 
-    switch ($type) {
-        case 'tags':
-            $taglist = get_the_tags(); //Return array of tag objects, false on failure or empty
-                                       //This is a tag list for posts non Nextcellent tag lists.
-            if (!$taglist) return "";
-            foreach ($taglist as $tag) {
-                $sluglist[] = $tag->slug;
-            }
-        break;
+	switch ( $type ) {
+		case 'tags':
+			$taglist = get_the_tags(); //Return array of tag objects, false on failure or empty
+			//This is a tag list for posts non Nextcellent tag lists.
+			if ( ! $taglist )
+				return "";
+			foreach ( $taglist as $tag ) {
+				$sluglist[] = $tag->slug;
+			}
+			break;
 
-        case 'category':
-            $catlist = get_the_category(); //return array (empty if no categories)
-            if (empty ($catlist)) return "";
-            foreach ($catlist as $cat) {
-               $sluglist[] = $cat->category_nicename;
-            }
-            break;
-    }
-    $sluglist = implode(',', $sluglist);
-    $out = nggShowRelatedGallery($sluglist, $maxImages);
-    return $out;
+		case 'category':
+			$catlist = get_the_category(); //return array (empty if no categories)
+			if ( empty( $catlist ) )
+				return "";
+			foreach ( $catlist as $cat ) {
+				$sluglist[] = $cat->category_nicename;
+			}
+			break;
+	}
+	$sluglist = implode( ',', $sluglist );
+	$out = nggShowRelatedGallery( $sluglist, $maxImages );
+	return $out;
 }
 
 /**
@@ -1050,8 +1086,8 @@ function nggShowRelatedImages($type = '', $maxImages = 0) {
  * @param integer (optional) $maxNumbers of images
  * @return void
  */
-function the_related_images($type = 'tags', $maxNumbers = 7) {
-    echo nggShowRelatedImages($type, $maxNumbers);
+function the_related_images( $type = 'tags', $maxNumbers = 7 ) {
+	echo nggShowRelatedImages( $type, $maxNumbers );
 }
 
 /**
@@ -1062,51 +1098,51 @@ function the_related_images($type = 'tags', $maxNumbers = 7) {
  * @param integer $maxImages of images
  * @param string $template (optional) name for a template file, look for gallery-$template
  * @param int $galleryId Limit to a specific gallery
- * @return the content
+ * @return string content
  */
-function nggShowRandomRecent($type, $maxImages, $template = '', $galleryId = 0) {
+function nggShowRandomRecent( $type, $maxImages, $template = '', $galleryId = 0 ) {
 
-    // $_GET from wp_query
-    $pid    = get_query_var('pid');
-    $pageid = get_query_var('pageid');
+	// $_GET from wp_query
+	$pid = get_query_var( 'pid' );
+	$pageid = get_query_var( 'pageid' );
 
-    // get now the recent or random images
-    switch ($type) {
-        case 'random':
-            $picturelist = nggdb::get_random_images($maxImages, $galleryId);
-            break;
-        case 'id':
-            $picturelist = nggdb::find_last_images(0, $maxImages, true, $galleryId, 'id');
-            break;
-        case 'date':
-            $picturelist = nggdb::find_last_images(0, $maxImages, true, $galleryId, 'date');
-            break;
-        case 'sort':
-            $picturelist = nggdb::find_last_images(0, $maxImages, true, $galleryId, 'sort');
-            break;
-        default:
-            // default is by pid
-            $picturelist = nggdb::find_last_images(0, $maxImages, true, $galleryId, 'id');
-    }
+	// get now the recent or random images
+	switch ( $type ) {
+		case 'random':
+			$picturelist = nggdb::get_random_images( $maxImages, $galleryId );
+			break;
+		case 'id':
+			$picturelist = nggdb::find_last_images( 0, $maxImages, true, $galleryId, 'id' );
+			break;
+		case 'date':
+			$picturelist = nggdb::find_last_images( 0, $maxImages, true, $galleryId, 'date' );
+			break;
+		case 'sort':
+			$picturelist = nggdb::find_last_images( 0, $maxImages, true, $galleryId, 'sort' );
+			break;
+		default:
+			// default is by pid
+			$picturelist = nggdb::find_last_images( 0, $maxImages, true, $galleryId, 'id' );
+	}
 
-    // look for ImageBrowser if we have a $_GET('pid')
-    if ( $pageid == get_the_ID() || !is_home() )
-        if (!empty( $pid ))  {
-            $out = nggCreateImageBrowser( $picturelist );
-            return $out;
-        }
+	// look for ImageBrowser if we have a $_GET('pid')
+	if ( $pageid == get_the_ID() || ! is_home() )
+		if ( ! empty( $pid ) ) {
+			$out = nggCreateImageBrowser( $picturelist );
+			return $out;
+		}
 
-    // go on if not empty
-    if ( empty($picturelist) )
-        return;
+	// go on if not empty
+	if ( empty( $picturelist ) )
+		return '';
 
-    // show gallery
-    if ( is_array($picturelist) )
-        $out = nggCreateGallery($picturelist, false, $template);
+	// show gallery
+	if ( is_array( $picturelist ) )
+		$out = nggCreateGallery( $picturelist, false, $template );
 
-    $out = apply_filters('ngg_show_images_content', $out, $picturelist);
+	$out = apply_filters( 'ngg_show_images_content', $out, $picturelist );
 
-    return $out;
+	return $out;
 }
 
 /**
@@ -1114,42 +1150,42 @@ function nggShowRandomRecent($type, $maxImages, $template = '', $galleryId = 0) 
  *
  * @param array $args
  * @param string $template (optional) name for a template file, look for gallery-$template
- * @return the content
+ * @return string content
  */
-function nggTagCloud($args ='', $template = '') {
-    global $nggRewrite;
+function nggTagCloud( $args = '', $template = '' ) {
+	global $nggRewrite;
 
-    // $_GET from wp_query
-    $tag     = get_query_var('gallerytag');
-    $pageid  = get_query_var('pageid');
+	// $_GET from wp_query
+	$tag = get_query_var( 'gallerytag' );
+	$pageid = get_query_var( 'pageid' );
 
-    // look for gallerytag variable
-    if ( $pageid == get_the_ID() || !is_home() )  {
-        if (!empty( $tag ))  {
+	// look for gallerytag variable
+	if ( $pageid == get_the_ID() || ! is_home() ) {
+		if ( ! empty( $tag ) ) {
 
-            $slug =  esc_attr( $tag );
-            $out  =  nggShowGalleryTags( $slug );
-            return $out;
-        }
-    }
+			$slug = esc_attr( $tag );
+			$out = nggShowGalleryTags( $slug );
+			return $out;
+		}
+	}
 
-    $defaults = array(
-        'smallest' => 8, 'largest' => 22, 'unit' => 'pt', 'number' => 45,
-        'format' => 'flat', 'orderby' => 'name', 'order' => 'ASC',
-        'exclude' => '', 'include' => '', 'link' => 'view', 'taxonomy' => 'ngg_tag'
-    );
-    $args = wp_parse_args( $args, $defaults );
+	$defaults = array(
+		'smallest' => 8, 'largest' => 22, 'unit' => 'pt', 'number' => 45,
+		'format' => 'flat', 'orderby' => 'name', 'order' => 'ASC',
+		'exclude' => '', 'include' => '', 'link' => 'view', 'taxonomy' => 'ngg_tag'
+	);
+	$args = wp_parse_args( $args, $defaults );
 
-    $tags = get_terms( $args['taxonomy'], array_merge( $args, array( 'orderby' => 'count', 'order' => 'DESC' ) ) ); // Always query top tags
+	$tags = get_terms( $args['taxonomy'], array_merge( $args, array( 'orderby' => 'count', 'order' => 'DESC' ) ) ); // Always query top tags
 
-    foreach ($tags as $key => $tag ) {
+	foreach ( $tags as $key => $tag ) {
 
-        $tags[ $key ]->link = $nggRewrite->get_permalink(array ('gallerytag' => $tag->slug));
-        $tags[ $key ]->id = $tag->term_id;
-    }
+		$tags[ $key ]->link = $nggRewrite->get_permalink( array( 'gallerytag' => $tag->slug ) );
+		$tags[ $key ]->id = $tag->term_id;
+	}
 
-    $out = '<div class="ngg-tagcloud">' . wp_generate_tag_cloud( $tags, $args ) . '</div>';
+	$out = '<div class="ngg-tagcloud">' . wp_generate_tag_cloud( $tags, $args ) . '</div>';
 
-    return $out;
+	return $out;
 }
 ?>

--- a/xml/json.php
+++ b/xml/json.php
@@ -1,40 +1,40 @@
 <?php
 /**
-* REST Application Programming Interface PHP class for the WordPress plugin NextGEN Gallery
-* Should emulate some kind of Flickr JSON callback : ?callback=json&format=json&api_key=1234567890&method=search&term=myterm
-* 
-* @version      1.1.0
-* @author Alex Rabe 
-* 
-* @require		PHP 5.2.0 or higher
-* 
-*/
+ * REST Application Programming Interface PHP class for the WordPress plugin NextGEN Gallery
+ * Should emulate some kind of Flickr JSON callback : ?callback=json&format=json&api_key=1234567890&method=search&term=myterm
+ * 
+ * @version      1.1.0
+ * @author Alex Rabe 
+ * 
+ * @require		PHP 5.2.0 or higher
+ * 
+ */
 
 class nggAPI {
 
 	/**
-	  *	$_GET Variables 
-	  * 
-	  * @since 1.5.0
-	  * @access private
-	  * @var string
-	  */
-    var $format		=	false;		// $_GET['format'] 	: Return a XML oder JSON output
-	var $api_key	=	false;		// $_GET['api_key']	: Protect the access via a random key (required if user is not logged into backend)
-	var $method		=	false;		// $_GET['method']	: search | gallery | image | album | tag | autocomplete
-	var $term		=	false;		// $_GET['term']   	: The search term (required for method search | tag)
-	var $id			=	false;		// $_GET['id']	  	: object id (required for method gallery | image | album )
-	var $limit		=	false;		// $_GET['limit']	: maximum of images which we request
-    var $type		=	false;		// $_GET['type']	: gallery | image | album (required for method autocomplete)
-    
+	 *	$_GET Variables 
+	 * 
+	 * @since 1.5.0
+	 * @access private
+	 * @var string
+	 */
+	var $format = false;		// $_GET['format'] 	: Return a XML oder JSON output
+	var $api_key = false;		// $_GET['api_key']	: Protect the access via a random key (required if user is not logged into backend)
+	var $method = false;		// $_GET['method']	: search | gallery | image | album | tag | autocomplete
+	var $term = false;		// $_GET['term']   	: The search term (required for method search | tag)
+	var $id = false;		// $_GET['id']	  	: object id (required for method gallery | image | album )
+	var $limit = false;		// $_GET['limit']	: maximum of images which we request
+	var $type = false;		// $_GET['type']	: gallery | image | album (required for method autocomplete)
+
 	/**
 	 * Contain the final output
 	 *
 	 * @since 1.5.0
 	 * @access private
 	 * @var string
-	 */	
-	var $output		=	'';
+	 */
+	var $output = '';
 
 	/**
 	 * Holds the requested information as array
@@ -42,227 +42,226 @@ class nggAPI {
 	 * @since 1.5.0
 	 * @access private
 	 * @var array
-	 */	
-	var $result		=	'';
-	
+	 */
+	var $result = '';
+
 	/**
 	 * Init the variables
 	 * 
-	 */	
+	 */
 	function __construct() {
-		
-        if ( !defined('ABSPATH') )
-            die('You are not allowed to call this page directly.');
 
-		if ( !function_exists('json_encode') )
-			wp_die('Json_encode not available. You need to use PHP 5.2');
-		
+		if ( ! defined( 'ABSPATH' ) )
+			die ( 'You are not allowed to call this page directly.' );
+
+		if ( ! function_exists( 'json_encode' ) )
+			wp_die( 'Json_encode not available. You need to use PHP 5.2' );
+
 		// Read the parameter on init
-		$this->format 	= isset($_GET['format']) ? strtolower( $_GET['format'] ) : false;
-		$this->api_key 	= isset($_GET['api_key'])? $_GET['api_key'] : false; 
-		$this->method 	= isset($_GET['method']) ? strtolower( $_GET['method'] ) : false; 
-		$this->term		= isset($_GET['term'])   ? urldecode( $_GET['term'] ) : false; 
-		$this->id 		= isset($_GET['id'])     ? (int) $_GET['id'] : 0;
-		$this->limit 	= isset($_GET['limit'])  ? (int) $_GET['limit'] : 0;
-        $this->type		= isset($_GET['type'])   ? strtolower( $_GET['type'] ) : false; 		
-		$this->result	= array();
-        $this->list     = false;
-		
+		$this->format = isset ( $_GET['format'] ) ? strtolower( $_GET['format'] ) : false;
+		$this->api_key = isset ( $_GET['api_key'] ) ? $_GET['api_key'] : false;
+		$this->method = isset ( $_GET['method'] ) ? strtolower( $_GET['method'] ) : false;
+		$this->term = isset ( $_GET['term'] ) ? urldecode( $_GET['term'] ) : false;
+		$this->id = isset ( $_GET['id'] ) ? (int) $_GET['id'] : 0;
+		$this->limit = isset ( $_GET['limit'] ) ? (int) $_GET['limit'] : 0;
+		$this->type = isset ( $_GET['type'] ) ? strtolower( $_GET['type'] ) : false;
+		$this->result = array();
+		$this->list = false;
+
 		$this->start_process();
 		$this->render_output();
 	}
 
 	function start_process() {
-	   
-        global $ngg,$nggdb;
-		
-		if ( !$this->valid_access() ) 
+
+		global $ngg, $nggdb;
+
+		if ( ! $this->valid_access() )
 			return;
-		
+
 		switch ( $this->method ) {
-			case 'search' :
+			case 'search':
 				//search for some images
-                //20140106:shouldn't call it statically when is not...
+				//20140106:shouldn't call it statically when is not...
 				//$this->result['images'] = array_merge( (array) nggdb::search_for_images( $this->term ), (array) nggTags::find_images_for_tags( $this->term , 'ASC' ));
-				$this->result['images'] = array_merge( (array) $nggdb->search_for_images( $this->term ), (array) nggTags::find_images_for_tags( $this->term , 'ASC' ));
-			break;
-			case 'album' :
+				$this->result['images'] = array_merge( (array) $nggdb->search_for_images( $this->term ), (array) nggTags::find_images_for_tags( $this->term, 'ASC' ) );
+				break;
+			case 'album':
 				//search for some album  //TODO : Get images for each gallery, could end in a big db query
 				$this->result['album'] = nggdb::find_album( $this->id );
-			break;            
-			case 'gallery' :
+				break;
+			case 'gallery':
 				//search for some gallery
-                //20140106:shouldn't call it statically when is not...
+				//20140106:shouldn't call it statically when is not...
 				//$this->result['images'] = ($this->id == 0) ? nggdb::find_last_images( 0 , 100 ) : nggdb::get_gallery( $this->id, $ngg->options['galSort'], $ngg->options['galSortDir'], true, 0, 0, true );
-				$this->result['images'] = ($this->id == 0) ? nggdb::find_last_images( 0 , 100 ) : $nggdb->get_gallery( $this->id, $ngg->options['galSort'], $ngg->options['galSortDir'], true, 0, 0, true );
-			break;
-			case 'image' :
+				$this->result['images'] = ( $this->id == 0 ) ? nggdb::find_last_images( 0, 100 ) : $nggdb->get_gallery( $this->id, $ngg->options['galSort'], $ngg->options['galSortDir'], true, 0, 0, true );
+				break;
+			case 'image':
 				//search for some image
 				$this->result['images'] = nggdb::find_image( $this->id );
-			break;
-			case 'tag' :
+				break;
+			case 'tag':
 				//search for images based on tags
-				$this->result['images'] = nggTags::find_images_for_tags( $this->term , 'ASC' );
-			break;
-			case 'recent' :
+				$this->result['images'] = nggTags::find_images_for_tags( $this->term, 'ASC' );
+				break;
+			case 'recent':
 				//search for images based on tags
-				$this->result['images'] = nggdb::find_last_images( 0 , $this->limit );
-			break;
-			case 'autocomplete' :
+				$this->result['images'] = nggdb::find_last_images( 0, $this->limit );
+				break;
+			case 'autocomplete':
 				//return images, galleries or albums for autocomplete drop down list
-				return $this->autocomplete();                
-			break;
-			case 'version' :
-				$this->result = array ('stat' => 'ok', 'version' => $ngg->version);
-				return;           
-			break;
-			default :
-				$this->result = array ('stat' => 'fail', 'code' => '98', 'message' => 'Method not known.');
-				return false;	
-			break;		
+				return $this->autocomplete();
+				break;
+			case 'version':
+				$this->result = array( 'stat' => 'ok', 'version' => $ngg->version );
+				return;
+				break;
+			default:
+				$this->result = array( 'stat' => 'fail', 'code' => '98', 'message' => 'Method not known.' );
+				return false;
+				break;
 		}
 
 		// result should be fine	
-		$this->result['stat'] = 'ok';	
+		$this->result['stat'] = 'ok';
 	}
-	
+
 	function valid_access() {
-		
+
 		// if we are logged in, then we can go on
 		if ( is_user_logged_in() )
 			return true;
-		
+
 		//TODO:Implement an API KEY check later
-		if 	($this->api_key != false)
+		if ( $this->api_key != false )
 			return true;
-		
-		$this->result = array ('stat' => 'fail', 'code' => '99', 'message' => 'Insufficient permissions. Method requires read privileges; none granted.');
+
+		$this->result = array( 'stat' => 'fail', 'code' => '99', 'message' => 'Insufficient permissions. Method requires read privileges; none granted.' );
 		return false;
 	}
 
 	/**
 	 * return search result for autocomplete request from backend
 	 * 
-     * @since 1.7.0
+	 * @since 1.7.0
 	 * @return void
 	 */
 	function autocomplete() {
-        global $nggdb;
-        
-        switch ( $this->type ) {
-			case 'image' :
-            
-                // return the last entries in case of an empty search string
-                if ( empty($this->term) )
-				    $list = $nggdb->find_last_images(0, $this->limit, false);
-                else
-                    //$list = $nggdb->search_for_images($this->term, $this->limit);
-                    $list = $nggdb->find_images_in_album($this->term);
-                    
-                if( is_array($list) ) {
-        			foreach($list as $image) {
-                        // reorder result to array-object
-                        $obj = new stdClass();
-                        $obj->id = $image->pid;
-                        $name = ( empty($image->alttext) ? $image->filename : $image->alttext );
-                        //TODO : need to rework save/load 
-                        $name = stripslashes( htmlspecialchars_decode($name, ENT_QUOTES));
-                        $obj->label = $image->pid . ' - ' . $name;
-                        $obj->value = $image->pid . ' - ' . $name;
-                        $this->result[] = $obj;
-        			}
-        		}
+		global $nggdb;
 
-                return $this->result;
-            break;
-			case 'gallery' :
-            
-                if ( empty($this->term) )
-                    $list = $nggdb->find_all_galleries('gid', 'DESC', false, $this->limit );
-                else
-                    $list = $nggdb->search_for_galleries($this->term, $this->limit);   
-                     
-                if( is_array($list) ) {
-        			foreach($list as $gallery) {
-                        // reorder result to array-object
-                        $obj = new stdClass();
-                        $obj->id = $gallery->gid;
-                        $name = ( empty($gallery->title) ) ? $gallery->name : $gallery->title;
-                        $name = stripslashes( htmlspecialchars_decode($name, ENT_QUOTES));
-                        $obj->label = $gallery->gid . ' - ' . $name;
-                        $obj->value = $name;
-                        $this->result[] = $obj;
-        			}
-        		}
-                return $this->result;
-            break;
-			case 'album' :
-            
-                if ( empty($this->term) )
-                    $list = $nggdb->find_all_album('id', 'DESC', $this->limit );
-                else
-                    $list = $nggdb->search_for_albums($this->term, $this->limit); 
-                                    
-                if( is_array($list) ) {
-        			foreach($list as $album) {
-                        // reorder result to array-object            			 
-                        $obj = new stdClass();
-                        $obj->id = $album->id;
-                        $album->name = stripslashes( htmlspecialchars_decode($album->name, ENT_QUOTES));
-                        $obj->label = $album->id . ' - ' . $album->name;
-                        $obj->value = $album->name;
-                        $this->result[] = $obj;
-        			}
-        		}
-                return $this->result;
-            break;
-			default :
-				$this->result = array ('stat' => 'fail', 'code' => '98', 'message' => 'Type not known.');
-				return false;	
-			break;	
-        }
-    }
+		switch ( $this->type ) {
+			case 'image':
 
-    /**
-     * Iterates through a multidimensional array
-     * 
-     * @author Boris Glumpler
-     * @param array $arr
-     * @return void
-     */
-    function create_xml_array( &$arr )
-    {
-        $xml = '';
-        
-        if( is_object( $arr ) )
-            $arr = get_object_vars( $arr );
+				// return the last entries in case of an empty search string
+				if ( empty ( $this->term ) )
+					$list = $nggdb->find_last_images( 0, $this->limit, false );
+				else
+					$list = $nggdb->search_for_images( $this->term, $this->limit );
+				// $list = $nggdb->find_images_in_album($this->term);
 
-        foreach( (array)$arr as $k => $v ) {
-            if( is_object( $v ) )
-                $v = get_object_vars( $v );
-            //nodes must contain letters   
-            if( is_numeric( $k ) )
-                $k = 'id-'.$k;                
-            if( is_array( $v ) )
-                $xml .= "<$k>\n". $this->create_xml_array( $v ). "</$k>\n";
-            else
-                $xml .= "<$k>$v</$k>\n";
-        }
-        
-        return $xml;
-    }
-	
+				if ( is_array( $list ) ) {
+					foreach ( $list as $image ) {
+						// reorder result to array-object
+						$obj = new stdClass();
+						$obj->id = $image->pid;
+						$name = ( empty ( $image->alttext ) ? $image->filename : $image->alttext );
+						//TODO : need to rework save/load 
+						$name = stripslashes( htmlspecialchars_decode( $name, ENT_QUOTES ) );
+						$obj->label = $image->pid . ' - ' . $name;
+						$obj->value = $image->pid . ' - ' . $name;
+						$this->result[] = $obj;
+					}
+				}
+
+				return $this->result;
+				break;
+			case 'gallery':
+
+				if ( empty ( $this->term ) )
+					$list = $nggdb->find_all_galleries( 'gid', 'DESC', false, $this->limit );
+				else
+					$list = $nggdb->search_for_galleries( $this->term, $this->limit );
+
+				if ( is_array( $list ) ) {
+					foreach ( $list as $gallery ) {
+						// reorder result to array-object
+						$obj = new stdClass();
+						$obj->id = $gallery->gid;
+						$name = ( empty ( $gallery->title ) ) ? $gallery->name : $gallery->title;
+						$name = stripslashes( htmlspecialchars_decode( $name, ENT_QUOTES ) );
+						$obj->label = $gallery->gid . ' - ' . $name;
+						$obj->value = $name;
+						$this->result[] = $obj;
+					}
+				}
+				return $this->result;
+				break;
+			case 'album':
+
+				if ( empty ( $this->term ) )
+					$list = $nggdb->find_all_album( 'id', 'DESC', $this->limit );
+				else
+					$list = $nggdb->search_for_albums( $this->term, $this->limit );
+
+				if ( is_array( $list ) ) {
+					foreach ( $list as $album ) {
+						// reorder result to array-object            			 
+						$obj = new stdClass();
+						$obj->id = $album->id;
+						$album->name = stripslashes( htmlspecialchars_decode( $album->name, ENT_QUOTES ) );
+						$obj->label = $album->id . ' - ' . $album->name;
+						$obj->value = $album->name;
+						$this->result[] = $obj;
+					}
+				}
+				return $this->result;
+				break;
+			default:
+				$this->result = array( 'stat' => 'fail', 'code' => '98', 'message' => 'Type not known.' );
+				return false;
+				break;
+		}
+	}
+
+	/**
+	 * Iterates through a multidimensional array
+	 * 
+	 * @author Boris Glumpler
+	 * @param array $arr
+	 * @return void
+	 */
+	function create_xml_array( &$arr ) {
+		$xml = '';
+
+		if ( is_object( $arr ) )
+			$arr = get_object_vars( $arr );
+
+		foreach ( (array) $arr as $k => $v ) {
+			if ( is_object( $v ) )
+				$v = get_object_vars( $v );
+			//nodes must contain letters   
+			if ( is_numeric( $k ) )
+				$k = 'id-' . $k;
+			if ( is_array( $v ) )
+				$xml .= "<$k>\n" . $this->create_xml_array( $v ) . "</$k>\n";
+			else
+				$xml .= "<$k>$v</$k>\n";
+		}
+
+		return $xml;
+	}
+
 	function render_output() {
-		
-		if ($this->format == 'json') {
-			header('Content-Type: application/json; charset=' . get_option('blog_charset'), true);
-			$this->output = json_encode($this->result);
+
+		if ( $this->format == 'json' ) {
+			header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ), true );
+			$this->output = json_encode( $this->result );
 		} else {
-			header('Content-Type: text/xml; charset=' . get_option('blog_charset'), true);
-			$this->output  = "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>\n";
-			$this->output .= "<nextgen-gallery>" . $this->create_xml_array( $this->result )  . "</nextgen-gallery>\n";
-		}	
-		
+			header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ), true );
+			$this->output = "<?xml version='1.0' encoding='UTF-8' standalone='yes'?>\n";
+			$this->output .= "<nextgen-gallery>" . $this->create_xml_array( $this->result ) . "</nextgen-gallery>\n";
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
Fixed some deprecation warnings, that popped up on PHP 8.2
Like PHP Deprecated: Creation of dynamic property is deprecated

- Changed utf8_encode to mb_convert_encoding since utf8_encode is deprecated in PHP 8.2
- Changed wpdb::escape to esc_sql since it is deprecated since Wordpress 3.6.0 

Used autoformatting to enforce Wordpress coding standard

The changes up the minimum PHP Version to 7.3