### PR TITLE
fix search of single image

### DIFF
--- a/xml/json.php
+++ b/xml/json.php
@@ -156,8 +156,8 @@ class nggAPI {
                 if ( empty($this->term) )
 				    $list = $nggdb->find_last_images(0, $this->limit, false);
                 else
-                    //$list = $nggdb->search_for_images($this->term, $this->limit);
-                    $list = $nggdb->find_images_in_album($this->term);
+                    $list = $nggdb->search_for_images($this->term, $this->limit);
+                    // $list = $nggdb->find_images_in_album($this->term);
                     
                 if( is_array($list) ) {
         			foreach($list as $image) {


### PR DESCRIPTION
Autocomplete for single image select did not work, when typing search queries

I´m not sure why the method "find_images_in_album" was used in line 166 and the right method "search_for_images" was commented out instead