### PR TITLE
fix: deprecations

### DIFF
--- a/admin/functions.php
+++ b/admin/functions.php
@@ -333,7 +333,7 @@ class nggAdmin{
 				// just look for images with the correct extension
                 if ( isset($info['extension']) )
 				    if ( in_array( strtolower($info['extension']), $ext) )
-					   $files[] = utf8_encode( $file );
+					   $files[] = mb_convert_encoding( $file, 'UTF-8' );
 			}		
 			closedir( $handle ); 
 		} 

--- a/lib/gd.thumbnail.inc.php
+++ b/lib/gd.thumbnail.inc.php
@@ -389,14 +389,14 @@ class ngg_Thumbnail {
      * @param int $Height
      */
     function resizeFix($Width = 0, $Height = 0, $deprecated = 3) {
-        $this->newWidth = $Width;
-        $this->newHeight = $Height;
+        $newWidth = $Width;
+        $newHeight = $Height;
 
 		if(function_exists("ImageCreateTrueColor")) {
-			$this->workingImage = ImageCreateTrueColor($this->newWidth,$this->newHeight);
+			$this->workingImage = ImageCreateTrueColor($newWidth,$newHeight);
 		}
 		else {
-			$this->workingImage = ImageCreate($this->newWidth,$this->newHeight);
+			$this->workingImage = ImageCreate($newWidth,$newHeight);
 		}
 
 //		ImageCopyResampled(
@@ -407,16 +407,16 @@ class ngg_Thumbnail {
 			0,
 			0,
 			0,
-			$this->newWidth,
-			$this->newHeight,
+			$newWidth,
+			$newHeight,
 			$this->currentDimensions['width'],
 			$this->currentDimensions['height']
 		);
 
 		$this->oldImage = $this->workingImage;
 		$this->newImage = $this->workingImage;
-		$this->currentDimensions['width'] = $this->newWidth;
-		$this->currentDimensions['height'] = $this->newHeight;
+		$this->currentDimensions['width'] = $newWidth;
+		$this->currentDimensions['height'] = $newHeight;
 	}
 
 

--- a/lib/image.php
+++ b/lib/image.php
@@ -9,37 +9,69 @@ if ( !class_exists('nggImage') ) :
 class nggImage{
 	
 	/**** Public variables ****/	
-	var $errmsg			=	'';			// Error message to display, if any
-	var $error			=	FALSE; 		// Error state
-	var $imageURL		=	'';			// URL Path to the image
-	var $thumbURL		=	'';			// URL Path to the thumbnail
-	var $imagePath		=	'';			// Server Path to the image
-	var $thumbPath		=	'';			// Server Path to the thumbnail
-	var $href			=	'';			// A href link code
+	public string $name = '';			// Gallery/image and album name
+	private string $errmsg = '';			// Error message to display, if any
+	public bool $error = FALSE; 		// Error state
+	public string $imageURL = '';			// URL Path to the image
+	public string $thumbURL = '';			// URL Path to the thumbnail
+	public string $imagePath = '';			// Server Path to the image
+	public string $thumbPath = '';			// Server Path to the thumbnail
+	public string $href = '';			// A href link code
 	
 	// TODO: remove thumbPrefix and thumbFolder (constants)
-	var $thumbPrefix	=	'thumbs_';	// FolderPrefix to the thumbnail
-	var $thumbFolder	=	'/thumbs/';	// Foldername to the thumbnail
+	private string $thumbPrefix = 'thumbs_';	// FolderPrefix to the thumbnail
+	private string $thumbFolder = '/thumbs/';	// Foldername to the thumbnail
 	
 	/**** Image Data ****/
-	var $galleryid		=	0;			// Gallery ID
-	var $pid			=	0;			// Image ID	
-	var $filename		=	'';			// Image filename
-	var $description	=	'';			// Image description	
-	var $alttext		=	'';			// Image alttext	
-	var $imagedate		=	'';			// Image date/time	
-	var $exclude		=	'';			// Image exclude
-	var $thumbcode		=	'';			// Image effect code
+	public int $galleryid = 0;			// Gallery ID
+	public int $pid = 0;			// Image ID	
+	public string $filename = '';			// Image filename
+	public string $description = '';			// Image description	
+	public string $alttext = '';			// Image alttext	
+	public string $imagedate = '';			// Image date/time	
+	public string $exclude = '';			// Image exclude
+	public string $thumbcode = '';			// Image effect code
+	public string $tags = '';
+	public $image_slug;
+	public string $imageHTML;
+	public string $thumbHTML;
+	public bool $hidden;
+	public string $style;
+	public string $pidlink;
+	public string $url;
+	public string $thumbnailURL;
+	public string $size;
+	public string $caption;
+	public string $href_link;
+	public string $previous_image_link;
+	public string $next_image_link;
+	public int $previous_pid;
+	public string $next_pid;
+	public int $number;
+	public int $total;
+	public string $linktitle;
+	public string $anchor;
 
 	/**** Gallery Data ****/
-	var $name			=	'';			// Gallery name
-	var $path			=	'';			// Gallery path	
-	var $title			=	'';			// Gallery title
-	var $pageid			=	0;			// Gallery page ID
-	var $previewpic		=	0;			// Gallery preview pic		
+	public string $path = '';			// Gallery path	
+	public string $title = '';			// Gallery title
+	public int $pageid = 0;			// Gallery page ID
+	public int $previewpic = 0;			// Gallery preview pic		
+	public int $gid;
+	public $galdesc;
+	public string $abspath;
+	public string $permalink = '';
+	public $post_id;
+	public $sortorder;
+	public $meta_data;
+	public $slug;
+	public int $author;
 
-	var $permalink		=	'';
-	var $tags			=   '';
+	/**** Album Data ****/
+	public array $gallery_ids;
+	public int $id;
+	public string $albumdesc;
+
 		
 	/**
 	 * Constructor

--- a/lib/meta.php
+++ b/lib/meta.php
@@ -150,7 +150,7 @@ class nggMeta{
                 if (!empty($exif['Make']))
                     $meta['make'] = $exif['Make'];
                 if (!empty($exif['ImageDescription']))
-                    $meta['title'] = utf8_encode($exif['ImageDescription']);
+                    $meta['title'] = mb_convert_encoding($exif['ImageDescription'], 'UTF-8');
                 if (!empty($exif['Orientation']))
                     $meta['Orientation'] = $exif['Orientation'];
             }
@@ -160,15 +160,15 @@ class nggMeta{
                 $exif = $this->exif_data['WINXP'];
 
                 if (!empty($exif['Title']) && empty($meta['title']))
-                    $meta['title'] = utf8_encode($exif['Title']);
+                    $meta['title'] = mb_convert_encoding($exif['Title'], 'UTF-8');
                 if (!empty($exif['Author']))
-                    $meta['author'] = utf8_encode($exif['Author']);
+                    $meta['author'] = mb_convert_encoding($exif['Author'], 'UTF-8');
                 if (!empty($exif['Keywords']))
-                    $meta['tags'] = utf8_encode($exif['Keywords']);
+                    $meta['tags'] = mb_convert_encoding($exif['Keywords'], 'UTF-8');
                 if (!empty($exif['Subject']))
-                    $meta['subject'] = utf8_encode($exif['Subject']);
+                    $meta['subject'] = mb_convert_encoding($exif['Subject'], 'UTF-8');
                 if (!empty($exif['Comments']))
-                    $meta['caption'] = utf8_encode($exif['Comments']);
+                    $meta['caption'] = mb_convert_encoding($exif['Comments'], 'UTF-8');
             }
 
             $this->exif_array = $meta;
@@ -245,7 +245,7 @@ class nggMeta{
             $meta = array();
             foreach ($iptcTags as $key => $value) {
                 if (isset ( $this->iptc_data[$key] ) )
-                    $meta[$value] = trim(utf8_encode(implode(", ", $this->iptc_data[$key])));
+                    $meta[$value] = trim(mb_convert_encoding(implode(", ", $this->iptc_data[$key]), 'UTF-8'));
 
             }
             $this->iptc_array = $meta;

--- a/lib/rewrite.php
+++ b/lib/rewrite.php
@@ -19,7 +19,7 @@ class nggRewrite {
 	 * @since 1.8.0
 	 * @var string
 	 */
-	var $slug = 'nggallery';
+	private string $slug = 'nggallery';
     
 	/**
 	 * Contain the main rewrite structure
@@ -27,7 +27,12 @@ class nggRewrite {
 	 * @since 1.8.3
 	 * @var array
 	 */    
-    var $ngg_rules = '';
+    private array $ngg_rules = [];
+
+	/**
+	 * Contains ngg options
+	 */
+	private array $options = [];
     
 	/**
 	* Constructor

--- a/lib/xmlrpc.php
+++ b/lib/xmlrpc.php
@@ -133,8 +133,8 @@ class nggXMLRPC{
 		require_once ( 'meta.php' );			// meta data import
 
 		$blog_ID	= (int) $args[0];
-		$username	= $wpdb->escape($args[1]);
-		$password	= $wpdb->escape($args[2]);
+		$username	= esc_sql($args[1]);
+		$password	= esc_sql($args[2]);
 		$data		= $args[3];
 
 		$name = $data['name'];
@@ -854,7 +854,7 @@ class nggXMLRPC{
 		global $wpdb;
 
 		if (!is_array($array)) {
-			return($wpdb->escape($array));
+			return(esc_sql($array));
 		} else {
 			foreach ( (array) $array as $k => $v ) {
 				if ( is_array($v) ) {
@@ -862,7 +862,7 @@ class nggXMLRPC{
 				} else if ( is_object($v) ) {
 					//skip
 				} else {
-					$array[$k] = $wpdb->escape($v);
+					$array[$k] = esc_sql($v);
 				}
 			}
 		}

--- a/nggallery.php
+++ b/nggallery.php
@@ -53,12 +53,16 @@ if (!class_exists('nggLoader')) {
      */
     class nggLoader {
 
-		var $version = '1.9.35';
-		var $dbversion   = '1.8.3';
-		var $minimum_WP  = '4.0';
-		var $options     = '';
-		var $manage_page;
-		var $add_PHP5_notice = false;
+		public string $version = '1.9.35';
+		private string $dbversion = '1.8.3';
+		private string $minimum_WP = '4.0';
+		public array $options = [];
+		private bool $add_PHP5_notice = false;
+		private bool $add_PHP7_notice = false;
+		public string $memory_limit = '0';
+		private string $plugin_name = '';
+		private string $translator = '';
+		private NGG_Admin_Launcher $nggAdminPanel;
 
         /**
          * class constructor
@@ -634,9 +638,15 @@ if (!class_exists('nggLoader')) {
         function activate() {
 			global $wpdb;
 			//Starting from version 1.8.0 it's works only with PHP5.2
-			if (version_compare(PHP_VERSION, '5.2.0', '<')) {
-					deactivate_plugins($this->plugin_name); // Deactivate ourself
-					wp_die("Sorry, but you can't run this plugin, it requires PHP 5.2 or higher.");
+			// if ( version_compare( PHP_VERSION, '5.2.0', '<' ) ) {
+					// 	deactivate_plugins( $this->plugin_name ); // Deactivate ourself
+					// 	wp_die( "Sorry, but you can't run this plugin, it requires PHP 5.2 or higher." );
+			// 	return;
+			// }
+
+			if ( version_compare( PHP_VERSION, '7.3.0', '<' ) ) {
+				deactivate_plugins( $this->plugin_name ); // Deactivate ourself
+				wp_die( "Sorry, but you can't run this plugin, it requires PHP 7.3 or higher." );
 					return;
 			}
 
@@ -710,13 +720,21 @@ if (!class_exists('nggLoader')) {
 				$option->response[ $this->plugin_name ]->package = '';
 
 				//Add a notice message
-				if ($this->add_PHP5_notice == false){
+				// if ( $this->add_PHP5_notice == false ) {
+				// 	add_action( "in_plugin_update_message-$this->plugin_name",
+				// 		function () {
+				// 			echo '<br /><span style="color:red">Please update to PHP5.2 as soon as possible, the plugin is not tested under PHP4 anymore</span>';
+				// 		}
+				// 	);
+				// 	$this->add_PHP5_notice = true;
+				// }
+				if ( $this->add_PHP7_notice == false ) {
 					add_action( "in_plugin_update_message-$this->plugin_name",
 						function () {
-							echo '<br /><span style="color:red">Please update to PHP5.2 as soon as possible, the plugin is not tested under PHP4 anymore</span>';
+							echo '<br /><span style="color:red">Please update to PHP7.3 as soon as possible, the plugin is not tested under PHP5 anymore</span>';
 						}
 					);
-					$this->add_PHP5_notice = true;
+					$this->add_PHP7_notice = true;
 				}
 			}
 			return $option;


### PR DESCRIPTION
Fixed some deprecation warnings, that popped up on PHP 8.2
Like PHP Deprecated: Creation of dynamic property is deprecated

Changed utf8_encode to mb_convert_encoding since utf8_encode is deprecated in PHP 8.2
Changed wpdb->escape to esc_sql since it is deprecated since Wordpress 3.6.0

The changes up the minimum PHP Version to 7.3

Now without autoformating